### PR TITLE
fix(ObservedElement): allow programmatically focusable on update

### DIFF
--- a/core/src/State/ObservedElement.ts
+++ b/core/src/State/ObservedElement.ts
@@ -359,7 +359,7 @@ export class ObservedElementAPI
 
             if (waitingFocusableElement && !waitingFocusableElement.conditionTimer) {
                 const resolveFocusable = () => {
-                    if (documentContains(val.ownerDocument, val) && this._tabster.focusable.isFocusable(val)) {
+                    if (documentContains(val.ownerDocument, val) && this._tabster.focusable.isFocusable(val, true)) {
                         resolve(waitingFocusableElementKey, waitingFocusableElement);
                     } else {
                         waitingFocusableElement.conditionTimer = win.setTimeout(resolveFocusable, _conditionCheckTimeout);

--- a/core/src/__tests__/ObservedElement.test.tsx
+++ b/core/src/__tests__/ObservedElement.test.tsx
@@ -6,7 +6,9 @@
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute, Types } from '../Tabster';
 
-interface WindowWithTabsterInternal extends Window { __tabsterInstance: Types.TabsterInternal; }
+interface WindowWithTabsterInternal extends Window {
+    __tabsterInstance: Types.TabsterInternal;
+}
 
 describe('Focusable', () => {
     beforeAll(async () => {
@@ -32,16 +34,42 @@ describe('Focusable', () => {
             .activeElement(el => {
                 expect(el?.textContent).toContain('Button1');
             })
-            .eval((name) => {
-                // @ts-ignore
-                return (window as unknwon as WindowWithTabsterInternal).__tabsterInstance.observedElement.requestFocus(
+            .eval(name => {
+                return ((window as unknown) as WindowWithTabsterInternal).__tabsterInstance.observedElement?.requestFocus(
                     name,
-                    0,
+                    0
                 );
             }, name)
             .check((res: boolean) => expect(res).toBe(true))
             .activeElement(el => {
                 expect(el?.textContent).toContain('Button2');
+            });
+    });
+
+    it('should request focus for non-existent element with tabindex -1', async () => {
+        const name = 'test';
+        await new BroTest.BroTest(
+            (<div id='root' {...getTabsterAttribute({ root: {} })}></div>)
+        )
+            .eval(name => {
+                const request = ((window as unknown) as WindowWithTabsterInternal).__tabsterInstance.observedElement?.requestFocus(
+                    name,
+                    5000
+                );
+
+                const observedButton = document.createElement('button');
+                observedButton.textContent = name;
+                document.getElementById('root')?.appendChild(observedButton);
+                ((window as unknown) as WindowWithTabsterInternal).__tabsterInstance.observedElement?.add(
+                    observedButton,
+                    { name }
+                );
+
+                return request;
+            }, name)
+            .check((res: boolean) => expect(res).toBe(true))
+            .activeElement(el => {
+                expect(el?.textContent).toContain(name);
             });
     });
 });


### PR DESCRIPTION
focusable elements (i.e. tabindex -1)

However, the previous PR missed the extra check in `_trigger` which is
called on observed element udpate. This means that when requesting focus
for an element that does not exist and with tabindex -1 will always fail