### PR TITLE
Removes pre-push hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "simple-git-hooks": {
     "pre-commit": "npm run tslint:check",
-    "pre-push": "npm run build"
+    "pre-push": ""
   }
 }


### PR DESCRIPTION
After #18 thanks to @layershifter, there is no more need for poor man automation.

Keeps the pre-push as empty, so that `npm run bootstrap` can clean up existing pre-push hooks