### PR TITLE
fix(examples): Add prepare phase to examples

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -21,7 +21,6 @@ jobs:
 
             - run: npm install
             - run: npm run bootstrap
-            - run: lerna run --scope examples build
 
             - name: Deploy storybook
               uses: JamesIves/github-pages-deploy-action@4.1.1

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,7 +19,8 @@
     "build": "build-storybook --quiet",
     "clean": "rimraf storybook-static",
     "tslint": "tslint --project tsconfig.json --fix || true",
-    "tslint:check": "tslint --project tsconfig.json"
+    "tslint:check": "tslint --project tsconfig.json",
+    "prepare": "npm run build"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Since the tabster repo uses `prepare` during the `bootstrap` command to
build projects, make this consistent with the `examples` project