### PR TITLE
fix(Modalizer): Restore focus asynchronously

### DIFF
--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -519,11 +519,12 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                 this._curModalizer.setFocused(true);
             }
         } else if (!this._curModalizer?.getBasicProps().isOthersAccessible) {
-            // this._restoreModalizerFocus(focusedElement);
-            const win = this._win();
             // Focused outside of the active modalizer, try pull focus back to current modalizer
+            const win = this._win();
             win.clearTimeout(this._restoreModalizerFocusTimer);
-            this._restoreModalizerFocusTimer = win.setTimeout(() => this._restoreModalizerFocus(focusedElement), 0);
+            // TODO some rendering frameworks (i.e. React) might async rerender the DOM so we need to wait for a duration
+            // Figure out a better way of doing this rather than a 100ms timeout
+            this._restoreModalizerFocusTimer = win.setTimeout(() => this._restoreModalizerFocus(focusedElement), 100);
         }
     }
 

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -280,6 +280,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
      */
     private _curModalizer: Types.Modalizer | undefined;
     private _focusOutTimer: number | undefined;
+    private _restoreModalizerFocusTimer: number | undefined;
     /**
      * Modalizers managed by this API, stored by id
      */
@@ -307,10 +308,8 @@ export class ModalizerAPI implements Types.ModalizerAPI {
             this._initTimer = undefined;
         }
 
-        if (this._focusOutTimer) {
-            win.clearTimeout(this._focusOutTimer);
-            this._focusOutTimer = undefined;
-        }
+        win.clearTimeout(this._restoreModalizerFocusTimer);
+        win.clearTimeout(this._focusOutTimer);
 
         // Dispose all modalizers managed by the API
         Object.keys(this._modalizers).forEach(modalizerId => {
@@ -520,8 +519,11 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                 this._curModalizer.setFocused(true);
             }
         } else if (!this._curModalizer?.getBasicProps().isOthersAccessible) {
+            // this._restoreModalizerFocus(focusedElement);
+            const win = this._win();
             // Focused outside of the active modalizer, try pull focus back to current modalizer
-            this._restoreModalizerFocus(focusedElement);
+            win.clearTimeout(this._restoreModalizerFocusTimer);
+            this._restoreModalizerFocusTimer = win.setTimeout(() => this._restoreModalizerFocus(focusedElement), 0);
         }
     }
 

--- a/core/src/__tests__/Modalizer.test.tsx
+++ b/core/src/__tests__/Modalizer.test.tsx
@@ -102,6 +102,7 @@ describe('Modalizer', () => {
                 .focusElement('#foo')
                 .activeElement(el => expect(el?.textContent).toBe('Foo'))
                 .click('#outside')
+                .wait(100)
                 .activeElement(el => expect(el?.textContent).toBe('Foo'));
         });
 

--- a/core/src/__tests__/Modalizer.test.tsx
+++ b/core/src/__tests__/Modalizer.test.tsx
@@ -96,6 +96,30 @@ describe('Modalizer', () => {
             .activeElement(el => expect(el?.textContent).toBe('Foo'));
     });
 
+    describe('should restore focus', () => {
+        it('after clicking on outside focusable', async () => {
+            await new BroTest.BroTest(getTestHtml())
+                .focusElement('#foo')
+                .activeElement(el => expect(el?.textContent).toBe('Foo'))
+                .click('#outside')
+                .activeElement(el => expect(el?.textContent).toBe('Foo'));
+        });
+
+        it('asynchronously after user mutates DOM', async () => {
+            await new BroTest.BroTest(getTestHtml())
+                .focusElement('#foo')
+                .activeElement(el => expect(el?.textContent).toBe('Foo'))
+                .eval(() => {
+                    // Simulates user clicking outside a modal dialog to close it
+                    document.addEventListener('click', () => {
+                        document.getElementById('modal')?.remove();
+                    });
+                })
+                .click('#outside')
+                .activeElement(el => expect(el?.textContent).toBe('Outside'));
+        });
+    });
+
     describe('Others content accessible', () => {
         it('should allow focus outside of modalizer', async () => {
             await new BroTest.BroTest(getTestHtml({ isOthersAccessible: true }))


### PR DESCRIPTION
If a user removes a modalizer from the document before restore focus
happens a race condition can occur where focus is lost because there is
no modalizer to restore focus to.

By restoring focus async, we can wait until the user has finished DOM
mutations before attempting to restore focus, and check if an active
modalizer still exists