### PR TITLE
fix(Core): Various small fixes

### DIFF
--- a/core/src/Focusable.ts
+++ b/core/src/Focusable.ts
@@ -1074,7 +1074,7 @@ export class FocusableAPI implements Types.FocusableAPI {
     }
 
     private _isDisabled(el: HTMLElement): boolean {
-        return this._attrIs(el, 'aria-disabled', 'true');
+        return this._attrIs(el, 'disabled', 'true');
     }
 
     private _isHidden(el: HTMLElement): boolean {

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -155,6 +155,7 @@ export class Root implements Types.Root {
 
         input.tabIndex = 0;
         input.setAttribute('role', 'none');
+        input.setAttribute(Types.TabsterDummyInputAttributeName, '');
         input.setAttribute('aria-hidden', 'true');
 
         const style = input.style;

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -241,7 +241,7 @@ export class FocusedElementState
     private _onKeyDown = (e: KeyboardEvent): void => {
         let curElement = this.getVal();
 
-        if (!curElement || !curElement.ownerDocument) {
+        if (!curElement || !curElement.ownerDocument || curElement.contentEditable === 'true') {
             return;
         }
 

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -4,6 +4,7 @@
  */
 
 export const TabsterAttributeName = 'data-tabster';
+export const TabsterDummyInputAttributeName = 'data-tabster-dummy';
 
 export interface InternalBasics {
     Promise?: PromiseConstructor;

--- a/core/src/__tests__/Focusable.test.tsx
+++ b/core/src/__tests__/Focusable.test.tsx
@@ -1,0 +1,42 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as BroTest from '../../testing/BroTest';
+import { getTabsterAttribute } from '../Tabster';
+
+describe('Focusable', () => {
+    beforeAll(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it('should allow aria-disabled elements to be focused', async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button aria-disabled='true'>Button1</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toContain('Button1');
+            });
+    });
+
+    it('should not allow aria-hidden elements to be focused', async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button aria-hidden='true'>Button1</button>
+                    <button>Button2</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toContain('Button2');
+            });
+    });
+});

--- a/core/src/__tests__/FocusedElement.test.tsx
+++ b/core/src/__tests__/FocusedElement.test.tsx
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as BroTest from '../../testing/BroTest';
+import { getTabsterAttribute } from '../Tabster';
+
+describe('onKeyDown', () => {
+    beforeAll(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it('should not do anything on element with contenteditable=\'true\'', async () => {
+        // Lots of things can happen on keydown
+        // Tabster never focuses aria-hidden so if we can focus in there it is safely ignored
+        const testHtml = (
+            <div id='root' {...getTabsterAttribute({ root: {} })}>
+                <div tabIndex={0} contentEditable='true'>
+                    <button aria-hidden>Button1</button>
+                    <button aria-hidden>Button2</button>
+                </div>
+                <button>Don't focus</button>
+            </div>
+        );
+
+        await new BroTest.BroTest(testHtml)
+            .pressTab()
+            .activeElement(el =>
+                expect(el?.attributes.contenteditable).toEqual('true')
+            )
+            .pressTab()
+            .activeElement(el =>
+                expect(el?.attributes['aria-hidden']).toEqual('true')
+            );
+    });
+});

--- a/core/src/__tests__/Root.test.tsx
+++ b/core/src/__tests__/Root.test.tsx
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as BroTest from '../../testing/BroTest';
+import { getTabsterAttribute, Types as TabsterTypes } from '../Tabster';
+
+describe('Root', () => {
+    beforeAll(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it('should insert dummy inputs as first and last children', async () => {
+        await new BroTest.BroTest(
+            (
+                <div id='root' {...getTabsterAttribute({ root: {} })}>
+                    <button>Button</button>
+                </div>
+            )
+        )
+            .eval((dummyAttribute) => {
+                return document.querySelectorAll(`[${dummyAttribute}]`).length;
+            }, TabsterTypes.TabsterDummyInputAttributeName)
+            .check((dummyCount: number) => {
+                expect(dummyCount).toBe(2);
+            })
+            .eval((dummyAttribute) => {
+                const first = document.getElementById('root')?.children[0].hasAttribute(dummyAttribute);
+                const second = document.getElementById('root')?.children[2].hasAttribute(dummyAttribute);
+                return first && second;
+            }, TabsterTypes.TabsterDummyInputAttributeName)
+            .check((areFirstAndLast: boolean) => {
+                expect(areFirstAndLast).toBe(true);
+            });
+    });
+});

--- a/core/testing/BroTest.ts
+++ b/core/testing/BroTest.ts
@@ -10,8 +10,17 @@ function buildAttributesString(attributes: {[name: string]: string}): string {
         className: 'class'
     };
 
-    return Object.keys(attributes).map(name =>
-        `${ nameOverrides[name] || name }="${ attributes[name].replace(/"/g, '&quot;') }"`).join(' ');
+    return Object.keys(attributes).map(name => {
+        if (typeof attributes[name] === 'string') {
+            return`${ nameOverrides[name] || name }="${ attributes[name].replace(/"/g, '&quot;') }"`;
+        } else if (typeof attributes[name] === 'number') {
+            return`${ nameOverrides[name] || name }="${attributes[name]}"`;
+        } else if (typeof attributes[name] === 'boolean') {
+            return`${ nameOverrides[name] || name }="${attributes[name] ? 'true' : 'false'}"`;
+        }
+
+        throw new Error(`unknown attribute: ${name}`);
+    }).join(' ');
 }
 
 export function createElementString(tagName: string, attributes: {[name: string]: string} | null, ...children: any[]): string {


### PR DESCRIPTION
* check for `disabled` attribute instead of `aria-disabled`
* do not handle keydown for `contextEditable = 'true'` areas
* Add a custom `data-tabster-dummy` for dummy inputs in tabster