### PR TITLE
Remove modalizer accessibility and set aria-hidden in tree instead

### DIFF
--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -168,12 +168,12 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
         //     }
         // }
 
-        // // Nothing is found, at least try to reset.
-        // for (let id of Object.keys(resetQueue)) {
-        //     if (await resetQueue[id].resetFocus()) {
-        //         return true;
-        //     }
-        // }
+        // Nothing is found, at least try to reset.
+        for (let id of Object.keys(resetQueue)) {
+            if (await resetQueue[id].resetFocus()) {
+                return true;
+            }
+        }
 
         return false;
     }

--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -200,7 +200,7 @@ export class DeloserHistory {
 
         const historyByRoot = this.make(rootUId, () => new DeloserHistoryByRoot(this._tabster, rootUId));
 
-        if (!ctx || !ctx.modalizer || (ctx.root.getCurrentModalizerId() === ctx.modalizer.userId)) {
+        if (!ctx || !ctx.modalizer?.isActive()) {
             historyByRoot.unshiftToDeloser(deloser, element);
         }
 

--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -108,28 +108,6 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
             }
         }
 
-        // TODO: Can look for modalizers and do the same thing, but is it necessary ? 
-        // const getWindow = (this._tabster as unknown as Types.TabsterInternal).getWindow;
-        // const root = RootAPI.getRootByUId(getWindow, this.rootUId);
-        // const modalizers = root && root.getModalizers();
-
-        // if (modalizers) {
-        //     // Nothing satisfactory in the focus history, each Modalizer has Deloser,
-        //     // let's try to find something under the same root.
-        //     for (let m of modalizers) {
-        //         const modalizerElements = m.getElements();
-        //         for (let e of modalizerElements) {
-        //             const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
-        //             const deloser = tabsterOnElement && tabsterOnElement.deloser;
-        //             const deloserItem = deloser && new DeloserItem(this._tabster, deloser);
-
-        //             if (deloserItem && await deloserItem.focusAvailable()) {
-        //                 return true;
-        //             }
-        //         }
-        //     }
-        // }
-
         return false;
     }
 
@@ -146,27 +124,6 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
                 resetQueue[i.uid] = i;
             }
         }
-
-        // TODO: Can look for modalizers and do the same thing, but is it necessary ? 
-        // const getWindow = (this._tabster as unknown as Types.TabsterInternal).getWindow;
-        // const root = RootAPI.getRootByUId(getWindow, this.rootUId);
-        // const modalizers = root && root.getModalizers();
-
-        // if (modalizers) {
-        //     // Nothing satisfactory in the focus history, each Modalizer has Deloser,
-        //     // let's try to find something under the same root.
-        //     for (let m of modalizers) {
-        //         const modalizerElements = m.getElements();
-        //         for (let e of modalizerElements) {
-        //             const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
-        //             const deloser = tabsterOnElement && tabsterOnElement.deloser;
-
-        //             if (deloser && !(deloser.uid in resetQueue)) {
-        //                 resetQueue[deloser.uid] = new DeloserItem(this._tabster, deloser);
-        //             }
-        //         }
-        //     }
-        // }
 
         // Nothing is found, at least try to reset.
         for (let id of Object.keys(resetQueue)) {

--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -159,7 +159,7 @@ export class DeloserHistory {
 
         const historyByRoot = this.make(rootUId, () => new DeloserHistoryByRoot(this._tabster, rootUId));
 
-        if (!ctx || !ctx.modalizer?.isActive()) {
+        if (!ctx || !ctx.modalizer || ctx.modalizer?.isActive()) {
             historyByRoot.unshiftToDeloser(deloser, element);
         }
 

--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -116,13 +116,15 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
             // Nothing satisfactory in the focus history, each Modalizer has Deloser,
             // let's try to find something under the same root.
             for (let m of modalizers) {
-                const e = m.getElement();
-                const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
-                const deloser = tabsterOnElement && tabsterOnElement.deloser;
-                const deloserItem = deloser && new DeloserItem(this._tabster, deloser);
+                const modalizerElements = m.getElements();
+                for (let e of modalizerElements) {
+                    const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
+                    const deloser = tabsterOnElement && tabsterOnElement.deloser;
+                    const deloserItem = deloser && new DeloserItem(this._tabster, deloser);
 
-                if (deloserItem && await deloserItem.focusAvailable()) {
-                    return true;
+                    if (deloserItem && await deloserItem.focusAvailable()) {
+                        return true;
+                    }
                 }
             }
         }
@@ -152,12 +154,14 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
             // Nothing satisfactory in the focus history, each Modalizer has Deloser,
             // let's try to find something under the same root.
             for (let m of modalizers) {
-                const e = m.getElement();
-                const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
-                const deloser = tabsterOnElement && tabsterOnElement.deloser;
+                const modalizerElements = m.getElements();
+                for (let e of modalizerElements) {
+                    const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
+                    const deloser = tabsterOnElement && tabsterOnElement.deloser;
 
-                if (deloser && !(deloser.uid in resetQueue)) {
-                    resetQueue[deloser.uid] = new DeloserItem(this._tabster, deloser);
+                    if (deloser && !(deloser.uid in resetQueue)) {
+                        resetQueue[deloser.uid] = new DeloserItem(this._tabster, deloser);
+                    }
                 }
             }
         }

--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -108,26 +108,27 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
             }
         }
 
-        const getWindow = (this._tabster as unknown as Types.TabsterInternal).getWindow;
-        const root = RootAPI.getRootByUId(getWindow, this.rootUId);
-        const modalizers = root && root.getModalizers();
+        // TODO: Can look for modalizers and do the same thing, but is it necessary ? 
+        // const getWindow = (this._tabster as unknown as Types.TabsterInternal).getWindow;
+        // const root = RootAPI.getRootByUId(getWindow, this.rootUId);
+        // const modalizers = root && root.getModalizers();
 
-        if (modalizers) {
-            // Nothing satisfactory in the focus history, each Modalizer has Deloser,
-            // let's try to find something under the same root.
-            for (let m of modalizers) {
-                const modalizerElements = m.getElements();
-                for (let e of modalizerElements) {
-                    const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
-                    const deloser = tabsterOnElement && tabsterOnElement.deloser;
-                    const deloserItem = deloser && new DeloserItem(this._tabster, deloser);
+        // if (modalizers) {
+        //     // Nothing satisfactory in the focus history, each Modalizer has Deloser,
+        //     // let's try to find something under the same root.
+        //     for (let m of modalizers) {
+        //         const modalizerElements = m.getElements();
+        //         for (let e of modalizerElements) {
+        //             const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
+        //             const deloser = tabsterOnElement && tabsterOnElement.deloser;
+        //             const deloserItem = deloser && new DeloserItem(this._tabster, deloser);
 
-                    if (deloserItem && await deloserItem.focusAvailable()) {
-                        return true;
-                    }
-                }
-            }
-        }
+        //             if (deloserItem && await deloserItem.focusAvailable()) {
+        //                 return true;
+        //             }
+        //         }
+        //     }
+        // }
 
         return false;
     }
@@ -146,32 +147,33 @@ class DeloserHistoryByRoot extends DeloserHistoryByRootBase<Types.Deloser, Delos
             }
         }
 
-        const getWindow = (this._tabster as unknown as Types.TabsterInternal).getWindow;
-        const root = RootAPI.getRootByUId(getWindow, this.rootUId);
-        const modalizers = root && root.getModalizers();
+        // TODO: Can look for modalizers and do the same thing, but is it necessary ? 
+        // const getWindow = (this._tabster as unknown as Types.TabsterInternal).getWindow;
+        // const root = RootAPI.getRootByUId(getWindow, this.rootUId);
+        // const modalizers = root && root.getModalizers();
 
