### PR TITLE
fix(Modalizer+Deloser): Check if already focused

### DIFF
--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -378,6 +378,11 @@ export class Deloser implements Types.Deloser {
         this._history = [];
     }
 
+    hasFocus() {
+        const deloserRoot = this._element.get();
+        return !!deloserRoot?.contains(deloserRoot.ownerDocument?.activeElement);
+    }
+
     isActive = (): boolean => {
         return this._isActive;
     }
@@ -603,7 +608,10 @@ export class DeloserAPI implements Types.DeloserAPI {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
     private _initTimer: number | undefined;
-    private _isInSomeDeloser = false;
+    /**
+     * Tracks if focus is inside a deloser
+     */
+    private _inDeloser = false;
     private _curDeloser: Types.Deloser | undefined;
     private _history: DeloserHistory;
     private _restoreFocusTimer: number | undefined;
@@ -682,9 +690,12 @@ export class DeloserAPI implements Types.DeloserAPI {
             return;
         }
 
-        setTabsterOnElement(this._tabster, element, {
-            deloser: new Deloser(element, this._tabster, this._win, basic, extended)
-        });
+        const deloser = new Deloser(element, this._tabster, this._win, basic, extended);
+        setTabsterOnElement(this._tabster, element, { deloser });
+
+        if (deloser.hasFocus()) {
+            this._activate(deloser);
+        }
     }
 
     remove(element: HTMLElement): void {
@@ -769,28 +780,32 @@ export class DeloserAPI implements Types.DeloserAPI {
         const deloser = this._history.process(e);
 
         if (deloser) {
-            this._isInSomeDeloser = true;
-
-            if (deloser !== this._curDeloser) {
-                if (this._curDeloser) {
-                    this._curDeloser.setActive(false);
-                }
-
-                this._curDeloser = deloser;
-            }
-
-            deloser.setActive(true);
+            this._activate(deloser);
         } else {
-            this._isInSomeDeloser = false;
-
-            this._curDeloser = undefined;
+            this._deactivate();
         }
     }
 
-    private _isLastFocusedAvailable(): boolean {
-        const last = this._tabster.focusedElement.getLastFocusedElement();
+    /**
+     * Activates and sets the current deloser
+     */
+    private _activate(deloser: Types.Deloser) {
+        const curDeloser = this._curDeloser;
+        if (curDeloser !== deloser) {
+            this._inDeloser = true;
+            curDeloser?.setActive(false);
+            deloser.setActive(true);
+            this._curDeloser = deloser;
+        }
+    }
 
-        return !!(last && last.offsetParent);
+    /**
+     * Called when focus should no longer be in a deloser
+     */
+    private _deactivate() {
+        this._inDeloser = false;
+        this._curDeloser?.setActive(false);
+        this._curDeloser = undefined;
     }
 
     private _scheduleRestoreFocus(force?: boolean): void {
@@ -798,33 +813,28 @@ export class DeloserAPI implements Types.DeloserAPI {
             return;
         }
 
-        const reallySchedule = async () => {
+        const restoreFocus = async () => {
             this._restoreFocusTimer = undefined;
+            const lastFocused = this._tabster.focusedElement.getLastFocusedElement();
 
-            if (!force && (this._isRestoringFocus || !this._isInSomeDeloser || this._isLastFocusedAvailable())) {
+            if (!force && (this._isRestoringFocus || !this._inDeloser || !!lastFocused?.offsetParent)) {
                 return;
             }
 
-            if (this._curDeloser) {
-                const last = this._tabster.focusedElement.getLastFocusedElement();
-
-                if (last && this._curDeloser.customFocusLostHandler(last)) {
+            const curDeloser = this._curDeloser;
+            if (curDeloser) {
+                if (lastFocused && curDeloser.customFocusLostHandler(lastFocused)) {
                     return;
                 }
 
-                const el = this._curDeloser.findAvailable();
+                const el = curDeloser.findAvailable();
 
                 if (el && this._tabster.focusedElement.focus(el)) {
                     return;
                 }
             }
 
-            this._isInSomeDeloser = false;
-
-            if (this._curDeloser) {
-                this._curDeloser.setActive(false);
-                this._curDeloser = undefined;
-            }
+            this._deactivate();
 
             this._isRestoringFocus = true;
 
@@ -836,9 +846,9 @@ export class DeloserAPI implements Types.DeloserAPI {
         };
 
         if (force) {
-            reallySchedule();
+            restoreFocus();
         } else {
-            this._restoreFocusTimer = this._win().setTimeout(reallySchedule, 100);
+            this._restoreFocusTimer = this._win().setTimeout(restoreFocus, 100);
         }
     }
 

--- a/core/src/Deloser.ts
+++ b/core/src/Deloser.ts
@@ -378,11 +378,6 @@ export class Deloser implements Types.Deloser {
         this._history = [];
     }
 
-    hasFocus() {
-        const deloserRoot = this._element.get();
-        return !!deloserRoot?.contains(deloserRoot.ownerDocument?.activeElement);
-    }
-
     isActive = (): boolean => {
         return this._isActive;
     }
@@ -693,7 +688,7 @@ export class DeloserAPI implements Types.DeloserAPI {
         const deloser = new Deloser(element, this._tabster, this._win, basic, extended);
         setTabsterOnElement(this._tabster, element, { deloser });
 
-        if (deloser.hasFocus()) {
+        if (element.contains(this._tabster.focusedElement.getFocusedElement() ?? null)) {
             this._activate(deloser);
         }
     }

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -138,15 +138,6 @@ export class Modalizer implements Types.Modalizer {
         this.setActive(!this._isActive);
     }
 
-    hasFocus(): boolean {
-        const modalizerRoot = this._modalizerRoot.get();
-        if (!modalizerRoot) {
-            return false;
-        }
-
-        return modalizerRoot.contains(modalizerRoot.ownerDocument.activeElement);
-    }
-
     setActive(active: boolean): void {
         if (active === this._isActive) {
             return;
@@ -358,7 +349,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         this._modalizers[basic.id] = modalizer;
 
         // Adding a modalizer which is already focused, activate it
-        if (modalizer.hasFocus()) {
+        if (element.contains(this._tabster.focusedElement.getFocusedElement() ?? null)) {
             const prevModalizer = this._curModalizer;
             if (prevModalizer) {
                 prevModalizer.setActive(false);

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -207,6 +207,10 @@ export interface Deloser {
     getBasicProps(): DeloserBasicProps;
     move(newContainer: HTMLElement): void;
     dispose(): void;
+    /**
+     * @returns Whether focus is inside the deloser
+     */
+    hasFocus(): boolean;
     isActive(): boolean;
     setActive(active: boolean): void;
     getActions(): DeloserElementActions;

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -468,6 +468,10 @@ export interface Modalizer {
     getModalizerRoot(): HTMLElement | undefined;
     getExtendedProps(): ModalizerExtendedProps;
     isActive(): boolean;
+    /**
+     * @returns Whether focus is inside the modalizer
+     */
+    hasFocus(): boolean;
     move(newElement: HTMLElement): void;
     onBeforeFocusOut(): boolean;
     /**

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -207,10 +207,6 @@ export interface Deloser {
     getBasicProps(): DeloserBasicProps;
     move(newContainer: HTMLElement): void;
     dispose(): void;
-    /**
-     * @returns Whether focus is inside the deloser
-     */
-    hasFocus(): boolean;
     isActive(): boolean;
     setActive(active: boolean): void;
     getActions(): DeloserElementActions;
@@ -472,10 +468,6 @@ export interface Modalizer {
     getModalizerRoot(): HTMLElement | undefined;
     getExtendedProps(): ModalizerExtendedProps;
     isActive(): boolean;
-    /**
-     * @returns Whether focus is inside the modalizer
-     */
-    hasFocus(): boolean;
     move(newElement: HTMLElement): void;
     onBeforeFocusOut(): boolean;
     /**

--- a/core/src/__tests__/Deloser.test.tsx
+++ b/core/src/__tests__/Deloser.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import * as BroTest from '../../testing/BroTest';
-import { getTabsterAttribute } from '../Tabster';
+import { getTabsterAttribute, Types } from '../Tabster';
 
 describe('Deloser', () => {
     beforeAll(async () => {
@@ -13,22 +13,109 @@ describe('Deloser', () => {
 
     it('should restore focus', async () => {
         await new BroTest.BroTest(
-            <div {...getTabsterAttribute({ root: {}, deloser: {} })}>
-                <button>Button1</button>
-                <button>Button2</button>
-                <button>Button3</button>
-                <button>Button4</button>
-            </div>
+            (
+                <div {...getTabsterAttribute({ root: {}, deloser: {} })}>
+                    <button>Button1</button>
+                    <button>Button2</button>
+                    <button>Button3</button>
+                    <button>Button4</button>
+                </div>
+            )
         )
-        .pressTab()
-        .pressTab()
-        .activeElement(el => {
-            expect(el?.textContent).toBe('Button2');
-        })
-        .removeElement()
-        .wait(300)
-        .activeElement(el => {
-            expect(el?.textContent).toBe('Button3');
-        });
+            .pressTab()
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toBe('Button2');
+            })
+            .removeElement()
+            .wait(300)
+            .activeElement(el => {
+                expect(el?.textContent).toBe('Button3');
+            });
+    });
+
+    it('should not restore focus if focus is not inside the deloser', async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div {...getTabsterAttribute({ deloser: {} })}>
+                        <button>Button1</button>
+                    </div>
+                    <button>Button2</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toBe('Button2');
+            })
+            .removeElement()
+            .wait(300)
+            .activeElement(el => {
+                expect(el?.textContent).toBeUndefined();
+            });
+    });
+
+    it('should not restore focus by deloser history', async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button {...getTabsterAttribute({ deloser: {} })}>
+                        Button1
+                    </button>
+                    <button {...getTabsterAttribute({ deloser: {} })}>
+                        Button2
+                    </button>
+                </div>
+            )
+        )
+            .pressTab()
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toBe('Button2');
+            })
+            .removeElement()
+            .wait(300)
+            .activeElement(el => {
+                expect(el?.textContent).toBe('Button1');
+            });
+    });
+
+    it('should be activated immediately if focus is inside', async () => {
+        const tabsterAttr = getTabsterAttribute(
+            {
+                deloser: {}
+            },
+            true
+        ) as string;
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button {...getTabsterAttribute({ deloser: {} })}>
+                        Button1
+                    </button>
+                    <button id='newDeloser'>Button2</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toBe('Button2');
+            })
+            .eval(
+                (attrName, tabsterAttr) => {
+                    const newDeloser = document.getElementById('newDeloser');
+                    newDeloser?.setAttribute(attrName, tabsterAttr);
+                },
+                Types.TabsterAttributeName,
+                tabsterAttr
+            )
+            .removeElement('#newDeloser')
+            .wait(300)
+            .activeElement(el => {
+                expect(el?.textContent).toBe('Button1');
+            });
     });
 });


### PR DESCRIPTION
Currently `ModalizerAPI.add` and `DeloserAPI.add` do not check if the new instances are already
focused.

This leads to a bugs if as new instance that is added already has focus.
This can be caused by React's virtual DOM rendering which can't
guarantee the order of mutation event and focus event. 

Added `hasFocus` to `Modalizer` and `Deloser` instances to check if the instance has a focused element inside. Call this method from the `add` APIs to see if the instances should be activated after being created.

Also Added tests to prevent regression. Below are examples for bugs that can occur for `Modalizer` and `Deloser`

Here is an example for the Modalizer:

* focus DOM element
* add tabster modalizer attributes to DOM element
* `ModalizerAPI._onFocus` triggers first and can't find a modalizer on the element ->
does nothing
* `Instance` adds the modalizer
* Focus is on the modalizer, but it is not active and not other content
on the page is hidden

Here is an example for the Deloser:

* add tabster deloser attributes to DOM element
* focus DOM element
* `DeloserAPI._onFocus` triggers first and can't find a deloser on the element ->
`isInDeloser` state is not active
* `Instance` adds the deloser to the DOM element
* Remove the Deloser element from DOM
* Schedule focus does not work as intended