### PR TITLE
Unique modalizer instance per user id

### DIFF
--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -116,13 +116,15 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
             // Nothing satisfactory in the focus history, each Modalizer has Deloser,
             // let's try to find something under the same root.
             for (let m of modalizers) {
-                const e = m.getElement();
-                const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
-                const deloser = tabsterOnElement && tabsterOnElement.deloser;
-                const deloserItem = deloser && new DeloserItem(this._tabster, deloser);
+                const modalizerElements = m.getElements();
+                for (let e of modalizerElements) {
+                    const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
+                    const deloser = tabsterOnElement && tabsterOnElement.deloser;
+                    const deloserItem = deloser && new DeloserItem(this._tabster, deloser);
 
-                if (deloserItem && await deloserItem.focusAvailable()) {
-                    return true;
+                    if (deloserItem && await deloserItem.focusAvailable()) {
+                        return true;
+                    }
                 }
             }
         }
@@ -152,12 +154,14 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
             // Nothing satisfactory in the focus history, each Modalizer has Deloser,
             // let's try to find something under the same root.
             for (let m of modalizers) {
-                const e = m.getElement();
-                const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
-                const deloser = tabsterOnElement && tabsterOnElement.deloser;
+                const modalizerElements = m.getElements();
+                for (let e of modalizerElements) {
+                    const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
+                    const deloser = tabsterOnElement && tabsterOnElement.deloser;
 
-                if (deloser && !(deloser.uid in resetQueue)) {
-                    resetQueue[deloser.uid] = new DeloserItem(this._tabster, deloser);
+                    if (deloser && !(deloser.uid in resetQueue)) {
+                        resetQueue[deloser.uid] = new DeloserItem(this._tabster, deloser);
+                    }
                 }
             }
         }

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -54,6 +54,9 @@ export class Modalizer implements Types.Modalizer {
     private _isAccessible = true;
     private _setAccessibleTimer: number | undefined;
     private _isFocused = false;
+    /**
+     * All HTML elements that are managed by the modalizer instance
+     */
     private _modalizerElements: WeakHTMLElement[];
 
     constructor(

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -219,15 +219,13 @@ export class Root implements Types.Root {
                     currentIsPresent = true;
                     isOthersAccessible = !!tabsterOnElement.modalizer.getBasicProps().isOthersAccessible;
                 }
-
-                return NodeFilter.FILTER_ACCEPT;
             }
 
             return NodeFilter.FILTER_SKIP;
         });
 
         if (walker) {
-            while (walker.nextNode()) { /* Iterating for the sake of calling acceptNode callback. */ }
+            while (walker.nextNode()) { /* Iterate nodes to find all modalizers */ }
         }
 
         if (!currentIsPresent) {

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -241,7 +241,7 @@ export class Root implements Types.Root {
 
             modalizer.setActive(active);
             modalizer.setAccessible(modalizer.getBasicProps().isAlwaysAccessible || isOthersAccessible || active);
-        })
+        });
     }
 
     private _createDummyInput(props: DummyInput): void {

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -369,7 +369,7 @@ export class FocusedElementState
                     ctx.modalizer = ctx.root.getModalizerById(curModalizerId);
 
                     if (ctx.modalizer) {
-                        curElement = ctx.modalizer.getElement();
+                        curElement = ctx.modalizer.getElementContaining(curElement);
 
                         if (!curElement) {
                             return;

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -444,17 +444,42 @@ export interface ModalizerExtendedProps {
 export interface Modalizer {
     readonly internalId: string;
     readonly userId: string;
-    setProps(basic?: Partial<ModalizerBasicProps> | null, extended?: Partial<ModalizerExtendedProps> | null): void;
-    getBasicProps(): ModalizerBasicProps;
-    getExtendedProps(): ModalizerExtendedProps;
+    /**
+     * Adds an element to the modalizer
+     * 
+     * @param element element the modalizer should manage
+     * @param win window getter, u
+     * @returns boolean, if operation was successful
+     */
+    add(element: HTMLElement, win: GetWindow): boolean;
     dispose(): void;
-    move(newElement: HTMLElement): void;
+    getBasicProps(): ModalizerBasicProps;
+    /**
+     * @returns All managed modalizer elements
+     */
+    getElements(): HTMLElement[];
+    /**
+     * Returns the modalizer element that contains the provided element
+     * 
+     * @param element Element to test
+     * @returns Modalizer element that contains the provided element
+     */
+    getElementContaining(element: HTMLElement): HTMLElement | undefined;
+    getExtendedProps(): ModalizerExtendedProps;
+    /**
+     * Checks if an element belongs to the modalizer instance
+     * 
+     * @param element Element to test
+     * @returns Whether the element is managed by the modalizer
+     */
+    hasElement(element: HTMLElement): boolean;
+    isActive(): boolean;
+    move(fromElement: HTMLElement, newElement: HTMLElement): void;
+    onBeforeFocusOut(): boolean;
     setAccessible(accessible: boolean): void;
     setActive(active: boolean): void;
-    isActive(): boolean;
-    getElement(): HTMLElement | undefined;
     setFocused(focused: boolean): void;
-    onBeforeFocusOut(): boolean;
+    setProps(basic?: Partial<ModalizerBasicProps> | null, extended?: Partial<ModalizerExtendedProps> | null): void;
 }
 
 export interface RootBasicProps {


### PR DESCRIPTION
This PR refactors modalizer so that one single instance exists and
manages and Modalizer DOM elements per user id. This makes sense since
all modalizers with the same id need to behave the same way.

This will enable more logic to be moved from `Root` to `Modalizer` in
the future. Lots of logic currently in `Root` regarding modalizer exists
because of the limitation that multiple modalizer instances can exist
that have the same user id.