-        if (modalizers) {
-            // Nothing satisfactory in the focus history, each Modalizer has Deloser,
-            // let's try to find something under the same root.
-            for (let m of modalizers) {
-                const modalizerElements = m.getElements();
-                for (let e of modalizerElements) {
-                    const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
-                    const deloser = tabsterOnElement && tabsterOnElement.deloser;
+        // if (modalizers) {
+        //     // Nothing satisfactory in the focus history, each Modalizer has Deloser,
+        //     // let's try to find something under the same root.
+        //     for (let m of modalizers) {
+        //         const modalizerElements = m.getElements();
+        //         for (let e of modalizerElements) {
+        //             const tabsterOnElement = e && getTabsterOnElement(this._tabster, e);
+        //             const deloser = tabsterOnElement && tabsterOnElement.deloser;
 
-                    if (deloser && !(deloser.uid in resetQueue)) {
-                        resetQueue[deloser.uid] = new DeloserItem(this._tabster, deloser);
-                    }
-                }
-            }
-        }
+        //             if (deloser && !(deloser.uid in resetQueue)) {
+        //                 resetQueue[deloser.uid] = new DeloserItem(this._tabster, deloser);
+        //             }
+        //         }
+        //     }
+        // }
 
-        // Nothing is found, at least try to reset.
-        for (let id of Object.keys(resetQueue)) {
-            if (await resetQueue[id].resetFocus()) {
-                return true;
-            }
-        }
+        // // Nothing is found, at least try to reset.
+        // for (let id of Object.keys(resetQueue)) {
+        //     if (await resetQueue[id].resetFocus()) {
+        //         return true;
+        //     }
+        // }
 
         return false;
     }

--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -4,7 +4,6 @@
  */
 
 import { getTabsterOnElement, setTabsterOnElement } from './Instance';
-import { Modalizer } from './Modalizer';
 import { dispatchMutationEvent, MutationEvent, MUTATION_EVENT_NAME } from './MutationEvent';
 import { RootAPI } from './Root';
 import * as Types from './Types';

