### PR TITLE
chore: add "sideEffects": false to enable tree shaking

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -4,6 +4,7 @@
   "description": "Focus Management Tools for Web",
   "author": "Marat Abdullin <marata@microsoft.com>",
   "license": "MIT",
+  "sideEffects": false
   "main": "./dist/index.js",
   "module": "./dist/tabster.esm.js",
   "typings": "./dist/index.d.ts",

--- a/core/package.json
+++ b/core/package.json
@@ -4,7 +4,7 @@
   "description": "Focus Management Tools for Web",
   "author": "Marat Abdullin <marata@microsoft.com>",
   "license": "MIT",
-  "sideEffects": false
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/tabster.esm.js",
   "typings": "./dist/index.d.ts",


### PR DESCRIPTION
This PR adds `"sideEffects": false` to indicate for bundlers that this package is tree shakable, otherwise we will get bailouts in Webpack:

```
  [8] ./src/main.js + 149 modules 255 KiB {0} [built]
      ModuleConcatenation bailout: Cannot concat with ./node_modules/tslib/tslib.es6.js because of ./node_modules/tabster/dist/tabster.esm.js
```

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free