### PR TITLE
chore: update Storybook deployment to Github pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -21,13 +21,14 @@ jobs:
 
             - run: npm install
             - run: npm run bootstrap
-            - run: lerna run --scope examples build:prod
+            - run: lerna run --scope examples build
 
             - name: Deploy storybook
               uses: JamesIves/github-pages-deploy-action@4.1.1
               with:
                   branch: gh-pages
                   folder: examples/storybook-static
+                  target-folder: storybook
 
                   clean: true
                   # 👇 defines a list of files that should be kept during deployment

--- a/examples/package.json
+++ b/examples/package.json
@@ -16,8 +16,7 @@
     "eject": "react-scripts eject",
     "start": "start-storybook -p 6006 -s public",
     "start:prod": "cross-env NODE_ENV=production npm run start",
-    "build": "cross-env NODE_ENV=development build-storybook",
-    "build:prod": "cross-env NODE_ENV=production build-storybook",
+    "build": "build-storybook --quiet",
     "clean": "rimraf storybook-static",
     "tslint": "tslint --project tsconfig.json --fix || true",
     "tslint:check": "tslint --project tsconfig.json"


### PR DESCRIPTION
A follow up for #21.

Removes `build:prod` in favor of having only `build` as `build-storybook` already creates a production build. Also added `--quiet` option to reduce noise from Webpack Progress Plugin on CI.

Storybook will be deployed into `/storybook` directory on Github pages.