--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -1048,11 +1048,6 @@ export class FocusableAPI implements Types.FocusableAPI {
     isAccessible(el: HTMLElement): boolean {
         for (let e: (HTMLElement | null) = el; e; e = e.parentElement) {
             const tabsterOnElement = getTabsterOnElement(this._tabster, e);
-
-            if (tabsterOnElement && tabsterOnElement.modalizer && !tabsterOnElement.modalizer.isActive()) {
-                return true;
-            }
-
             if (this._isHidden(e)) {
                 return false;
             }

--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -4,7 +4,9 @@
  */
 
 import { getTabsterOnElement, setTabsterOnElement } from './Instance';
+import { Modalizer } from './Modalizer';
 import { dispatchMutationEvent, MutationEvent, MUTATION_EVENT_NAME } from './MutationEvent';
+import { RootAPI } from './Root';
 import * as Types from './Types';
 import { createElementTreeWalker, isElementVisibleInContainer, matchesSelector, WeakHTMLElement } from './Utils';
 
@@ -1282,12 +1284,15 @@ export class FocusableAPI implements Types.FocusableAPI {
         ignoreModalizer?: boolean,
         ignoreGroupper?: boolean
     ): number {
+        const ctx = RootAPI.getTabsterContext(this._tabster, element);
         if (this._isHidden(element)) {
             return NodeFilter.FILTER_REJECT;
         }
 
-        if (!ignoreGroupper && (this._isInCurrentGroupper(element, true) === false)) {
-            return NodeFilter.FILTER_REJECT;
+        if (ignoreModalizer || (!ctx || !ctx.modalizer) || ctx.modalizer.getBasicProps().isAlwaysAccessible) {
+            if (!ignoreGroupper && (this._isInCurrentGroupper(element, true) === false)) {
+                return NodeFilter.FILTER_REJECT;
+            }
         }
 
         return acceptCondition(element) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;

--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -1273,11 +1273,9 @@ export class FocusableAPI implements Types.FocusableAPI {
         ignoreGroupper?: boolean
     ): number {
         const ctx = RootAPI.getTabsterContext(this._tabster, element);
-        const currentModalizerId = ctx && ctx.root.getCurrentModalizerId();
 
         if (ignoreModalizer || (!ctx || !ctx.modalizer) ||
-            (currentModalizerId === undefined) ||
-            (currentModalizerId === ctx.modalizer.userId) ||
+            (ctx.modalizer.isActive()) ||
             ctx.modalizer.getBasicProps().isAlwaysAccessible
         ) {
             if (!ignoreGroupper && (this._isInCurrentGroupper(element, true) === false)) {

--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -1278,7 +1278,7 @@ export class FocusableAPI implements Types.FocusableAPI {
             return NodeFilter.FILTER_REJECT;
         }
 
-        if (!ctx.groupper ||  (!ignoreGroupper && (this._isInCurrentGroupper(element, true) === false))) {
+        if (ignoreGroupper && (this._isInCurrentGroupper(element, true) === false)) {
             return NodeFilter.FILTER_REJECT;
         }
 

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -452,7 +452,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     }
 
     /**
-     * If a modalizer is still active and has no elements left on the document, set it to inactive
+     * Listens to DOM mutation events for removed modalizers
      */
     private _onMutation = (e: MutationEvent) => {
         const details = e.details;
@@ -460,6 +460,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
             return;
         }
 
+        // If an active modalizer is no longer on DOM, remove it
         if (details.modalizer.isActive()) {
             if (__DEV__) {
                 console.warn(`Modalizer: ${details.modalizer.userId}.

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -54,6 +54,9 @@ export class Modalizer implements Types.Modalizer {
     private _isAccessible = true;
     private _setAccessibleTimer: number | undefined;
     private _isFocused = false;
+    /**
+     * All HTML elements that are managed by the modalizer instance
+     */
     private _modalizerElements: WeakHTMLElement[];
 
     constructor(

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -469,16 +469,21 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         }
     }
 
+    /**
+     * Subscribes to the focus state and handles modalizer related focus events
+     * @param e - Element that is focused
+     * @param details - Additional data about the focus event
+     */
     private _onFocus = (e: HTMLElement | undefined, details: Types.FocusedElementDetails): void => {
-        if (this._focusOutTimer) {
-            this._win().clearTimeout(this._focusOutTimer);
-            this._focusOutTimer = undefined;
-        }
-
         const ctx = e && RootAPI.getTabsterContext(this._tabster, e);
         // Modalizer behaviour is opt in, only apply to elements that have a tabster context
         if (!ctx) {
             return;
+        }
+
+        if (this._focusOutTimer) {
+            this._win().clearTimeout(this._focusOutTimer);
+            this._focusOutTimer = undefined;
         }
 
         const modalizer = ctx?.modalizer;

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -506,7 +506,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                 this._curModalizer.setActive(true);
                 this._curModalizer.setFocused(true);
             } 
-        } else if (focusedElement && this._curModalizer && !this._curModalizer.contains(e)) {
+        } else if (focusedElement && this._curModalizer && !this._curModalizer.contains(focusedElement)) {
             // Focused outside of the active modalizer, try pull focus back to current modalizer
             this._restoreModalizerFocus(focusedElement);
         }

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -477,8 +477,8 @@ export class ModalizerAPI implements Types.ModalizerAPI {
      * @param e - Element that is focused
      * @param details - Additional data about the focus event
      */
-    private _onFocus = (e: HTMLElement | undefined, details: Types.FocusedElementDetails): void => {
-        const ctx = e && RootAPI.getTabsterContext(this._tabster, e);
+    private _onFocus = (focusedElement: HTMLElement | undefined, details: Types.FocusedElementDetails): void => {
+        const ctx = focusedElement && RootAPI.getTabsterContext(this._tabster, focusedElement);
         // Modalizer behaviour is opt in, only apply to elements that have a tabster context
         if (!ctx) {
             return;
@@ -506,9 +506,9 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                 this._curModalizer.setActive(true);
                 this._curModalizer.setFocused(true);
             } 
-        } else if (e && this._curModalizer && !this._curModalizer.contains(e)) {
-            // Focused outside of the active modalizer, pull focus back to current modalizer
-            this._restoreModalizerFocus(e);
+        } else if (focusedElement && this._curModalizer && !this._curModalizer.contains(e)) {
+            // Focused outside of the active modalizer, try pull focus back to current modalizer
+            this._restoreModalizerFocus(focusedElement);
         }
     }
 

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -212,6 +212,10 @@ export class Modalizer implements Types.Modalizer {
         return this._modalizerRoot.get();
     }
 
+    contains(element: HTMLElement) {
+        return !!this.getModalizerRoot()?.contains(element);
+    }
+
     setFocused(focused: boolean): void {
         if (this._isFocused === focused) {
             return;
@@ -449,7 +453,6 @@ export class ModalizerAPI implements Types.ModalizerAPI {
 
     /**
      * If a modalizer is still active and has no elements left on the document, set it to inactive
-     * This is a fallback, recommended action is to remove the modalizer before removing DOM elements
      */
     private _onMutation = (e: MutationEvent) => {
         const details = e.details;
@@ -491,19 +494,19 @@ export class ModalizerAPI implements Types.ModalizerAPI {
             return;
         }
 
+        this._curModalizer?.setFocused(false);
+
         // Developers calling `element.focus()` should change/deactivate active modalizer 
         if (details.isFocusedProgrammatically) {
-            if (this._curModalizer) {
-                this._curModalizer.setActive(false);
-                this._curModalizer.setFocused(false);
-            }
+            this._curModalizer?.setActive(false);
+            this._curModalizer = undefined;
 
             if (modalizer) {
                 this._curModalizer = modalizer;
                 this._curModalizer.setActive(true);
                 this._curModalizer.setFocused(true);
             } 
-        } else {
+        } else if (e && this._curModalizer && !this._curModalizer.contains(e)) {
             // Focused outside of the active modalizer, pull focus back to current modalizer
             this._restoreModalizerFocus(e);
         }

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -463,12 +463,17 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         if (details.modalizer.isActive()) {
             if (__DEV__) {
                 console.warn(`Modalizer: ${details.modalizer.userId}.
-                    Elements should be removed from the Modalizer before they are removed from DOM.
-                    Removing elements from the modalizer first is more performant.
+                    calling ModalizerAPI.remove(element) before removing a modalizer from DOM can be safer.
                 `);
             }
 
+            delete this._modalizers[details.modalizer.userId];
+            if (this._curModalizer === details.modalizer) {
+                this._curModalizer = undefined;
+            }
+            details.modalizer.setFocused(false);
             details.modalizer.setActive(false);
+            details.modalizer.dispose();
         }
     }
 

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -151,7 +151,7 @@ export class Modalizer implements Types.Modalizer {
         this.setActive(!this._isActive);
     }
 
-    setActive(active: boolean): void {
+    setActive(active: boolean, visitSubTree?: boolean): void {
         if (active === this._isActive) {
             return;
         }
@@ -198,10 +198,10 @@ export class Modalizer implements Types.Modalizer {
             // Add `aria-hidden` when modalizer is active
             // Restore `aria-hidden` when modalizer is inactive
             augmentAttribute(this._tabster, el, 'aria-hidden', active ? 'true' : undefined);
-            // TODO: figure out a way to ignore  subtrees when restoring aria-hidden
-            // Modalizer element might no longer be on the DOM so containsModalizerElement might never return
-            if (active) {
-                // aria-hidden will apply for all children
+
+            if (!visitSubTree) {
+                // if the modalizer elements guaranteed to be in DOM, there is no need to visit subtrees
+                // Previous checks will either skip or reject subtrees if mdoalizer elements are present
                 return NodeFilter.FILTER_REJECT;
             }
 
@@ -492,7 +492,8 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                 `);
             }
 
-            details.modalizer.setActive(false);
+            // No guarantee modalizer elements are on the page - safer to visit all subtrees
+            details.modalizer.setActive(false, true);
         }
     }
 

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -512,7 +512,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                 this._curModalizer.setActive(true);
                 this._curModalizer.setFocused(true);
             } 
-        } else if (focusedElement && this._curModalizer && !this._curModalizer.contains(focusedElement)) {
+        } else if (focusedElement && this._curModalizer && !this._curModalizer.getBasicProps().isOthersAccessible) {
             // Focused outside of the active modalizer, try pull focus back to current modalizer
             this._restoreModalizerFocus(focusedElement);
         }

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -178,21 +178,33 @@ export class Modalizer implements Types.Modalizer {
             }
 
             const isModalizerElement = this._modalizerElements.some(modalizerElement => modalizerElement.get() === el);
-            const hasModalizerElement = this._modalizerElements.some(modalizerElement => !!modalizerElement.get()?.contains(el));
+            const containsModalizerElement = this._modalizerElements.some(modalizerElement => {
+                const modalizerElementValue = modalizerElement.get();
+                if (modalizerElementValue && el.contains(modalizerElementValue)) {
+                    return true;
+                }
+
+                return false;
+            });
 
             // Reached a modalizer element, no need to continue
             if (isModalizerElement) {
                 return NodeFilter.FILTER_REJECT;
             }
 
-            // Has a modalizer element as a descendant, continue
-            if (hasModalizerElement) {
+            // Contains a modalizer element as a descendant, continue
+            if (containsModalizerElement) {
                 return NodeFilter.FILTER_SKIP;
             }
 
             augmentAttribute(this._tabster, el, 'aria-hidden', active ? 'true' : undefined);
-            // aria-hidden will apply for all children
-            return NodeFilter.FILTER_REJECT;
+            // TODO: figure out a way to ignore  subtrees when restoring aria-hidden
+            if (active) {
+                // aria-hidden will apply for all children
+                return NodeFilter.FILTER_REJECT;
+            }
+
+            return NodeFilter.FILTER_SKIP;
         });
 
         if (ariaHiddenWalker) {

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -26,7 +26,7 @@ export interface WindowWithTabsterInstance extends Window {
     __tabsterInstance?: Types.TabsterCore;
 }
 
-function _setInformativeStyle(weakElement: WeakHTMLElement, remove: boolean, id?: string, currentModalizerId?: string) {
+function _setInformativeStyle(weakElement: WeakHTMLElement, remove: boolean, id?: string) {
     if (__DEV__) {
         const element = weakElement.get();
 
@@ -34,7 +34,7 @@ function _setInformativeStyle(weakElement: WeakHTMLElement, remove: boolean, id?
             if (remove) {
                 element.style.removeProperty('--tabster-root');
             } else {
-                element.style.setProperty('--tabster-root', id + ',' + currentModalizerId);
+                element.style.setProperty('--tabster-root', id + ',');
             }
         }
     }
@@ -47,7 +47,6 @@ export class Root implements Types.Root {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
     private _basic: Types.RootBasicProps;
-    private _curModalizerId: string | undefined;
     private _updateModalizersTimer: number | undefined;
     private _dummyInputFirst: DummyInput | undefined;
     private _dummyInputLast: DummyInput | undefined;
@@ -139,7 +138,7 @@ export class Root implements Types.Root {
 
     private _add(): void {
         if (__DEV__) {
-            _setInformativeStyle(this._element, false, this.uid, this._curModalizerId);
+            _setInformativeStyle(this._element, false, this.uid);
         }
     }
 

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -48,7 +48,6 @@ export class Root implements Types.Root {
     private _win: Types.GetWindow;
     private _basic: Types.RootBasicProps;
     private _curModalizerId: string | undefined;
-    private _knownModalizers: { [id: string]: Types.Modalizer } = {};
     private _updateModalizersTimer: number | undefined;
     private _dummyInputFirst: DummyInput | undefined;
     private _dummyInputLast: DummyInput | undefined;
@@ -97,7 +96,6 @@ export class Root implements Types.Root {
             delete this._dummyInputLast;
         }
 
-        this._knownModalizers = {};
         this._forgetFocusedGrouppers = () => {/**/};
     }
 
@@ -121,32 +119,6 @@ export class Root implements Types.Root {
 
     getElement(): HTMLElement | undefined {
         return this._element.get();
-    }
-
-    getCurrentModalizerId(): string | undefined {
-        return this._curModalizerId;
-    }
-
-    setCurrentModalizerId(id: string | undefined, noModalizersUpdate?: boolean): void {
-        this._curModalizerId = id;
-
-        if (__DEV__) {
-            _setInformativeStyle(this._element, false, this.uid, this._curModalizerId);
-        }
-    }
-
-    getModalizers(): Types.Modalizer[] {
-        const modalizers: Types.Modalizer[] = [];
-
-        for (let id of Object.keys(this._knownModalizers)) {
-            modalizers.push(this._knownModalizers[id]);
-        }
-
-        return modalizers;
-    }
-
-    getModalizerById(id: string): Types.Modalizer | undefined {
-        return this._knownModalizers[id];
     }
 
     updateDummyInputs(): void {

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -47,7 +47,6 @@ export class Root implements Types.Root {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
     private _basic: Types.RootBasicProps;
-    private _updateModalizersTimer: number | undefined;
     private _dummyInputFirst: DummyInput | undefined;
     private _dummyInputLast: DummyInput | undefined;
     private _forgetFocusedGrouppers: () => void;
@@ -76,11 +75,6 @@ export class Root implements Types.Root {
     }
 
     dispose(): void {
-        if (this._updateModalizersTimer) {
-            this._win().clearTimeout(this._updateModalizersTimer);
-            this._updateModalizersTimer = undefined;
-        }
-
         this._remove();
 
         const dif = this._dummyInputFirst;

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -219,15 +219,13 @@ export class Root implements Types.Root {
                     currentIsPresent = true;
                     isOthersAccessible = !!tabsterOnElement.modalizer.getBasicProps().isOthersAccessible;
                 }
-
-                return NodeFilter.FILTER_ACCEPT;
             }
 
             return NodeFilter.FILTER_SKIP;
         });
 
         if (walker) {
-            while (walker.nextNode()) { /* Iterating for the sake of calling acceptNode callback. */ }
+            while (walker.nextNode()) { /* Iterate nodes to find all modalizers */ }
         }
 
         if (!currentIsPresent) {

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -241,7 +241,7 @@ export class Root implements Types.Root {
 
             modalizer.setActive(active);
             modalizer.setAccessible(modalizer.getBasicProps().isAlwaysAccessible || isOthersAccessible || active);
-        })
+        });
     }
 
     private _createDummyInput(props: DummyInput): void {

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -362,19 +362,11 @@ export class FocusedElementState
                     )
                 );
 
-            if (ctx && ctx.modalizer) {
-                const curModalizerId = ctx.root.getCurrentModalizerId();
+            if (ctx && ctx.modalizer?.isActive()) {
+                curElement = ctx.modalizer.getElementContaining(curElement);
 
-                if (curModalizerId && (curModalizerId !== ctx.modalizer.userId)) {
-                    ctx.modalizer = ctx.root.getModalizerById(curModalizerId);
-
-                    if (ctx.modalizer) {
-                        curElement = ctx.modalizer.getElementContaining(curElement);
-
-                        if (!curElement) {
-                            return;
-                        }
-                    }
+                if (!curElement) {
+                    return;
                 }
             }
 
@@ -486,8 +478,7 @@ export class FocusedElementState
                 if (
                     !nctx ||
                     (ctx.root.uid !== nctx.root.uid) ||
-                    !nctx.modalizer ||
-                    (nctx.root.getCurrentModalizerId() !== nctx.modalizer.userId)
+                    !nctx.modalizer?.isActive()
                 ) {
                     if (ctx.modalizer.onBeforeFocusOut()) {
                         e.preventDefault();
@@ -729,7 +720,6 @@ export class FocusedElementState
 
     private _validateFocusedElement = (element: HTMLElement, details: Types.FocusedElementDetails): void => {
         const ctx = RootAPI.getTabsterContext(this._tabster, element);
-        const curModalizerId = ctx ? ctx.root.getCurrentModalizerId() : undefined;
 
         this._tabster.focusable.setCurrentGroupper(element);
 
@@ -739,13 +729,7 @@ export class FocusedElementState
 
         let eModalizer = ctx.modalizer;
 
-        if (curModalizerId === eModalizer.userId) {
-            return;
-        }
-
-        if ((curModalizerId === undefined) || details.isFocusedProgrammatically) {
-            ctx.root.setCurrentModalizerId(eModalizer.userId);
-
+        if (eModalizer.isActive()) {
             return;
         }
 

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -369,7 +369,7 @@ export class FocusedElementState
                     ctx.modalizer = ctx.root.getModalizerById(curModalizerId);
 
                     if (ctx.modalizer) {
-                        curElement = ctx.modalizer.getElement();
+                        curElement = ctx.modalizer.getElementContaining(curElement);
 
                         if (!curElement) {
                             return;

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -711,40 +711,7 @@ export class FocusedElementState
     }
 
     private _validateFocusedElement = (element: HTMLElement, details: Types.FocusedElementDetails): void => {
-        const ctx = RootAPI.getTabsterContext(this._tabster, element);
-
         this._tabster.focusable.setCurrentGroupper(element);
-
-        if (!ctx || !ctx.modalizer) {
-            return;
-        }
-
-        let eModalizer = ctx.modalizer;
-
-        if (eModalizer.isActive()) {
-            return;
-        }
-
-        if (eModalizer && element.ownerDocument) {
-            let toFocus = this._tabster.focusable.findFirst(ctx.root.getElement());
-
-            if (toFocus) {
-                if (element.compareDocumentPosition(toFocus) & document.DOCUMENT_POSITION_PRECEDING) {
-                    toFocus = this._tabster.focusable.findLast(element.ownerDocument.body);
-
-                    if (!toFocus) {
-                        // This only might mean that findFirst/findLast are buggy and inconsistent.
-                        throw new Error('Something went wrong.');
-                    }
-                }
-
-                this._tabster.focusedElement.focus(toFocus);
-            } else {
-                // Current Modalizer doesn't seem to have focusable elements.
-                // Blurring the currently focused element which is outside of the current Modalizer.
-                element.blur();
-            }
-        }
     }
 
     private _isInput(element: HTMLElement): boolean {

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -585,7 +585,7 @@ export class FocusedElementState
 
             if (next) {
                 if (!this._tabster.focusable.isFocusable(next)) {
-                    next = this._tabster.focusable.findFirst(next, false, false, true);
+                    next = this._tabster.focusable.findFirst(next, false, true);
                 }
 
                 if (next) {
@@ -602,7 +602,7 @@ export class FocusedElementState
     private _getFirstInGroupper(groupperElement: HTMLElement, ignoreGroupper: boolean): HTMLElement | null {
         return this._tabster.focusable.isFocusable(groupperElement)
             ? groupperElement
-            : this._tabster.focusable.findFirst(groupperElement, false, false, ignoreGroupper);
+            : this._tabster.focusable.findFirst(groupperElement, false, ignoreGroupper);
     }
 
     private _findNextGroupper(from: HTMLElement, key: Key, direction?: Types.GroupperNextDirection, isRtl?: boolean): HTMLElement | null {

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -242,7 +242,7 @@ export class FocusedElementState
         const nextVal = this._nextVal = { element: element ? new WeakHTMLElement(this._win, element) : undefined, details };
 
         if (element && (element !== this._val)) {
-            this._validateFocusedElement(element, details);
+            this._validateFocusedElement(element);
         }
 
         // _validateFocusedElement() might cause the refocus which will trigger
@@ -710,7 +710,7 @@ export class FocusedElementState
         return pde;
     }
 
-    private _validateFocusedElement = (element: HTMLElement, details: Types.FocusedElementDetails): void => {
+    private _validateFocusedElement = (element: HTMLElement): void => {
         this._tabster.focusable.setCurrentGroupper(element);
     }
 

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -362,14 +362,6 @@ export class FocusedElementState
                     )
                 );
 
-            if (ctx && ctx.modalizer?.isActive()) {
-                curElement = ctx.modalizer.getElementContaining(curElement);
-
-                if (!curElement) {
-                    return;
-                }
-            }
-
             let fromElement: HTMLElement | null = curElement;
 
             // If the current element is in a mover, move to the mover boundaries since a mover is considered a single tabstop

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -518,6 +518,10 @@ export interface ModalizerAPI {
      */
     add(element: HTMLElement, basic: ModalizerBasicProps, extended?: ModalizerExtendedProps): void;
     /**
+     * Gets the currently active modalizer if it exists
+     */
+    getActiveModalizer(): Modalizer | undefined;
+    /**
      * Stops managing an element with Modalizer. Should be called before the element is removed from DOM.
      *  
      * @param element Element that is managed by Modalizer

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -444,37 +444,15 @@ export interface ModalizerExtendedProps {
 export interface Modalizer {
     readonly internalId: string;
     readonly userId: string;
-    /**
-     * Adds an element to the modalizer
-     * 
-     * @param element element the modalizer should manage
-     * @param win window getter, u
-     * @returns boolean, if operation was successful
-     */
-    add(element: HTMLElement, win: GetWindow): boolean;
     dispose(): void;
     getBasicProps(): ModalizerBasicProps;
     /**
-     * @returns All managed modalizer elements
+     * @returns The root element of the modal
      */
-    getElements(): HTMLElement[];
-    /**
-     * Returns the modalizer element that contains the provided element
-     * 
-     * @param element Element to test
-     * @returns Modalizer element that contains the provided element
-     */
-    getElementContaining(element: HTMLElement): HTMLElement | undefined;
+    getModalizerRoot(): HTMLElement | undefined;
     getExtendedProps(): ModalizerExtendedProps;
-    /**
-     * Checks if an element belongs to the modalizer instance
-     * 
-     * @param element Element to test
-     * @returns Whether the element is managed by the modalizer
-     */
-    hasElement(element: HTMLElement): boolean;
     isActive(): boolean;
-    move(fromElement: HTMLElement, newElement: HTMLElement): void;
+    move(newElement: HTMLElement): void;
     onBeforeFocusOut(): boolean;
     /**
      * Sets the active state of the modalizr

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -313,15 +313,15 @@ export interface FocusableAPI {
     isVisible(element: HTMLElement): boolean;
     isAccessible(element: HTMLElement): boolean;
     findFirst(context?: HTMLElement, includeProgrammaticallyFocusable?: boolean,
-        ignoreModalizer?: boolean, ignoreGroupper?: boolean): HTMLElement | null;
+        ignoreGroupper?: boolean): HTMLElement | null;
     findLast(context?: HTMLElement, includeProgrammaticallyFocusable?: boolean,
-        ignoreModalizer?: boolean, ignoreGroupper?: boolean): HTMLElement | null;
+        ignoreGroupper?: boolean): HTMLElement | null;
     findNext(current: HTMLElement, context?: HTMLElement, includeProgrammaticallyFocusable?: boolean,
-        ignoreModalizer?: boolean, ignoreGroupper?: boolean): HTMLElement | null;
+        ignoreGroupper?: boolean): HTMLElement | null;
     findPrev(current: HTMLElement, context?: HTMLElement, includeProgrammaticallyFocusable?: boolean,
-        ignoreModalizer?: boolean, ignoreGroupper?: boolean): HTMLElement | null;
+        ignoreGroupper?: boolean): HTMLElement | null;
     findDefault(context?: HTMLElement, includeProgrammaticallyFocusable?: boolean,
-        ignoreModalizer?: boolean, ignoreGroupper?: boolean): HTMLElement | null;
+        ignoreGroupper?: boolean): HTMLElement | null;
     findAll(
         context: HTMLElement,
         customFilter: (el: HTMLElement) => boolean,

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -499,8 +499,6 @@ export interface Root {
     getBasicProps(): RootBasicProps;
     move(newElement: HTMLElement): void;
     getElement(): HTMLElement | undefined;
-    getModalizers(): Modalizer[];
-    getModalizerById(id: string): Modalizer | undefined;
     updateDummyInputs(): void;
     moveOutWithDefaultAction(backwards: boolean): void;
 }

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -532,10 +532,29 @@ export interface RootAPI {
 }
 
 export interface ModalizerAPI {
+    /**
+     * Adds an element to be managed by Modalizer
+     * 
+     * @param element Element that is not managed by Modalizer
+     * @param basic Basic props
+     * @param extended Extended props
+     */
     add(element: HTMLElement, basic: ModalizerBasicProps, extended?: ModalizerExtendedProps): void;
+    /**
+     * Stops managing an element with Modalizer. Should be called before the element is removed from DOM.
+     *  
+     * @param element Element that is managed by Modalizer
+     */
     remove(element: HTMLElement): void;
     move(from: HTMLElement, to: HTMLElement): void;
     setProps(element: HTMLElement, basic?: Partial<ModalizerBasicProps> | null, extended?: Partial<ModalizerExtendedProps> | null): void;
+    /**
+     * Activates a Modalizer and focuses the first or default element within
+     * 
+     * @param elementFromModalizer An element that belongs to a Modalizer
+     * @param noFocusFirst Do not focus on the first element in the Modalizer
+     * @param noFocusDefault Do not focus the default element in the Modalizre
+     */
     focus(elementFromModalizer: HTMLElement, noFocusFirst?: boolean, noFocusDefault?: boolean): boolean;
 }
 

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -460,9 +460,8 @@ export interface Modalizer {
      * Reverts `aria-hidden` changes when set to inactive
      *  
      * @param active Whether the modalizer is active
-     * @param visitSubtree If modalizer elements are not present in DOM, visit all nodes in subtrees to restore `aria-hidden`
      */
-    setActive(active: boolean, visitSubtree?: boolean): void;
+    setActive(active: boolean): void;
     setFocused(focused: boolean): void;
     setProps(basic?: Partial<ModalizerBasicProps> | null, extended?: Partial<ModalizerExtendedProps> | null): void;
 }

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -476,7 +476,13 @@ export interface Modalizer {
     isActive(): boolean;
     move(fromElement: HTMLElement, newElement: HTMLElement): void;
     onBeforeFocusOut(): boolean;
-    setAccessible(accessible: boolean): void;
+    /**
+     * Sets the active state of the modalizr
+     * When active, sets `aria-hidden` on all other elements
+     * Reverts `aria-hidden` changes when set to inactive
+     *  
+     * @param active Whether the modalizer is active
+     */
     setActive(active: boolean): void;
     setFocused(focused: boolean): void;
     setProps(basic?: Partial<ModalizerBasicProps> | null, extended?: Partial<ModalizerExtendedProps> | null): void;
@@ -493,11 +499,8 @@ export interface Root {
     getBasicProps(): RootBasicProps;
     move(newElement: HTMLElement): void;
     getElement(): HTMLElement | undefined;
-    getCurrentModalizerId(): string | undefined;
-    setCurrentModalizerId(id: string | undefined, noModalizersUpdate?: boolean): void;
     getModalizers(): Modalizer[];
     getModalizerById(id: string): Modalizer | undefined;
-    updateModalizers(): void;
     updateDummyInputs(): void;
     moveOutWithDefaultAction(backwards: boolean): void;
 }

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -444,17 +444,42 @@ export interface ModalizerExtendedProps {
 export interface Modalizer {
     readonly internalId: string;
     readonly userId: string;
-    setProps(basic?: Partial<ModalizerBasicProps> | null, extended?: Partial<ModalizerExtendedProps> | null): void;
-    getBasicProps(): ModalizerBasicProps;
-    getExtendedProps(): ModalizerExtendedProps;
+    /**
+     * Adds an element to the modalizer
+     * 
+     * @param element element the modalizer should manage
+     * @param win window getter, u
+     * @returns boolean, if operation was successful
+     */
+    add(element: HTMLElement, win: GetWindow): boolean;
     dispose(): void;
-    move(newElement: HTMLElement): void;
+    getBasicProps(): ModalizerBasicProps;
+    /**
+     * @returns All managed modalizer elements
+     */
+    getElements(): HTMLElement[];
+    /**
+     * Returns the modalizer element that contains the provided element
+     * 
+     * @param element Element to test
+     * @returns Modalizer element that contains the provided element
+     */
+    getElementContaining(element: HTMLElement): HTMLElement | undefined;
+    getExtendedProps(): ModalizerExtendedProps;
+    /**
+     * Checks if an element belongs to the modalizer instance
+     * 
+     * @param element Element to test
+     * @returns Whether the element is managed by the modalizer
+     */
+    hasElement(element: HTMLElement): boolean;
+    isActive(): boolean;
+    move(fromElement: HTMLElement, newElement: HTMLElement): void;
+    onBeforeFocusOut(): boolean;
     setAccessible(accessible: boolean): void;
     setActive(active: boolean): void;
-    isActive(): boolean;
-    getElement(): HTMLElement | undefined;
     setFocused(focused: boolean): void;
-    onBeforeFocusOut(): boolean;
+    setProps(basic?: Partial<ModalizerBasicProps> | null, extended?: Partial<ModalizerExtendedProps> | null): void;
 }
 
 export interface RootBasicProps {

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -444,6 +444,10 @@ export interface ModalizerExtendedProps {
 export interface Modalizer {
     readonly internalId: string;
     readonly userId: string;
+    /**
+     * @returns - Whether the element is inside the modalizer
+     */
+    contains(element: HTMLElement): boolean;
     dispose(): void;
     getBasicProps(): ModalizerBasicProps;
     /**

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -482,8 +482,9 @@ export interface Modalizer {
      * Reverts `aria-hidden` changes when set to inactive
      *  
      * @param active Whether the modalizer is active
+     * @param visitSubtree If modalizer elements are not present in DOM, visit all nodes in subtrees to restore `aria-hidden`
      */
-    setActive(active: boolean): void;
+    setActive(active: boolean, visitSubtree?: boolean): void;
     setFocused(focused: boolean): void;
     setProps(basic?: Partial<ModalizerBasicProps> | null, extended?: Partial<ModalizerExtendedProps> | null): void;
 }

--- a/demo/src/demo.tsx
+++ b/demo/src/demo.tsx
@@ -28,7 +28,7 @@ class App extends React.PureComponent {
         return (
             <div { ...getTabsterAttribute({ root: {} }) }>
                 <TabsterExistsExample />
-                <div aria-label='Main' { ...getTabsterAttribute({ modalizer: { id: 'main' }, deloser: {} }) }>
+                <div { ...getTabsterAttribute({ deloser: {} }) }>
                     <h1>Hello world</h1>
 
                     <div { ...getTabsterAttribute({ 

--- a/examples/src/Groupper.stories.tsx
+++ b/examples/src/Groupper.stories.tsx
@@ -18,7 +18,6 @@ export const NestedGrouppers = () => (
         <div
             aria-label='Main'
             {...getTabsterAttribute({
-                modalizer: { id: 'main' },
                 deloser: {},
             })}
         >

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -29,16 +29,29 @@ export const ModalDialog = () => {
 
 export const PopupContent = () => {
     const [open, setOpen ] = React.useState<boolean>(false);
-    const modalizerRef = React.useCallback(node => {
+    const popupRef = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+        const popupEl = popupRef.current;
         const tabster = getCurrentTabster(window);
-        if (tabster && node !== null) {
+        if (popupEl && open && tabster) {
             const modalizer = getModalizer(tabster);
             const deloser = getDeloser(tabster);
-            modalizer.add(node, {id: 'popup'});
-            deloser.add(node);
-            modalizer.focus(node);
+            modalizer.add(popupEl, {id: 'popup'});
+            deloser.add(popupEl);
+            modalizer.focus(popupEl);
         }
-    }, []);
+
+        return () => {
+            const tabster = getCurrentTabster(window);
+            if (popupEl && tabster && open) {
+                const modalizer = getModalizer(tabster);
+                const deloser = getDeloser(tabster);
+                modalizer.remove(popupEl);
+                deloser.remove(popupEl);
+            }
+        };
+
+    }, [open, popupRef]);
 
     const onClick = () => setOpen(s => !s);
 
@@ -55,7 +68,7 @@ export const PopupContent = () => {
                 <button onClick={onClick}>Toggle popup</button>
             </div>
             <div>
-                {open && <div ref={modalizerRef} style={popupStyles}>
+                {open && <div aria-label={'popup'} ref={popupRef} style={popupStyles}>
                     <div tabIndex={0}>Focusable item</div>
                     <div tabIndex={0}>Focusable item</div>
                     <div tabIndex={0}>Focusable item</div>

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -64,14 +64,22 @@ export const ImperativeModalizerAPI = () => {
     return (
         <div  { ...getTabsterAttribute({ deloser: {} })}>
             <button onClick={onClick}>Toggle popup</button>
-            {open && <div aria-label={'popup'} ref={callbackRef} style={popupStyles}>
-                <div tabIndex={0}>Focusable item</div>
-                <div tabIndex={0}>Focusable item</div>
-                <div tabIndex={0}>Focusable item</div>
-                <div tabIndex={0}>Focusable item</div>
-                <button onClick={onClick}>Dismiss</button>
-            </div>}
-            <button>Outside Modalizer</button>
+            {open && (
+                <>
+                    <div 
+                        ref={callbackRef} 
+                        aria-label={'popup'} 
+                        style={popupStyles} 
+                    >
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <button onClick={onClick}>Dismiss</button>
+                    </div>
+                    <button>Outside Modalizer</button>
+                </>
+            )}
         </div>
     );
 };
@@ -92,20 +100,22 @@ export const DeclarativeModalizerAPI = () => {
         <div  { ...getTabsterAttribute({ deloser: {} })}>
             <button onClick={onClick}>Toggle popup</button>
             {open && (
-                <div 
-                    ref={popupRef} 
-                    aria-label={'popup'} 
-                    style={popupStyles} 
-                    {...getTabsterAttribute({ deloser: {}, modalizer: { id: 'modalizer'} })}
-                >
-                    <div tabIndex={0}>Focusable item</div>
-                    <div tabIndex={0}>Focusable item</div>
-                    <div tabIndex={0}>Focusable item</div>
-                    <div tabIndex={0}>Focusable item</div>
-                    <button onClick={onClick}>Dismiss</button>
-                </div>
+                <>
+                    <div 
+                        ref={popupRef} 
+                        aria-label={'popup'} 
+                        style={popupStyles} 
+                        {...getTabsterAttribute({ deloser: {}, modalizer: { id: 'modalizer'} })}
+                    >
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <button onClick={onClick}>Dismiss</button>
+                    </div>
+                    <button>Outside Modalizer</button>
+                </>
             )}
-            <button>Outside Modalizer</button>
         </div>
     );
 

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -27,7 +27,16 @@ export const ModalDialog = () => {
     );
 };
 
-export const PopupContent = () => {
+const popupStyles = {
+    maxWidth: 400,
+    maxHeight: 400,
+    border: '2px solid green',
+    padding: 5,
+    marginTop: 5,
+    marginBottom: 5
+}; 
+
+export const ImperativeModalizerAPI = () => {
     const [open, setOpen ] = React.useState<boolean>(false);
     const popupRef = React.useRef<HTMLDivElement>();
 
@@ -52,19 +61,9 @@ export const PopupContent = () => {
     }, [popupRef]);
 
     const onClick = () => setOpen(s => !s);
-
-    const popupStyles = {
-        maxWidth: 400,
-        maxHeight: 400,
-        border: '1px solid',
-        padding: 5
-    };
-
     return (
-        <>
-            <div  { ...getTabsterAttribute({ deloser: {} })}>
-                <button onClick={onClick}>Toggle popup</button>
-            </div>
+        <div  { ...getTabsterAttribute({ deloser: {} })}>
+            <button onClick={onClick}>Toggle popup</button>
             {open && <div aria-label={'popup'} ref={callbackRef} style={popupStyles}>
                 <div tabIndex={0}>Focusable item</div>
                 <div tabIndex={0}>Focusable item</div>
@@ -72,24 +71,49 @@ export const PopupContent = () => {
                 <div tabIndex={0}>Focusable item</div>
                 <button onClick={onClick}>Dismiss</button>
             </div>}
-            <div { ...getTabsterAttribute({ deloser: {} })}>
-                <button>Do not focus</button>
-            </div>
-        </>
+            <button>Outside Modalizer</button>
+        </div>
     );
 };
 
-export const FocusWithoutModalizerAPI = () => {
+export const DeclarativeModalizerAPI = () => {
+    const [open, setOpen ] = React.useState<boolean>(false);
+    const popupRef = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+        if (open && popupRef.current) {
+            const first = getCurrentTabster(window)?.focusable.findFirst(popupRef.current);
+            first?.focus();
+        }
+    }, [popupRef, open]);
+
+    const onClick = () => setOpen(s => !s);
+
+    return (
+        <div  { ...getTabsterAttribute({ deloser: {} })}>
+            <button onClick={onClick}>Toggle popup</button>
+            {open && (
+                <div 
+                    ref={popupRef} 
+                    aria-label={'popup'} 
+                    style={popupStyles} 
+                    {...getTabsterAttribute({ deloser: {}, modalizer: { id: 'modalizer'} })}
+                >
+                    <div tabIndex={0}>Focusable item</div>
+                    <div tabIndex={0}>Focusable item</div>
+                    <div tabIndex={0}>Focusable item</div>
+                    <div tabIndex={0}>Focusable item</div>
+                    <button onClick={onClick}>Dismiss</button>
+                </div>
+            )}
+            <button>Outside Modalizer</button>
+        </div>
+    );
+
+}
+
+export const ModalizerAlwaysOnPage = () => {
     const modalRef = React.useRef<HTMLDivElement>(null);
     const outsideRef = React.useRef<HTMLButtonElement>(null);
-    const popupStyles = {
-        maxWidth: 400,
-        maxHeight: 400,
-        border: '2px solid green',
-        padding: 5,
-        marginTop: 5,
-        marginBottom: 5
-    };
 
     const focusIn = () => {
         if (modalRef.current) {
@@ -107,10 +131,8 @@ export const FocusWithoutModalizerAPI = () => {
     };
 
     return (
-        <>
-            <div  >
-                <button onClick={focusIn}>Focus modalizer</button>
-            </div>
+        <div  { ...getTabsterAttribute({ deloser: {} })}>
+            <button onClick={focusIn}>Focus modalizer</button>
             <div 
                 aria-hidden 
                 ref={modalRef} 
@@ -124,9 +146,7 @@ export const FocusWithoutModalizerAPI = () => {
                 <div tabIndex={0}>Focusable item</div>
                 <button onClick={focusOut}>Focus out</button>
             </div>
-            <div >
-                <button ref={outsideRef}>Outside modal</button>
-            </div>
-        </>
+            <button ref={outsideRef}>Outside modal</button>
+        </div>
     ); 
 };

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -109,7 +109,7 @@ export const DeclarativeModalizerAPI = () => {
         </div>
     );
 
-}
+};
 
 export const ModalizerAlwaysOnPage = () => {
     const modalRef = React.useRef<HTMLDivElement>(null);

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -29,29 +29,26 @@ export const ModalDialog = () => {
 
 export const PopupContent = () => {
     const [open, setOpen ] = React.useState<boolean>(false);
-    const popupRef = React.useRef<HTMLDivElement>(null);
-    React.useEffect(() => {
-        const popupEl = popupRef.current;
+    const popupRef = React.useRef<HTMLDivElement>();
+
+    const callbackRef = React.useCallback((node: HTMLDivElement) => {
         const tabster = getCurrentTabster(window);
-        if (popupEl && open && tabster) {
-            const modalizer = getModalizer(tabster);
-            const deloser = getDeloser(tabster);
-            modalizer.add(popupEl, {id: 'popup'});
-            deloser.add(popupEl);
-            modalizer.focus(popupEl);
+        const modalizer = tabster && getModalizer(tabster);
+        const deloser = tabster && getDeloser(tabster);
+        if (!modalizer || !deloser) {
+            return;
         }
 
-        return () => {
-            const tabster = getCurrentTabster(window);
-            if (popupEl && tabster && open) {
-                const modalizer = getModalizer(tabster);
-                const deloser = getDeloser(tabster);
-                modalizer.remove(popupEl);
-                deloser.remove(popupEl);
-            }
-        };
-
-    }, [open, popupRef]);
+        if (node) {
+            popupRef.current = node;
+            modalizer.add(popupRef.current, {id: 'popup'});
+            deloser.add(popupRef.current);
+            modalizer.focus(popupRef.current);
+        } else {
+            popupRef.current &&  modalizer.remove(popupRef.current);
+            popupRef.current && deloser.remove(popupRef.current);
+        }
+    }, [popupRef])
 
     const onClick = () => setOpen(s => !s);
 
@@ -68,7 +65,7 @@ export const PopupContent = () => {
                 <button onClick={onClick}>Toggle popup</button>
             </div>
             <div>
-                {open && <div aria-label={'popup'} ref={popupRef} style={popupStyles}>
+                {open && <div aria-label={'popup'} ref={callbackRef} style={popupStyles}>
                     <div tabIndex={0}>Focusable item</div>
                     <div tabIndex={0}>Focusable item</div>
                     <div tabIndex={0}>Focusable item</div>

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -78,3 +78,55 @@ export const PopupContent = () => {
         </>
     );
 };
+
+export const FocusWithoutModalizerAPI = () => {
+    const modalRef = React.useRef<HTMLDivElement>(null);
+    const outsideRef = React.useRef<HTMLButtonElement>(null);
+    const popupStyles = {
+        maxWidth: 400,
+        maxHeight: 400,
+        border: '2px solid green',
+        padding: 5,
+        marginTop: 5,
+        marginBottom: 5
+    };
+
+    const focusIn = () => {
+        if (modalRef.current) {
+            modalRef.current.removeAttribute('aria-hidden');
+            const first = getCurrentTabster(window)?.focusable.findFirst(modalRef.current);
+            first?.focus();
+        }
+    };
+
+    const focusOut = () => {
+        if (modalRef.current && outsideRef.current) {
+            modalRef.current.setAttribute('aria-hidden', 'true');
+            outsideRef.current.focus();
+        }
+    };
+
+    return (
+        <>
+            <div  >
+                <button onClick={focusIn}>Focus modalizer</button>
+            </div>
+            <div 
+                aria-hidden 
+                ref={modalRef} 
+                aria-label={'popup'} 
+                style={popupStyles} 
+                {...getTabsterAttribute({ modalizer: { id: 'modalizer'} })}
+            >
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <button onClick={focusOut}>Focus out</button>
+            </div>
+            <div >
+                <button ref={outsideRef}>Outside modal</button>
+            </div>
+        </>
+    ); 
+};

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -121,7 +121,7 @@ export const DeclarativeModalizerAPI = () => {
 
 };
 
-export const ModalizerAlwaysOnPage = () => {
+export const AlwaysOnPage = () => {
     const modalRef = React.useRef<HTMLDivElement>(null);
     const outsideRef = React.useRef<HTMLButtonElement>(null);
 
@@ -155,6 +155,46 @@ export const ModalizerAlwaysOnPage = () => {
                 <div tabIndex={0}>Focusable item</div>
                 <div tabIndex={0}>Focusable item</div>
                 <button onClick={focusOut}>Focus out</button>
+            </div>
+            <button ref={outsideRef}>Outside modal</button>
+        </div>
+    ); 
+};
+
+export const AllowFocusOutside = () => {
+    const modalRef = React.useRef<HTMLDivElement>(null);
+    const outsideRef = React.useRef<HTMLButtonElement>(null);
+
+    const focusIn = () => {
+        if (modalRef.current) {
+            modalRef.current.removeAttribute('aria-hidden');
+            const first = getCurrentTabster(window)?.focusable.findFirst(modalRef.current);
+            first?.focus();
+        }
+    };
+
+    const focusOut = () => {
+        if (modalRef.current && outsideRef.current) {
+            modalRef.current.setAttribute('aria-hidden', 'true');
+            outsideRef.current.focus();
+        }
+    };
+
+    return (
+        <div  { ...getTabsterAttribute({ deloser: {} })}>
+            <button onClick={focusIn}>Activate modalizer</button>
+            <div 
+                aria-hidden 
+                ref={modalRef} 
+                aria-label={'popup'} 
+                style={popupStyles} 
+                {...getTabsterAttribute({ modalizer: { id: 'modalizer', isOthersAccessible: true} })}
+            >
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <button onClick={focusOut}>Deactivate modalizer</button>
             </div>
             <button ref={outsideRef}>Outside modal</button>
         </div>

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -31,6 +31,7 @@ export const PopupContent = () => {
     const [open, setOpen ] = React.useState<boolean>(false);
     const popupRef = React.useRef<HTMLDivElement>();
 
+    // Use callback ref because it will run before DOM element is removed from the tree
     const callbackRef = React.useCallback((node: HTMLDivElement) => {
         const tabster = getCurrentTabster(window);
         const modalizer = tabster && getModalizer(tabster);
@@ -44,11 +45,11 @@ export const PopupContent = () => {
             modalizer.add(popupRef.current, {id: 'popup'});
             deloser.add(popupRef.current);
             modalizer.focus(popupRef.current);
-        } else {
-            popupRef.current &&  modalizer.remove(popupRef.current);
-            popupRef.current && deloser.remove(popupRef.current);
+        } else if (!node && popupRef.current) {
+            modalizer.remove(popupRef.current);
+            deloser.remove(popupRef.current);
         }
-    }, [popupRef])
+    }, [popupRef]);
 
     const onClick = () => setOpen(s => !s);
 

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -19,7 +19,7 @@ export const ModalDialog = () => {
     const onClick = () => ref.current?.show();
     return (
         <>
-            <div aria-label='Main' { ...getTabsterAttribute({ modalizer: { id: 'main' }, deloser: {} })}>
+            <div { ...getTabsterAttribute({ deloser: {} })}>
                 <button onClick={onClick}>Open modal</button>
             </div>
             <Modal ref={ref} />
@@ -62,19 +62,17 @@ export const PopupContent = () => {
 
     return (
         <>
-            <div aria-label='Main' { ...getTabsterAttribute({ modalizer: { id: 'main' }, deloser: {} })}>
+            <div  { ...getTabsterAttribute({ deloser: {} })}>
                 <button onClick={onClick}>Toggle popup</button>
             </div>
-            <div>
-                {open && <div aria-label={'popup'} ref={callbackRef} style={popupStyles}>
-                    <div tabIndex={0}>Focusable item</div>
-                    <div tabIndex={0}>Focusable item</div>
-                    <div tabIndex={0}>Focusable item</div>
-                    <div tabIndex={0}>Focusable item</div>
-                    <button onClick={onClick}>Dismiss</button>
-                </div>}
-            </div>
-            <div aria-label='Main' { ...getTabsterAttribute({ modalizer: { id: 'main' }, deloser: {} })}>
+            {open && <div aria-label={'popup'} ref={callbackRef} style={popupStyles}>
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <div tabIndex={0}>Focusable item</div>
+                <button onClick={onClick}>Dismiss</button>
+            </div>}
+            <div { ...getTabsterAttribute({ deloser: {} })}>
                 <button>Do not focus</button>
             </div>
         </>

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -6,7 +6,7 @@
 import { Meta } from '@storybook/react';
 import { Modal } from './components/Modal';
 import * as React from 'react';
-import { getCurrentTabster, getDeloser, getModalizer, getTabsterAttribute } from 'tabster';
+import { getCurrentTabster, getModalizer, getTabsterAttribute } from 'tabster';
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
@@ -36,55 +36,7 @@ const popupStyles = {
     marginBottom: 5
 }; 
 
-export const ImperativeModalizerAPI = () => {
-    const [open, setOpen ] = React.useState<boolean>(false);
-    const popupRef = React.useRef<HTMLDivElement>();
-
-    // Use callback ref because it will run before DOM element is removed from the tree
-    const callbackRef = React.useCallback((node: HTMLDivElement) => {
-        const tabster = getCurrentTabster(window);
-        const modalizer = tabster && getModalizer(tabster);
-        const deloser = tabster && getDeloser(tabster);
-        if (!modalizer || !deloser) {
-            return;
-        }
-
-        if (node) {
-            popupRef.current = node;
-            modalizer.add(popupRef.current, {id: 'popup'});
-            deloser.add(popupRef.current);
-            modalizer.focus(popupRef.current);
-        } else if (!node && popupRef.current) {
-            modalizer.remove(popupRef.current);
-            deloser.remove(popupRef.current);
-        }
-    }, [popupRef]);
-
-    const onClick = () => setOpen(s => !s);
-    return (
-        <div  { ...getTabsterAttribute({ deloser: {} })}>
-            <button onClick={onClick}>Toggle popup</button>
-            {open && (
-                <>
-                    <div 
-                        ref={callbackRef} 
-                        aria-label={'popup'} 
-                        style={popupStyles} 
-                    >
-                        <div tabIndex={0}>Focusable item</div>
-                        <div tabIndex={0}>Focusable item</div>
-                        <div tabIndex={0}>Focusable item</div>
-                        <div tabIndex={0}>Focusable item</div>
-                        <button onClick={onClick}>Dismiss</button>
-                    </div>
-                    <button>Outside Modalizer</button>
-                </>
-            )}
-        </div>
-    );
-};
-
-export const DeclarativeModalizerAPI = () => {
+export const NativeFocus = () => {
     const [open, setOpen ] = React.useState<boolean>(false);
     const popupRef = React.useRef<HTMLDivElement>(null);
     React.useEffect(() => {
@@ -119,6 +71,44 @@ export const DeclarativeModalizerAPI = () => {
         </div>
     );
 
+};
+
+export const ModalizerAPIFocus = () => {
+    const [open, setOpen ] = React.useState<boolean>(false);
+    const popupRef = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+        const tabster = getCurrentTabster(window);
+        const modalizer = tabster && getModalizer(tabster);
+        if (open && popupRef.current && modalizer) {
+            modalizer.focus(popupRef.current);
+        }
+
+    }, [open, popupRef]);
+
+    const onClick = () => setOpen(s => !s);
+    return (
+        <div  { ...getTabsterAttribute({ deloser: {} })}>
+            <button onClick={onClick}>Toggle popup</button>
+            {open && (
+                <>
+                    <div 
+                        ref={popupRef} 
+                        aria-label={'popup'} 
+                        style={popupStyles} 
+                        {...getTabsterAttribute({ deloser: {}, modalizer: { id: 'modalizer'} })}
+                    >
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <div tabIndex={0}>Focusable item</div>
+                        <button onClick={onClick}>Dismiss</button>
+                    </div>
+                    <button>Outside Modalizer</button>
+                </>
+            )}
+        </div>
+    );
 };
 
 export const AlwaysOnPage = () => {


### PR DESCRIPTION
Removes the concept of `accessible` for `Modalizer`

`Modalizer` will set `aria-hidden` on all non-Modalizer content on the document when active, and restore `aria-hidden` when no longer active.

Should result in most `Modalizer` references no longer needed for focusing/finding