### PR TITLE
chore(Mover): MoverAPI now handles `updateVisible`

### DIFF
--- a/core/src/Mover.ts
+++ b/core/src/Mover.ts
@@ -477,10 +477,6 @@ export class MoverAPI implements Types.MoverAPI {
             validateMoverProps(props);
         }
 
-        if (!tabster.mover) {
-            throw new Error('Mover needs to be created with getMover before being used');
-        }
-
         const self = tabster.mover as MoverAPI;
         const newMover = new Mover(tabster, element, self._onMoverDispose, props);
         self._movers[newMover.id] = newMover;


### PR DESCRIPTION
Fixes #62

Removes the static `Mover._movers` collection to be owned by the
`MoverAPI`. This means that `updateVisible` needs to be done in the
`MoverAPI`