### PR TITLE
feat: Only control Tab key within APIs

### DIFF
--- a/core/jest-puppeteer.config.js
+++ b/core/jest-puppeteer.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     launch: {
-        headless: true,
+        headless: false,
         devtools: true,
     }
 }

--- a/core/src/Groupper.ts
+++ b/core/src/Groupper.ts
@@ -3,14 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { nativeFocus } from 'keyborg';
-
 import { FocusedElementState } from './State/FocusedElement';
 import { getTabsterOnElement } from './Instance';
+import { nativeFocus } from 'keyborg';
 import { Keys } from './Keys';
 import { RootAPI } from './Root';
 import * as Types from './Types';
-import { TabsterPart, DummyInput } from './Utils';
+import { DummyInput, TabsterPart } from './Utils';
 
 interface DummyInputProps {
     shouldMoveOut?: boolean;

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -6,7 +6,7 @@
 import { augmentAttribute } from './Instance';
 import { RootAPI } from './Root';
 import * as Types from './Types';
-import { createElementTreeWalker, TabsterPart, WeakHTMLElement, DummyInput } from './Utils';
+import { createElementTreeWalker, DummyInput, TabsterPart, WeakHTMLElement } from './Utils';
 
 let _lastInternalId = 0;
 
@@ -80,8 +80,8 @@ export class Modalizer extends TabsterPart<Types.ModalizerBasicProps, Types.Moda
         this._setAccessibilityProps();
 
         const getWin = tabster.getWindow;
-        this.preDummy = new DummyInput(getWin, false, this._onFocusDummyInput, () => {}, {});
-        this.postDummy = new DummyInput(getWin, false, this._onFocusDummyInput, () => {}, {});
+        this.preDummy = new DummyInput(getWin, false, this._onFocusDummyInput, () => undefined, {});
+        this.postDummy = new DummyInput(getWin, false, this._onFocusDummyInput, () => undefined, {});
         this._addDummyInputs();
 
         if (__DEV__) {
@@ -98,7 +98,7 @@ export class Modalizer extends TabsterPart<Types.ModalizerBasicProps, Types.Moda
 
     private _onFocusDummyInput = (input: HTMLDivElement) => {
         const container = this._element.get();
-        if(this.isActive()) {
+        if (this.isActive()) {
             // Focus trap is active
             if (input === this.postDummy.input) {
                 this._tabster.focusedElement.focusFirst({ container });

--- a/core/src/Mover.ts
+++ b/core/src/Mover.ts
@@ -11,6 +11,7 @@ import { Keys } from './Keys';
 import { RootAPI } from './Root';
 import * as Types from './Types';
 import {
+    DummyInput,
     getElementUId,
     isElementVerticallyVisibleInContainer,
     isElementVisibleInContainer,
@@ -18,7 +19,6 @@ import {
     scrollIntoView,
     TabsterPart,
     WeakHTMLElement,
-    DummyInput,
 } from './Utils';
 
 const _inputSelector = [

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -3,12 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { nativeFocus } from 'keyborg';
-
 import { getTabsterOnElement } from './Instance';
-import { KeyboardNavigationState } from './State/KeyboardNavigation';
 import * as Types from './Types';
-import { DummyInput, getElementUId, TabsterPart, WeakHTMLElement } from './Utils';
+import { getElementUId, TabsterPart, WeakHTMLElement } from './Utils';
 
 export interface WindowWithTabsterInstance extends Window {
     __tabsterInstance?: Types.TabsterCore;
@@ -28,115 +25,23 @@ function _setInformativeStyle(weakElement: WeakHTMLElement, remove: boolean, id?
     }
 }
 
-interface DummyInputProps {
-    isFirst: boolean;
-    shouldMoveOut?: boolean;
-    isActive: boolean;
-}
-
 export class Root extends TabsterPart<Types.RootBasicProps, undefined> implements Types.Root {
     readonly uid: string;
-
-    private _dummyInputFirst: DummyInput<DummyInputProps> | undefined;
-    private _dummyInputLast: DummyInput<DummyInputProps> | undefined;
-    private _forgetFocusedGrouppers: () => void;
 
     constructor(
         tabster: Types.TabsterInternal,
         element: HTMLElement,
-        forgetFocusedGrouppers: () => void,
         basic?: Types.RootBasicProps
     ) {
         super(tabster, element, basic);
-
         const win = tabster.getWindow;
         this.uid = getElementUId(win, element);
-        this._forgetFocusedGrouppers = forgetFocusedGrouppers;
-
-        this._dummyInputFirst = new DummyInput(
-            win,
-            false,
-            this._onDummyInputFocus,
-            this._onDummyInputBlur,
-            { isFirst: true, isActive: true }
-        );
-
-        this._dummyInputLast = new DummyInput(
-            win,
-            false,
-            this._onDummyInputFocus,
-            this._onDummyInputBlur,
-            { isFirst: false, isActive: true }
-        );
 
         this._add();
-        this._addDummyInputs();
-
-        tabster.focusedElement.subscribe(this._onFocus);
     }
 
     dispose(): void {
-        this._tabster.focusedElement.unsubscribe(this._onFocus);
-
         this._remove();
-
-        const dif = this._dummyInputFirst;
-        if (dif) {
-            dif.dispose();
-            delete this._dummyInputFirst;
-        }
-
-        const dil = this._dummyInputLast;
-        if (dil) {
-            dil.dispose();
-            delete this._dummyInputLast;
-        }
-
-        this._forgetFocusedGrouppers = () => {/**/};
-    }
-
-    updateDummyInputs(): void {
-        this._addDummyInputs();
-    }
-
-    moveOutWithDefaultAction(backwards: boolean): void {
-        const first = this._dummyInputFirst;
-        const last = this._dummyInputLast;
-
-        if (first?.input && last?.input) {
-            if (backwards) {
-                first.props.shouldMoveOut = true;
-                nativeFocus(first.input);
-            } else {
-                last.props.shouldMoveOut = true;
-                nativeFocus(last.input);
-            }
-        }
-    }
-
-    private _onFocus = (e: HTMLElement | undefined) => {
-        if (e) {
-            const ctx = RootAPI.getTabsterContext(this._tabster, e);
-
-            if (!ctx || ctx.uncontrolled) {
-                this._setDummyInputsActive(false);
-                return;
-            }
-        }
-
-        this._setDummyInputsActive(true);
-    }
-
-    private _setDummyInputsActive(isActive: boolean) {
-        for (let dummy of [this._dummyInputFirst, this._dummyInputLast]) {
-            if (dummy && (dummy.props.isActive !== isActive) && dummy.input) {
-                // If the uncontrolled element is first/last in the application, focusing the
-                // dummy input will not let the focus to go outside of the application.
-                // So, we're making dummy inputs not tabbable if the uncontrolled element has focus.
-                dummy.input.tabIndex = isActive ? 0 : -1;
-                dummy.props.isActive = isActive;
-            }
-        }
     }
 
     private _add(): void {
@@ -146,75 +51,8 @@ export class Root extends TabsterPart<Types.RootBasicProps, undefined> implement
     }
 
     private _remove(): void {
-        this._removeDummyInputs();
-
         if (__DEV__) {
             _setInformativeStyle(this._element, true);
-        }
-    }
-
-    private _onDummyInputFocus = (input: HTMLDivElement, props: DummyInputProps): void => {
-        if (props.shouldMoveOut) {
-            // When we've reached the last focusable element, we want to let the browser
-            // to move the focus outside of the page. In order to do that we're synchronously
-            // calling focus() of the dummy input from the Tab key handler and allowing
-            // the default action to move the focus out.
-        } else {
-            // The only way a dummy input gets focused is during the keyboard navigation.
-            KeyboardNavigationState.setVal(this._tabster.keyboardNavigation, true);
-
-            this._forgetFocusedGrouppers();
-
-            const element = this._element.get();
-
-            if (element) {
-                let hasFocused = props.isFirst
-                    ? this._tabster.focusedElement.focusFirst({ container: element })
-                    : this._tabster.focusedElement.focusLast({ container: element });
-
-                if (hasFocused) {
-                    return;
-                }
-            }
-
-            input.blur();
-        }
-    }
-
-    private _onDummyInputBlur = (input: HTMLDivElement, props: DummyInputProps): void => {
-        props.shouldMoveOut = false;
-    }
-
-    private _addDummyInputs(): void {
-        const element = this._element.get();
-        const dif = this._dummyInputFirst?.input;
-        const dil = this._dummyInputLast?.input;
-
-        if (!element || !dif || !dil) {
-            return;
-        }
-
-        if (element.lastElementChild !== dil) {
-            element.appendChild(dil);
-        }
-
-        const firstElementChild = element.firstElementChild;
-
-        if (firstElementChild && (firstElementChild !== dif)) {
-            element.insertBefore(dif, firstElementChild);
-        }
-    }
-
-    private _removeDummyInputs(): void {
-        const dif = this._dummyInputFirst?.input;
-        const dil = this._dummyInputLast?.input;
-
-        if (dif?.parentElement) {
-            dif.parentElement.removeChild(dif);
-        }
-
-        if (dil?.parentElement) {
-            dil.parentElement.removeChild(dil);
         }
     }
 }
@@ -223,15 +61,13 @@ export class RootAPI implements Types.RootAPI {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
     private _initTimer: number | undefined;
-    private _forgetFocusedGrouppers: () => void;
     private _autoRoot: Types.RootBasicProps | undefined;
     private _autoRootInstance: Root | undefined;
     rootById: { [id: string]: Types.Root } = {};
 
-    constructor(tabster: Types.TabsterCore, forgetFocusedGrouppers: () => void, autoRoot?: Types.RootBasicProps) {
+    constructor(tabster: Types.TabsterCore, autoRoot?: Types.RootBasicProps) {
         this._tabster = tabster;
         this._win = (tabster as Types.TabsterInternal).getWindow;
-        this._forgetFocusedGrouppers = forgetFocusedGrouppers;
         this._initTimer = this._win().setTimeout(this._init, 0);
         this._autoRoot = autoRoot;
     }
@@ -254,8 +90,6 @@ export class RootAPI implements Types.RootAPI {
             this._initTimer = undefined;
         }
 
-        this._forgetFocusedGrouppers = () => {/**/};
-
         this.rootById = {};
     }
 
@@ -268,7 +102,7 @@ export class RootAPI implements Types.RootAPI {
         element: HTMLElement,
         basic?: Types.RootBasicProps
     ): Types.Root => {
-        return new Root(tabster, element, (tabster.root as RootAPI)._forgetFocusedGrouppers, basic) as Types.Root;
+        return new Root(tabster, element, basic) as Types.Root;
     }
 
     static getRootByUId(getWindow: Types.GetWindow, id: string): Types.Root | undefined {
@@ -375,7 +209,6 @@ export class RootAPI implements Types.RootAPI {
                     rootAPI._autoRootInstance = new Root(
                         rootAPI._tabster as Types.TabsterInternal,
                         body,
-                        rootAPI._forgetFocusedGrouppers,
                         rootAPI._autoRoot
                     );
                 }

--- a/core/src/Tabster.ts
+++ b/core/src/Tabster.ts
@@ -89,9 +89,7 @@ class Tabster implements Types.TabsterCore, Types.TabsterInternal {
         this.keyboardNavigation = new KeyboardNavigationState(getWindow);
         this.focusedElement = new FocusedElementState(this, getWindow);
         this.focusable = new FocusableAPI(this, getWindow);
-        this.root = new RootAPI(this, () => {
-            (this.groupper as Types.GroupperInternalAPI | undefined)?.forgetUnlimitedGrouppers();
-        }, props?.autoRoot);
+        this.root = new RootAPI(this, props?.autoRoot);
         this.createRoot = RootAPI.createRoot;
         this.updateRoot = (root: Types.Root, removed?: boolean) => {
             RootAPI.onRoot(this.root, root, removed);

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -451,6 +451,7 @@ export interface Mover extends TabsterPart<MoverBasicProps, MoverExtendedProps> 
     forceUpdate(): void;
     findNextTabbable(current: HTMLElement, prev?: boolean): NextTabbable | null;
     acceptElement(element: HTMLElement, state: FocusableAcceptElementState): number | undefined;
+    moveOutWithDefaultAction(backwards: boolean): void;
 }
 
 export type MoverConstructor = (
@@ -490,6 +491,7 @@ export interface Groupper extends TabsterPart<GroupperBasicProps, GroupperExtend
     isActive(): boolean | undefined; // Tri-state boolean, undefined when parent is not active, false when parent is active.
     findNextTabbable(current: HTMLElement, prev?: boolean): NextTabbable | null;
     acceptElement(element: HTMLElement, state: FocusableAcceptElementState): number | undefined;
+    moveOutWithDefaultAction(backwards: boolean): void;
 }
 
 export type GroupperConstructor = (
@@ -554,8 +556,9 @@ export interface RootBasicProps {
 export interface Root extends TabsterPart<RootBasicProps, undefined> {
     readonly uid: string;
     dispose(): void;
-    updateDummyInputs(): void;
-    moveOutWithDefaultAction(backwards: boolean): void;
+    setProps(basic?: Partial<RootBasicProps> | null): void;
+    getBasicProps(): RootBasicProps;
+    getElement(): HTMLElement | undefined;
 }
 
 export type RootConstructor = (

--- a/core/src/Utils.ts
+++ b/core/src/Utils.ts
@@ -574,7 +574,7 @@ export interface DummyInputProps {
 
 export type DummyInputFocusCallback<P> = (input: HTMLDivElement, props: P) => void;
 
-export class DummyInput<P> {
+export class DummyInput<P = {}> {
     private _onFocusIn: DummyInputFocusCallback<P> | undefined;
     private _onFocusOut: DummyInputFocusCallback<P> | undefined;
     private _isPhantom: boolean;

--- a/core/src/__tests__/Focusable.test.tsx
+++ b/core/src/__tests__/Focusable.test.tsx
@@ -25,7 +25,7 @@ describe('Focusable', () => {
             });
     });
 
-    it('should not allow aria-hidden elements to be focused', async () => {
+    it('should allow aria-hidden elements to be focused', async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -36,7 +36,7 @@ describe('Focusable', () => {
         )
             .pressTab()
             .activeElement(el => {
-                expect(el?.textContent).toContain('Button2');
+                expect(el?.textContent).toContain('Button1');
             });
     });
 });

--- a/core/src/__tests__/Modalizer.test.tsx
+++ b/core/src/__tests__/Modalizer.test.tsx
@@ -78,6 +78,7 @@ describe('Modalizer', () => {
             );
     });
 
+    // TODO focus trap no longer escapes the document
     it('should trap focus', async () => {
         await new BroTest.BroTest(getTestHtml())
             .focusElement('#foo')
@@ -85,15 +86,9 @@ describe('Modalizer', () => {
             .pressTab()
             .activeElement(el => expect(el?.textContent).toBe('Bar'))
             .pressTab()
-            .activeElement(el => expect(el).toBeNull())
-            .pressTab(true)
-            .activeElement(el => expect(el?.textContent).toBe('Bar'))
-            .pressTab(true)
             .activeElement(el => expect(el?.textContent).toBe('Foo'))
             .pressTab(true)
-            .activeElement(el => expect(el).toBeNull())
-            .pressTab()
-            .activeElement(el => expect(el?.textContent).toBe('Foo'));
+            .activeElement(el => expect(el?.textContent).toBe('Bar'))
     });
 
     describe('should restore focus', () => {

--- a/core/src/__tests__/Modalizer.test.tsx
+++ b/core/src/__tests__/Modalizer.test.tsx
@@ -88,7 +88,7 @@ describe('Modalizer', () => {
             .pressTab()
             .activeElement(el => expect(el?.textContent).toBe('Foo'))
             .pressTab(true)
-            .activeElement(el => expect(el?.textContent).toBe('Bar'))
+            .activeElement(el => expect(el?.textContent).toBe('Bar'));
     });
 
     describe('should restore focus', () => {

--- a/core/src/__tests__/Root.test.tsx
+++ b/core/src/__tests__/Root.test.tsx
@@ -4,35 +4,11 @@
  */
 
 import * as BroTest from '../../testing/BroTest';
-import { getTabsterAttribute, Types as TabsterTypes } from '../Tabster';
+import { getTabsterAttribute} from '../Tabster';
 
 describe('Root', () => {
     beforeAll(async () => {
         await BroTest.bootstrapTabsterPage();
-    });
-
-    it('should insert dummy inputs as first and last children', async () => {
-        await new BroTest.BroTest(
-            (
-                <div id='root' {...getTabsterAttribute({ root: {} })}>
-                    <button>Button</button>
-                </div>
-            )
-        )
-            .eval((dummyAttribute) => {
-                return document.querySelectorAll(`[${dummyAttribute}]`).length;
-            }, TabsterTypes.TabsterDummyInputAttributeName)
-            .check((dummyCount: number) => {
-                expect(dummyCount).toBe(2);
-            })
-            .eval((dummyAttribute) => {
-                const first = document.getElementById('root')?.children[0].hasAttribute(dummyAttribute);
-                const second = document.getElementById('root')?.children[2].hasAttribute(dummyAttribute);
-                return first && second;
-            }, TabsterTypes.TabsterDummyInputAttributeName)
-            .check((areFirstAndLast: boolean) => {
-                expect(areFirstAndLast).toBe(true);
-            });
     });
 
     it('should allow to go outside of the application when tabbing forward', async () => {

--- a/core/src/__tests__/Uncontrolled.test.tsx
+++ b/core/src/__tests__/Uncontrolled.test.tsx
@@ -68,19 +68,22 @@ describe('Uncontrolled', () => {
             });
     });
 
-    it('should allow to go outside of the application when tabbing and the uncontrolled element is the last', async () => {
+    it.only('should allow to go outside of the application when tabbing and the uncontrolled element is the last', async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
-                    <button aria-hidden='true'>Button1</button>
-                    <button>Button2</button>
+                    <button>Button1</button>
                     <div {...getTabsterAttribute({ uncontrolled: {} })}>
-                        <button aria-hidden='true'>Button3</button>
-                        <button>Button4</button>
+                        <button aria-hidden='true'>Button2</button>
+                        <button>Button3</button>
                     </div>
                 </div>
             )
         )
+            .pressTab()
+            .activeElement(el => {
+                expect(el?.textContent).toContain('Button1');
+            })
             .pressTab()
             .activeElement(el => {
                 expect(el?.textContent).toContain('Button2');
@@ -88,10 +91,6 @@ describe('Uncontrolled', () => {
             .pressTab()
             .activeElement(el => {
                 expect(el?.textContent).toContain('Button3');
-            })
-            .pressTab()
-            .activeElement(el => {
-                expect(el?.textContent).toContain('Button4');
             })
             .pressTab()
             .activeElement(el => {

--- a/core/testing/BroTest.ts
+++ b/core/testing/BroTest.ts
@@ -177,6 +177,9 @@ export class BroTest implements PromiseLike<undefined> {
         }, 0) as any;
     }
 
+    /**
+     * @param time - in milliseconds
+     */
     wait(time: number) {
         this._chain.push(new BroTestItemWait(time));
         return this;


### PR DESCRIPTION
This PR removes the global tab controlling, so that tabster will only
control the `Tab` key within:
* Groupper
* Mover
* Modalizer