### PR TITLE
RTL awareness for tabster context and arrow keys

### DIFF
--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -329,7 +329,7 @@ export class FocusedElementState
                 return;
         }
 
-        const ctx = RootAPI.getTabsterContext(this._tabster, curElement);
+        const ctx = RootAPI.getTabsterContext(this._tabster, curElement, { checkRtl: true });
 
         const keyCode = e.keyCode;
         const isTab = keyCode === Keys.Tab;
@@ -352,7 +352,8 @@ export class FocusedElementState
                 (
                     !isTab &&
                     (
-                        (keyCode === Keys.Left) ||
+                        (keyCode === Keys.Left && !ctx.isRtl) ||
+                        (keyCode === Keys.Right && ctx.isRtl) ||
                         (keyCode === Keys.Up) ||
                         (keyCode === Keys.PageUp) ||
                         (keyCode === Keys.Home)
@@ -562,7 +563,7 @@ export class FocusedElementState
                 case Keys.Right:
                 case Keys.Up:
                 case Keys.Left:
-                    next = this._findNextGroupper(groupperElement, e.keyCode, groupper.getBasicProps().nextDirection);
+                    next = this._findNextGroupper(groupperElement, e.keyCode, groupper.getBasicProps().nextDirection, ctx?.isRtl);
                     break;
 
                 case Keys.PageDown:
@@ -619,7 +620,7 @@ export class FocusedElementState
             : this._tabster.focusable.findFirst(groupperElement, false, false, ignoreGroupper);
     }
 
-    private _findNextGroupper(from: HTMLElement, key: Key, direction?: Types.GroupperNextDirection): HTMLElement | null {
+    private _findNextGroupper(from: HTMLElement, key: Key, direction?: Types.GroupperNextDirection, isRtl?: boolean): HTMLElement | null {
         if ((direction === Types.GroupperNextDirections.Vertical) && ((key === Keys.Left) || (key === Keys.Right))) {
             return null;
         }
@@ -629,7 +630,7 @@ export class FocusedElementState
         }
 
         if ((direction === undefined) || (direction === Types.GroupperNextDirections.Both)) {
-            if ((key === Keys.Left) || (key === Keys.Up)) {
+            if ((key === Keys.Left && !isRtl) || (key === Keys.Right && isRtl) || (key === Keys.Up)) {
                 return this._tabster.focusable.findPrevGroupper(from);
             } else {
                 return this._tabster.focusable.findNextGroupper(from);

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -477,6 +477,13 @@ export interface Root {
     moveOutWithDefaultAction(backwards: boolean): void;
 }
 
+export interface GetTabsterContextOptions {
+    /**
+     * Should visit **all** element ancestors to verify if `dir='rtl'` is set
+     */
+    checkRtl?: boolean;
+}
+
 export interface TabsterContext {
     root: Root;
     modalizer?: Modalizer;
@@ -484,6 +491,10 @@ export interface TabsterContext {
     mover?: HTMLElement;
     moverOptions?: MoverOptions;
     isGroupperFirst?: boolean;
+    /**
+     * Whether `dir='rtl'` is set on an ancestor
+     */
+    isRtl?: boolean;
 }
 
 export interface RootAPI {

--- a/examples/src/Groupper.stories.tsx
+++ b/examples/src/Groupper.stories.tsx
@@ -59,6 +59,14 @@ export const NestedGrouppers = () => (
     </>
 );
 
+export const GroupperRtl = () => (
+    <div dir='rtl' style={{display: 'flex'}}>
+        <Item />
+        <Item />
+        <Item />
+    </div>
+);
+
 export const AccordionPrototype = () => (
     <>
         <Accordion>

--- a/examples/src/Mover.stories.tsx
+++ b/examples/src/Mover.stories.tsx
@@ -58,6 +58,22 @@ export const ArrowNavigationHorizontal = () => (
     </div>
 );
 
+export const ArrowNavigationHorizontalRtl = () => (
+    <div
+        dir='rtl'
+        {...getTabsterAttribute({
+            focusable: {
+                mover: {
+                    navigationType: TabsterTypes.MoverKeys.Arrows,
+                    axis: TabsterTypes.MoverAxis.Horizontal,
+                },
+            },
+        })}
+    >
+        <Collection />
+    </div>
+);
+
 export const ArrowNavigationCircular = () => (
     <div
         {...getTabsterAttribute({


### PR DESCRIPTION
This PR adds RTL checking for `getTabsterContext` through an extra
option, that checks all ancestors in the dom tree for the `dir`
attribute.

Also uses this new RTL flag to flip arrow keys (left/right) for groupper
and mover use cases.

Resolves #5