### PR TITLE
fix(requestFocus): Should focus tabindex=-1

### DIFF
--- a/core/src/CrossOrigin.ts
+++ b/core/src/CrossOrigin.ts
@@ -1312,14 +1312,19 @@ export class CrossOriginObservedElementState
         }, timeout).then(value => value ? StateTransaction.createElement(this._tabster, value) : null);
     }
 
-    async requestFocus(observedName: string, timeout: number): Promise<boolean> {
+    async requestFocus(
+        observedName: string,
+        timeout: number,
+        accessibility: Types.ObservedElementAccesibility = Types.ObservedElementAccesibilities.Focusable,
+    ): Promise<boolean> {
         let requestId = ++this._lastRequestFocusId;
         return this.waitElement(
             observedName,
             timeout,
-            Types.ObservedElementAccesibilities.Focusable
+            accessibility,
         ).then(element => ((this._lastRequestFocusId === requestId) && element)
-            ? (this._tabster as unknown as Types.TabsterInternal).crossOrigin!!!.focusedElement.focus(element)
+            // ignore focusedElement checks since cross origin has its own
+            ? (this._tabster as unknown as Types.TabsterInternal).crossOrigin!!!.focusedElement.focus(element, true, true)
             : false
         );
     }

--- a/core/src/CrossOrigin.ts
+++ b/core/src/CrossOrigin.ts
@@ -1312,19 +1312,14 @@ export class CrossOriginObservedElementState
         }, timeout).then(value => value ? StateTransaction.createElement(this._tabster, value) : null);
     }
 
