### PR TITLE
fix(Focusable): Use default Tab behaviour for iframes

### DIFF
--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -1273,7 +1273,12 @@ export class FocusableAPI implements Types.FocusableAPI {
         if (!ctx) {
             return NodeFilter.FILTER_SKIP;
         }
-        
+
+        // We assume iframes are focusable because native tab behaviour would tab inside
+        if (element.tagName === 'IFRAME') {
+            return NodeFilter.FILTER_ACCEPT;
+        }
+
         if (!this.isAccessible(element)) {
             return NodeFilter.FILTER_REJECT;
         }

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -413,9 +413,11 @@ export class FocusedElementState
             }
 
             if (next) {
-                e.preventDefault();
-
-                nativeFocus(next);
+                // For iframes just allow normal Tab behaviour
+                if (next.tagName !== 'IFRAME') {
+                    e.preventDefault();
+                    nativeFocus(next);
+                }
             } else if (ctx) {
                 ctx.root.moveOutWithDefaultAction(isPrev);
             }
@@ -520,11 +522,9 @@ export class FocusedElementState
                     next = this._tabster.focusable.findFirst(next, false, true);
                 }
 
-                if (next) {
+                if (next && next.tagName !== 'IFRAME') {
                     this._tabster.focusable.setCurrentGroupper(next);
-
                     KeyboardNavigationState.setVal(this._tabster.keyboardNavigation, true);
-
                     nativeFocus(next);
                 }
             }

--- a/core/src/__tests__/iframeFocus.test.tsx
+++ b/core/src/__tests__/iframeFocus.test.tsx
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as BroTest from '../../testing/BroTest';
+import { getTabsterAttribute } from '../Tabster';
+
+describe('<iframe />', () => {
+    beforeAll(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it('should focus in an out with Tab', async () => {
+        await new BroTest.BroTest(
+            <div {...getTabsterAttribute({ root: {}, deloser: {} })}>
+                <button>Button1</button>
+                <iframe src='/iframe.html' />
+                <button>Button2</button>
+            </div>
+        )
+        .pressTab()
+        .activeElement(el => {
+            expect(el?.textContent).toContain('Button1');
+        })
+        .pressTab()
+        .activeElement(el => {
+            expect(el?.tag).toBe('iframe');
+        })
+        .pressTab()
+        .activeElement(el => {
+            expect(el?.textContent).toContain('Button2');
+        });
+    });
+});

--- a/test-container/package.json
+++ b/test-container/package.json
@@ -19,6 +19,7 @@
     "tabster": "^0.7.1"
   },
   "devDependencies": {
+    "copy-webpack-plugin": "^9.0.0",
     "html-webpack-plugin": "^5.3.1",
     "rimraf": "^3.0.2",
     "source-map-loader": "^3.0.0",

--- a/test-container/public/iframe.html
+++ b/test-container/public/iframe.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <button>iframe button</button>
+    </body>
+</html>

--- a/test-container/webpack.config.js
+++ b/test-container/webpack.config.js
@@ -1,47 +1,52 @@
-const webpack = require('webpack');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const path = require('path');
-const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
+const webpack = require("webpack");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const CopyPlugin = require("copy-webpack-plugin");
+const path = require("path");
+const { TsconfigPathsPlugin } = require("tsconfig-paths-webpack-plugin");
 
 module.exports = {
-    mode: 'development',
+    mode: "development",
 
-    entry: path.resolve(__dirname, 'src/index.ts'),
+    entry: path.resolve(__dirname, "src/index.ts"),
 
     output: {
-        filename: 'bundle.js',
-        path: path.resolve(__dirname, "dist")
+        filename: "bundle.js",
+        path: path.resolve(__dirname, "dist"),
     },
 
-    devtool: 'source-map',
+    devtool: "source-map",
 
     devServer: {
         port: 8080,
-        contentBase: path.join(__dirname, 'dist'),
+        contentBase: path.join(__dirname, "dist"),
+        writeToDisk: true,
     },
 
     resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.json'],
-        plugins: [
-            new TsconfigPathsPlugin(),
-        ]
+        extensions: [".ts", ".tsx", ".js", ".json"],
+        plugins: [new TsconfigPathsPlugin()],
     },
     stats: {
-        errorDetails:true
+        errorDetails: true,
     },
 
     module: {
         rules: [
             // TODO replace with babel loader, this project really doesn't need to care about types
-            { test: /\.ts?$/, loader: 'ts-loader' },
-            { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' }
-        ]
+            { test: /\.ts?$/, loader: "ts-loader" },
+            { enforce: "pre", test: /\.js$/, loader: "source-map-loader" },
+        ],
     },
 
     plugins: [
         new webpack.DefinePlugin({
-            '__DEV__': true
+            __DEV__: true,
         }),
-        new HtmlWebpackPlugin({ title: 'Tabster Test' }),
+        new HtmlWebpackPlugin({ title: "Tabster Test" }),
+        new CopyPlugin({
+            patterns: [
+                { from: "public" },
+            ],
+        }),
     ],
 };


### PR DESCRIPTION
Since iframes cannot be interacted with by the parent document, this PR:
* Returns iframes as a focusable element in the tree walk
* Allows normal tab behaviour in `_onKeyDown` in `FocusedElement`

This change will impact `find*` methods in `Focusable` but this should
be mitigated eventually be #39 by allowing accept conditions in all of
those methods.

Since `Tabster` can't really know and can't handle tabs inside an
iframe, considering iframes as focusable elements should be a feature.