### PR TITLE
Handle shift+tab nested movers

### DIFF
--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -383,7 +383,7 @@ export class FocusedElementState
                 if (isPrev) {
                     let  parentCtx: typeof ctx | undefined = ctx;
                     let rootMover = ctx.mover;
-                    while(parentCtx?.mover && parentCtx?.mover.parentElement) {
+                    while(parentCtx?.mover?.parentElement) {
                         rootMover = parentCtx.mover;
                         parentCtx = RootAPI.getTabsterContext(this._tabster, parentCtx.mover.parentElement);
                     }

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -390,6 +390,7 @@ export class FocusedElementState
 
                     fromElement = this._tabster.focusable.findFirst(rootMover);
                 } else {
+                    // no need to find root since tree walking will always find the most nested mover
                     fromElement = this._tabster.focusable.findLast(ctx.mover);
                 }
             }

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -383,7 +383,7 @@ export class FocusedElementState
                 if (isPrev) {
                     let  parentCtx: typeof ctx | undefined = ctx;
                     let rootMover = ctx.mover;
-                    while(parentCtx?.mover?.parentElement) {
+                    while (parentCtx?.mover?.parentElement) {
                         rootMover = parentCtx.mover;
                         parentCtx = RootAPI.getTabsterContext(this._tabster, parentCtx.mover.parentElement);
                     }
@@ -393,8 +393,6 @@ export class FocusedElementState
                     fromElement = this._tabster.focusable.findLast(ctx.mover);
                 }
             }
-
-
 
             if (!fromElement) {
                 return;

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -375,12 +375,26 @@ export class FocusedElementState
                 }
             }
 
-            let fromElement = (isTab && ctx.mover && ctx.moverOptions?.navigationType === Types.MoverKeys.Arrows)
-                ? (isPrev // Find next focusable outside of the Mover container.
-                    ? this._ah.focusable.findFirst(ctx.mover)
-                    : this._ah.focusable.findLast(ctx.mover)
-                )
-                : curElement;
+            let fromElement: HTMLElement | null = curElement;
+
+            // If the current element is in a mover, move to the mover boundaries since a mover is considered a single tabstop
+            if (isTab && ctx.mover && ctx.moverOptions?.navigationType === Types.MoverKeys.Arrows) {
+                // Consider nested movers a as a single tab stop, go up until there is no more mover
+                if (isPrev) {
+                    let  parentCtx: typeof ctx | undefined = ctx;
+                    let rootMover = ctx.mover;
+                    while(parentCtx?.mover && parentCtx?.mover.parentElement) {
+                        rootMover = parentCtx.mover;
+                        parentCtx = RootAPI.getAbilityHelpersContext(this._ah, parentCtx.mover.parentElement);
+                    }
+
+                    fromElement = this._ah.focusable.findFirst(rootMover);
+                } else {
+                    fromElement = this._ah.focusable.findLast(ctx.mover);
+                }
+            }
+
+
 
             if (!fromElement) {
                 return;

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -380,18 +380,17 @@ export class FocusedElementState
             // If the current element is in a mover, move to the mover boundaries since a mover is considered a single tabstop
             if (isTab && ctx.mover && ctx.moverOptions?.navigationType === Types.MoverKeys.Arrows) {
                 // Consider nested movers a as a single tab stop, go up until there is no more mover
-                if (isPrev) {
-                    let  parentCtx: typeof ctx | undefined = ctx;
-                    let rootMover = ctx.mover;
-                    while (parentCtx?.mover?.parentElement) {
-                        rootMover = parentCtx.mover;
-                        parentCtx = RootAPI.getTabsterContext(this._tabster, parentCtx.mover.parentElement);
-                    }
+                let  parentCtx: typeof ctx | undefined = ctx;
+                let rootMover = ctx.mover;
+                while (parentCtx?.mover?.parentElement) {
+                    rootMover = parentCtx.mover;
+                    parentCtx = RootAPI.getTabsterContext(this._tabster, parentCtx.mover.parentElement);
+                }
 
+                if (isPrev) {
                     fromElement = this._tabster.focusable.findFirst(rootMover);
                 } else {
-                    // no need to find root since tree walking will always find the most nested mover
-                    fromElement = this._tabster.focusable.findLast(ctx.mover);
+                    fromElement = this._tabster.focusable.findLast(rootMover);
                 }
             }
 

--- a/examples/src/Mover.stories.tsx
+++ b/examples/src/Mover.stories.tsx
@@ -39,9 +39,9 @@ export const ArrowNavigationCircular = () => (
 export const NestedMovers = () => (
     <div>
         <button>Tabstop</button>
-        <div style={{border: '1px solid', padding: 10}} { ...getAbilityHelpersAttribute({ focusable: { mover: { cyclic: true, navigationType: AHTypes.MoverKeys.Arrows } } }) }>
+        <div style={{border: '1px solid', padding: 10}} { ...getTabsterAttribute({ focusable: { mover: { cyclic: true, navigationType: TabsterTypes.MoverKeys.Arrows } } }) }>
             <Collection />
-            <div style={{marginLeft: 10, marginTop: 10}} { ...getAbilityHelpersAttribute({ focusable: { mover: { cyclic: true, navigationType: AHTypes.MoverKeys.Arrows } } }) }>
+            <div style={{marginLeft: 10, marginTop: 10}} { ...getTabsterAttribute({ focusable: { mover: { cyclic: true, navigationType: TabsterTypes.MoverKeys.Arrows } } }) }>
                 <Collection />
             </div>
         </div>

--- a/examples/src/Mover.stories.tsx
+++ b/examples/src/Mover.stories.tsx
@@ -44,6 +44,10 @@ export const NestedMovers = () => (
             <div style={{marginLeft: 10, marginTop: 10}} { ...getTabsterAttribute({ focusable: { mover: { cyclic: true, navigationType: TabsterTypes.MoverKeys.Arrows } } }) }>
                 <Collection />
             </div>
+            <div style={{paddingTop: 10}}>
+                <button>In root mover</button>
+                <button>In root mover</button>
+            </div>
         </div>
         <button>Tabstop</button>
     </div>

--- a/examples/src/Mover.stories.tsx
+++ b/examples/src/Mover.stories.tsx
@@ -35,3 +35,16 @@ export const ArrowNavigationCircular = () => (
         <Collection />
     </div>
 );
+
+export const NestedMovers = () => (
+    <div>
+        <button>Tabstop</button>
+        <div style={{border: '1px solid', padding: 10}} { ...getAbilityHelpersAttribute({ focusable: { mover: { cyclic: true, navigationType: AHTypes.MoverKeys.Arrows } } }) }>
+            <Collection />
+            <div style={{marginLeft: 10, marginTop: 10}} { ...getAbilityHelpersAttribute({ focusable: { mover: { cyclic: true, navigationType: AHTypes.MoverKeys.Arrows } } }) }>
+                <Collection />
+            </div>
+        </div>
+        <button>Tabstop</button>
+    </div>
+);


### PR DESCRIPTION
We consider a mover to be a single tab stop, therefore when focus is inside the mover:
1. TAB - should move to the next focusable element outside the mover
2. SHIFT+TAB - should mover the previous focusable element outside the mover

`1.` is already handled by default since walking the tree will always lead to the boundary of the most nested mover

In order to handle `2.` the `FocusedElementState` needs to traverse up the tree to until there is no more mover to determine what is the root mover element. 