-    async requestFocus(
-        observedName: string,
-        timeout: number,
-        accessibility: Types.ObservedElementAccesibility = Types.ObservedElementAccesibilities.Focusable,
-    ): Promise<boolean> {
+    async requestFocus(observedName: string, timeout: number): Promise<boolean> {
         let requestId = ++this._lastRequestFocusId;
         return this.waitElement(
             observedName,
             timeout,
-            accessibility,
+            Types.ObservedElementAccesibilities.Focusable
         ).then(element => ((this._lastRequestFocusId === requestId) && element)
-            // ignore focusedElement checks since cross origin has its own
-            ? (this._tabster as unknown as Types.TabsterInternal).crossOrigin!!!.focusedElement.focus(element, true, true)
+            ? (this._tabster as unknown as Types.TabsterInternal).crossOrigin!!!.focusedElement.focus(element, true)
             : false
         );
     }

--- a/core/src/State/ObservedElement.ts
+++ b/core/src/State/ObservedElement.ts
@@ -166,11 +166,13 @@ export class ObservedElementAPI
         if (o) {
             for (let uid of Object.keys(o)) {
                 let el = o[uid].element.get() || null;
-
                 if (el) {
                     if (
-                        ((accessibility === Types.ObservedElementAccesibilities.Accessible) && !this._tabster.focusable.isAccessible(el)) ||
-                        ((accessibility === Types.ObservedElementAccesibilities.Focusable) && !this._tabster.focusable.isFocusable(el))
+                        (accessibility === Types.ObservedElementAccesibilities.Accessible &&
+                        !this._tabster.focusable.isAccessible(el)) ||
+
+                        (accessibility === Types.ObservedElementAccesibilities.Focusable &&
+                        !this._tabster.focusable.isFocusable(el, true))
                     ) {
                         el = null;
                     }
@@ -242,19 +244,14 @@ export class ObservedElementAPI
         return promise;
     }
 
-    async requestFocus(
-        observedName: string,
-        timeout: number,
-        accessibility: Types.ObservedElementAccesibility = Types.ObservedElementAccesibilities.Focusable,
-    ): Promise<boolean> {
+    async requestFocus(observedName: string, timeout: number): Promise<boolean> {
         let requestId = ++this._lastRequestFocusId;
         return this.waitElement(
             observedName,
             timeout,
-            accessibility,
+            Types.ObservedElementAccesibilities.Focusable
         ).then(element => ((this._lastRequestFocusId === requestId) && element)
-            // ignore focusedElement checks since observedElement has its own
-            ? this._tabster.focusedElement.focus(element, true, true)
+            ? this._tabster.focusedElement.focus(element, true)
             : false
         );
     }

--- a/core/src/State/ObservedElement.ts
+++ b/core/src/State/ObservedElement.ts
@@ -242,14 +242,19 @@ export class ObservedElementAPI
         return promise;
     }
 
-    async requestFocus(observedName: string, timeout: number): Promise<boolean> {
+    async requestFocus(
+        observedName: string,
+        timeout: number,
+        accessibility: Types.ObservedElementAccesibility = Types.ObservedElementAccesibilities.Focusable,
+    ): Promise<boolean> {
         let requestId = ++this._lastRequestFocusId;
         return this.waitElement(
             observedName,
             timeout,
-            Types.ObservedElementAccesibilities.Focusable
+            accessibility,
         ).then(element => ((this._lastRequestFocusId === requestId) && element)
-            ? this._tabster.focusedElement.focus(element)
+            // ignore focusedElement checks since observedElement has its own
+            ? this._tabster.focusedElement.focus(element, true, true)
             : false
         );
     }

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -81,7 +81,7 @@ export interface ObservedElementAPI extends Subscribable<HTMLElement, ObservedEl
     setProps(element: HTMLElement, basic?: Partial<ObservedElementBasicProps>, extended?: Partial<ObservedElementExtendedProps>): void;
     getElement(observedName: string, accessibility?: ObservedElementAccesibility): HTMLElement | null;
     waitElement(observedName: string, timeout: number, accessibility?: ObservedElementAccesibility): Promise<HTMLElement | null>;
-    requestFocus(observedName: string, timeout: number): Promise<boolean>;
+    requestFocus(observedName: string, timeout: number, accessibility?: ObservedElementAccesibility): Promise<boolean>;
 }
 
 export interface CrossOriginElement {

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -81,7 +81,7 @@ export interface ObservedElementAPI extends Subscribable<HTMLElement, ObservedEl
     setProps(element: HTMLElement, basic?: Partial<ObservedElementBasicProps>, extended?: Partial<ObservedElementExtendedProps>): void;
     getElement(observedName: string, accessibility?: ObservedElementAccesibility): HTMLElement | null;
     waitElement(observedName: string, timeout: number, accessibility?: ObservedElementAccesibility): Promise<HTMLElement | null>;
-    requestFocus(observedName: string, timeout: number, accessibility?: ObservedElementAccesibility): Promise<boolean>;
+    requestFocus(observedName: string, timeout: number): Promise<boolean>;
 }
 
 export interface CrossOriginElement {

--- a/core/src/__tests__/ObservedElement.test.tsx
+++ b/core/src/__tests__/ObservedElement.test.tsx
@@ -13,7 +13,7 @@ describe('Focusable', () => {
         await BroTest.bootstrapTabsterPage();
     });
 
-    it('should not request focus tabindex -1 by default', async () => {
+    it('should request focus for element with tabindex -1', async () => {
         const name = 'test';
         await new BroTest.BroTest(
             (
@@ -32,45 +32,13 @@ describe('Focusable', () => {
             .activeElement(el => {
                 expect(el?.textContent).toContain('Button1');
             })
-            .eval(name => {
-                return (window as unknown as WindowWithTabsterInternal).__tabsterInstance?.observedElement?.requestFocus(
-                    name,
-                    0
-                );
-            }, name)
-            .check((res: boolean) => expect(res).toBe(false))
-            .activeElement(el => {
-                expect(el?.textContent).toContain('Button1');
-            });
-    });
-
-    it('should request focus for any element', async () => {
-        const name = 'test';
-        await new BroTest.BroTest(
-            (
-                <div {...getTabsterAttribute({ root: {} })}>
-                    <button>Button1</button>
-                    <button
-                        {...getTabsterAttribute({ observed: { name } })}
-                        tabIndex={-1}
-                    >
-                        Button2
-                    </button>
-                </div>
-            )
-        )
-            .pressTab()
-            .activeElement(el => {
-                expect(el?.textContent).toContain('Button1');
-            })
-            .eval((name, accessibility) => {
+            .eval((name) => {
                 // @ts-ignore
                 return (window as unknwon as WindowWithTabsterInternal).__tabsterInstance.observedElement.requestFocus(
                     name,
                     0,
-                    accessibility
                 );
-            }, name, Types.ObservedElementAccesibilities.Any)
+            }, name)
             .check((res: boolean) => expect(res).toBe(true))
             .activeElement(el => {
                 expect(el?.textContent).toContain('Button2');

--- a/core/src/__tests__/ObservedElement.test.tsx
+++ b/core/src/__tests__/ObservedElement.test.tsx
@@ -1,0 +1,79 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as BroTest from '../../testing/BroTest';
+import { getTabsterAttribute, Types } from '../Tabster';
+
+interface WindowWithTabsterInternal extends Window { __tabsterInstance: Types.TabsterInternal; }
+
+describe('Focusable', () => {
+    beforeAll(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it('should not request focus tabindex -1 by default', async () => {
+        const name = 'test';
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button>Button1</button>
+                    <button
+                        {...getTabsterAttribute({ observed: { name } })}
+                        tabIndex={-1}
+                    >
+                        Button2
+                    </button>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toContain('Button1');
+            })
+            .eval(name => {
+                return (window as unknown as WindowWithTabsterInternal).__tabsterInstance?.observedElement?.requestFocus(
+                    name,
+                    0
+                );
+            }, name)
+            .check((res: boolean) => expect(res).toBe(false))
+            .activeElement(el => {
+                expect(el?.textContent).toContain('Button1');
+            });
+    });
+
+    it('should request focus for any element', async () => {
+        const name = 'test';
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button>Button1</button>
+                    <button
+                        {...getTabsterAttribute({ observed: { name } })}
+                        tabIndex={-1}
+                    >
+                        Button2
+                    </button>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toContain('Button1');
+            })
+            .eval((name, accessibility) => {
+                // @ts-ignore
+                return (window as unknwon as WindowWithTabsterInternal).__tabsterInstance.observedElement.requestFocus(
+                    name,
+                    0,
+                    accessibility
+                );
+            }, name, Types.ObservedElementAccesibilities.Any)
+            .check((res: boolean) => expect(res).toBe(true))
+            .activeElement(el => {
+                expect(el?.textContent).toContain('Button2');
+            });
+    });
+});

--- a/test-container/src/index.ts
+++ b/test-container/src/index.ts
@@ -1,4 +1,4 @@
-import { getModalizer, createTabster, getDeloser, getOutline } from 'tabster';
+import { getModalizer, createTabster, getDeloser, getOutline, getObservedElement } from 'tabster';
 
 const tabster = createTabster(window);
 console.log('created tabster');
@@ -9,6 +9,8 @@ getDeloser(tabster)
 console.log('created deloser')
 getOutline(tabster)
 console.log('created outline')
+getObservedElement(tabster)
+console.log('created observed');
 
 // @ts-ignore
 console.log('initialized tabster', window.__tabsterInstance);


### PR DESCRIPTION
Previously `requestFocus` did not allow focus for programmatically focusable elements even though it is a programmatic focus since it is called in code