### PR TITLE
FocusedElement: capture keydown listener

### DIFF
--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -97,10 +97,10 @@ export class FocusedElementState
             this._initTimer = undefined;
         }
 
-        win.document.removeEventListener('focusin', this._onFocusIn, true); // Capture!
-        win.document.removeEventListener('focusout', this._onFocusOut, true); // Capture!
-        win.document.removeEventListener('mousedown', this._onMouseDown, true); // Capture!
-        win.removeEventListener('keydown', this._onKeyDown);
+        win.document.removeEventListener('focusin', this._onFocusIn, true);
+        win.document.removeEventListener('focusout', this._onFocusOut, true);
+        win.document.removeEventListener('mousedown', this._onMouseDown, true);
+        win.removeEventListener('keydown', this._onKeyDown, true);
 
         delete FocusedElementState._lastFocusedProgrammatically;
         delete FocusedElementState._lastResetElement;

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -78,10 +78,11 @@ export class FocusedElementState
 
         FocusedElementState.replaceFocus(this._win);
 
-        win.document.addEventListener('focusin', this._onFocusIn, true); // Capture!
-        win.document.addEventListener('focusout', this._onFocusOut, true); // Capture!
-        win.document.addEventListener('mousedown', this._onMouseDown, true); // Capture!
-        win.addEventListener('keydown', this._onKeyDown);
+        // Add these event listeners as capture - we want Tabster to run before user event handlers
+        win.document.addEventListener('focusin', this._onFocusIn, true);
+        win.document.addEventListener('focusout', this._onFocusOut, true);
+        win.document.addEventListener('mousedown', this._onMouseDown, true);
+        win.addEventListener('keydown', this._onKeyDown, true);
     }
 
     protected dispose(): void {

--- a/core/src/Tabster.ts
+++ b/core/src/Tabster.ts
@@ -293,17 +293,10 @@ export function disposeTabster(tabster: Types.TabsterCore): void {
 }
 
 export function getTabsterAttribute(
-    props: Types.TabsterAttributeProps | null,
-    plain: true
-): string | undefined;
-export function getTabsterAttribute(
-    props: Types.TabsterAttributeProps | null, plain?: false
-): Types.TabsterDOMAttribute;
-export function getTabsterAttribute(
-    props: Types.TabsterAttributeProps | null,
+    props?: Types.TabsterAttributeProps,
     plain?: boolean
 ): Types.TabsterDOMAttribute | string | undefined {
-    const attr = props === null ? undefined : JSON.stringify(props);
+    const attr = props ? JSON.stringify(props) : undefined;
 
     if (plain === true) {
         return attr;


### PR DESCRIPTION
Runs Tabster's `keydown` listener for a focused element before the rest
of the window.

Ensures that `Tabster` behaviour runs before user behaviour
i.e.: Tabster drags you into a pit of success and it's up to you to
climb out