### PR TITLE
Fix(Modalizer): Dispose inactive modalizers

### DIFF
--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -456,25 +456,26 @@ export class ModalizerAPI implements Types.ModalizerAPI {
      */
     private _onMutation = (e: MutationEvent) => {
         const details = e.details;
-        if (!details.modalizer?.isActive() || !details.removed) {
+        if (!details.modalizer || !details.removed) {
             return;
         }
 
-        // If an active modalizer is no longer on DOM, remove it
-        if (details.modalizer.isActive()) {
-            if (__DEV__) {
-                console.warn(`Modalizer: ${details.modalizer.userId}.
-                    calling ModalizerAPI.remove(element) before removing a modalizer from DOM can be safer.
-                `);
-            }
+        if (__DEV__) {
+            console.warn(`Modalizer: ${details.modalizer.userId}.
+                calling ModalizerAPI.remove(element) before removing a modalizer from DOM can be safer.
+            `);
+        }
 
-            delete this._modalizers[details.modalizer.userId];
-            if (this._curModalizer === details.modalizer) {
-                this._curModalizer = undefined;
-            }
+        // If an active modalizer is no longer on DOM, deactivate it
+        if (details.modalizer.isActive()) {
             details.modalizer.setFocused(false);
             details.modalizer.setActive(false);
-            details.modalizer.dispose();
+        }
+
+        details.modalizer.dispose();
+        delete this._modalizers[details.modalizer.userId];
+        if (this._curModalizer === details.modalizer) {
+            this._curModalizer = undefined;
         }
     }
 

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -487,7 +487,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     private _onFocus = (focusedElement: HTMLElement | undefined, details: Types.FocusedElementDetails): void => {
         const ctx = focusedElement && RootAPI.getTabsterContext(this._tabster, focusedElement);
         // Modalizer behaviour is opt in, only apply to elements that have a tabster context
-        if (!ctx) {
+        if (!ctx || !focusedElement) {
             return;
         }
 
@@ -504,7 +504,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         this._curModalizer?.setFocused(false);
 
         // Developers calling `element.focus()` should change/deactivate active modalizer 
-        if (details.isFocusedProgrammatically) {
+        if (details.isFocusedProgrammatically && !this._curModalizer?.contains(focusedElement)) {
             this._curModalizer?.setActive(false);
             this._curModalizer = undefined;
 
@@ -513,7 +513,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                 this._curModalizer.setActive(true);
                 this._curModalizer.setFocused(true);
             } 
-        } else if (focusedElement && this._curModalizer && !this._curModalizer.getBasicProps().isOthersAccessible) {
+        } else if (!this._curModalizer?.getBasicProps().isOthersAccessible) {
             // Focused outside of the active modalizer, try pull focus back to current modalizer
             this._restoreModalizerFocus(focusedElement);
         }

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -268,7 +268,7 @@ export const ModalizerStack = () => {
                 </>
             )}
 
-            <button onClick={() => { setOpen(false); setSecondOpen(false); setThirdOpen(false)}}>Close all</button>
+            <button onClick={() => { setOpen(false); setSecondOpen(false); setThirdOpen(false); }}>Close all</button>
         </div>
     );
-}
+};

--- a/examples/src/Modalizer.stories.tsx
+++ b/examples/src/Modalizer.stories.tsx
@@ -190,3 +190,85 @@ export const AllowFocusOutside = () => {
         </div>
     ); 
 };
+
+export const ModalizerStack = () => {
+    const [open, setOpen ] = React.useState<boolean>(false);
+    const [secondOpen, setSecondOpen ] = React.useState<boolean>(false);
+    const [thirdOpen, setThirdOpen] = React.useState<boolean>(false);
+    const popupRef = React.useRef<HTMLDivElement>(null);
+    const secondPopupRef = React.useRef<HTMLDivElement>(null);
+    const thirdPopupRef = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+        if (open && popupRef.current) {
+            const first = getCurrentTabster(window)?.focusable.findFirst(popupRef.current);
+            first?.focus();
+        }
+    }, [popupRef, open]);
+
+    React.useEffect(() => {
+        if (secondOpen && secondPopupRef.current) {
+            const first = getCurrentTabster(window)?.focusable.findFirst(secondPopupRef.current);
+            first?.focus();
+        }
+    }, [secondPopupRef, secondOpen]);
+
+    React.useEffect(() => {
+        if (thirdOpen && thirdPopupRef.current) {
+            const first = getCurrentTabster(window)?.focusable.findFirst(thirdPopupRef.current);
+            first?.focus();
+        }
+    }, [thirdPopupRef, thirdOpen]);
+
+    const onClick = () => setOpen(s => !s);
+
+    return (
+        <div  { ...getTabsterAttribute({ deloser: {} })}>
+            <button onClick={onClick}>Toggle popup</button>
+            {open && (
+                <>
+                    <div 
+                        ref={popupRef} 
+                        aria-label={'popup'} 
+                        style={popupStyles} 
+                        {...getTabsterAttribute({ deloser: {}, modalizer: { id: 'modalizer'} })}
+                    >
+                        <button onClick={() => setSecondOpen(true)}>Open next</button>
+                        <button onClick={() => setOpen(false)}>Dismiss</button>
+                    </div>
+                    <button>Outside Modalizer</button>
+                </>
+            )}
+
+            {secondOpen && (
+                <>
+                    <div 
+                        ref={secondPopupRef} 
+                        aria-label={'popup'} 
+                        style={popupStyles} 
+                        {...getTabsterAttribute({ deloser: {}, modalizer: { id: 'modalizer-2'} })}
+                    >
+                        <button onClick={() => setThirdOpen(true)}>Open next</button>
+                        <button onClick={() => setSecondOpen(false)}>Dismiss</button>
+                    </div>
+                    <button>Outside Modalizer</button>
+                </>
+            )}
+
+            {thirdOpen && (
+                <>
+                    <div 
+                        ref={thirdPopupRef} 
+                        aria-label={'popup'} 
+                        style={popupStyles} 
+                        {...getTabsterAttribute({ deloser: {}, modalizer: { id: 'modalizer-3'} })}
+                    >
+                        <button onClick={() => setThirdOpen(false)}>Dismiss</button>
+                    </div>
+                    <button>Outside Modalizer</button>
+                </>
+            )}
+
+            <button onClick={() => { setOpen(false); setSecondOpen(false); setThirdOpen(false)}}>Close all</button>
+        </div>
+    );
+}


### PR DESCRIPTION
Currently the mutation listener for `Modalizer` only disposes inactive
modalizers. This is a problem for 'stacks' of `Modalizers` (i.e. when
one modalizer opens another one)

When all modalizers in a stack are removed from DOM, some may already
inactive so doesn't get cleaned up.

This changes makes sure that any `Modalizer` removed from DOM will be
dsposed from the `ModalizerAPI`