### PR TITLE
Focusable can optioanlly ignore aria-disabled

### DIFF
--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -975,12 +975,14 @@ export class FocusableAPI implements Types.FocusableAPI {
             newProps.isDefault = props.isDefault;
             newProps.isIgnored = props.isIgnored;
             newProps.mover = props.mover;
+            newProps.ignoreAriaDisabled = props.ignoreAriaDisabled;
         }
 
         if (
             (curProps.isDefault !== newProps.isDefault) ||
             (curProps.isIgnored !== newProps.isIgnored) ||
-            (curProps.mover !== newProps.mover)
+            (curProps.mover !== newProps.mover) || 
+            (curProps.ignoreAriaDisabled!== newProps.ignoreAriaDisabled)
         ) {
             setTabsterOnElement(this._tabster, element, { focusable: newProps });
         }
@@ -1043,8 +1045,6 @@ export class FocusableAPI implements Types.FocusableAPI {
             if (attrVal && (attrVal.toLowerCase() === 'true')) {
                 return false;
             }
-
-            attrVal = e.getAttribute('aria-disabled');
 
             if (attrVal && (attrVal.toLowerCase() === 'true')) {
                 return false;

--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -982,7 +982,7 @@ export class FocusableAPI implements Types.FocusableAPI {
             (curProps.isDefault !== newProps.isDefault) ||
             (curProps.isIgnored !== newProps.isIgnored) ||
             (curProps.mover !== newProps.mover) || 
-            (curProps.ignoreAriaDisabled!== newProps.ignoreAriaDisabled)
+            (curProps.ignoreAriaDisabled !== newProps.ignoreAriaDisabled)
         ) {
             setTabsterOnElement(this._tabster, element, { focusable: newProps });
         }
@@ -1046,7 +1046,9 @@ export class FocusableAPI implements Types.FocusableAPI {
                 return false;
             }
 
-            if (attrVal && (attrVal.toLowerCase() === 'true')) {
+            attrVal = e.getAttribute('aria-disabled');
+            const ignoreDisabled = tabsterOnElement?.focusable?.ignoreAriaDisabled;            
+            if (!ignoreDisabled && attrVal && (attrVal.toLowerCase() === 'true')) {
                 return false;
             }
         }

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -263,6 +263,10 @@ export interface FocusableProps {
     isDefault?: boolean;
     isIgnored?: boolean;
     mover?: MoverOptions;
+    /**
+     * Do not determine an element's focusability based on aria-disabled
+     */
+    ignoreAriaDisabled?: boolean;
 }
 
 export interface FocusableAPI {

--- a/examples/src/Focusable.stories.tsx
+++ b/examples/src/Focusable.stories.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { getCurrentTabster, getTabsterAttribute } from 'tabster';
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  title: 'Focusable',
+};
+
+export const IgnoreAriaDisabled = () => {
+    const ref = React.useRef<HTMLButtonElement>(null);
+    const tabster = getCurrentTabster(window);
+    const onClick = () => {
+        console.log(tabster?.focusable.findNext(ref.current as HTMLButtonElement));
+        tabster?.focusable.findNext(ref.current as HTMLButtonElement, undefined, true)?.focus();
+    }
+    return (
+        <div>
+            <button onClick={onClick} ref={ref}>Focus aria disabled element</button>
+            <div aria-disabled={true} tabIndex={-1} {...getTabsterAttribute({ focusable: { ignoreAriaDisabled: true }})}>aria-disabled element</div>
+        </div>
+    )
+};


### PR DESCRIPTION
According to [WAI](https://www.w3.org/TR/wai-aria-practices/#kbd_disabled_controls) spec some `aria-disabled` elements should still be
focusable

This PR adds an `ignoreAriaDisabled` option for focusable so that
Tabster's `isAccessible` check allways passes if set