### PR TITLE
Fix(autoRoot): auto root should have tabster attr

### DIFF
--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -90,6 +90,11 @@ export class Root implements Types.Root {
             delete this._dummyInputLast;
         }
 
+        const rootElement = this._element.get();
+        if (rootElement) {
+            setTabsterOnElement(this._tabster, rootElement, { root: undefined });
+        }
+
         this._forgetFocusedGrouppers = () => {/**/};
     }
 
@@ -353,9 +358,6 @@ export class RootAPI implements Types.RootAPI {
         }
 
         dispatchMutationEvent(element, { root, removed: true });
-
-        setTabsterOnElement(this._tabster, element, { root: undefined });
-
         root.dispose();
     }
 

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -73,6 +73,8 @@ export class Root implements Types.Root {
 
         this._add();
         this._addDummyInputs();
+
+        setTabsterOnElement(this._tabster, element, { root: this });
     }
 
     dispose(): void {
@@ -108,12 +110,6 @@ export class Root implements Types.Root {
 
     getBasicProps(): Types.RootBasicProps {
         return this._basic;
-    }
-
-    move(newElement: HTMLElement): void {
-        this._remove();
-        this._element = new WeakHTMLElement(this._win, newElement);
-        this._add();
     }
 
     getElement(): HTMLElement | undefined {
@@ -338,8 +334,6 @@ export class RootAPI implements Types.RootAPI {
 
         const root = new Root(element, this._tabster, this._win, this._forgetFocusedGrouppers, basic);
 
-        setTabsterOnElement(this._tabster, element, { root });
-
         const n: HTMLElement[] = [];
 
         for (let i: HTMLElement | null = element; i; i = i.parentElement) {
@@ -359,21 +353,6 @@ export class RootAPI implements Types.RootAPI {
 
         dispatchMutationEvent(element, { root, removed: true });
         root.dispose();
-    }
-
-    move(from: HTMLElement, to: HTMLElement): void {
-        const tabsterOnElementFrom = getTabsterOnElement(this._tabster, from);
-        const root = tabsterOnElementFrom && tabsterOnElementFrom.root;
-
-        if (root) {
-            root.move(to);
-
-            setTabsterOnElement(this._tabster, to, { root: root });
-            setTabsterOnElement(this._tabster, from, { root: undefined });
-
-            dispatchMutationEvent(from, { root, removed: true });
-            dispatchMutationEvent(to, { root });
-        }
     }
 
     setProps(element: HTMLElement, basic?: Partial<Types.RootBasicProps> | null): void {
@@ -481,8 +460,6 @@ export class RootAPI implements Types.RootAPI {
                         rootAPI._forgetFocusedGrouppers,
                         rootAPI._autoRoot
                     );
-
-                    setTabsterOnElement(rootAPI._tabster, body, { root: rootAPI._autoRootInstance });
                 }
             }
 

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -479,6 +479,8 @@ export class RootAPI implements Types.RootAPI {
                         rootAPI._forgetFocusedGrouppers,
                         rootAPI._autoRoot
                     );
+
+                    setTabsterOnElement(rootAPI._tabster, body, { root: rootAPI._autoRootInstance });
                 }
             }
 

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -479,7 +479,6 @@ export interface Root {
     dispose(): void;
     setProps(basic?: Partial<RootBasicProps> | null): void;
     getBasicProps(): RootBasicProps;
-    move(newElement: HTMLElement): void;
     getElement(): HTMLElement | undefined;
     updateDummyInputs(): void;
     moveOutWithDefaultAction(backwards: boolean): void;
@@ -508,7 +507,6 @@ export interface TabsterContext {
 export interface RootAPI {
     add(element: HTMLElement, basic?: RootBasicProps): void;
     remove(element: HTMLElement): void;
-    move(from: HTMLElement, to: HTMLElement): void;
     setProps(element: HTMLElement, basic?: Partial<RootBasicProps> | null): void;
 }
 


### PR DESCRIPTION
Currently `autoRoot` does not have tabster attributes applied to the DOM
element. This results in mutations not being dispatched to the `RootAPI`
because `getTabsterOnElement` is used on the mutation target before the
observer decides to dispatch the mutation event