### PR TITLE
implement code path with dummy inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            - name: Use Node.js 10
+            - name: Use Node.js 14
               uses: actions/setup-node@v1
               with:
-                  node-version: 10.x
+                  node-version: 14.x
 
             - run: npm install
             - run: npm run bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,9 @@ jobs:
               run: |
                 npm run serve &
                 npm run test
+            - name: "Run tests (uncontrolled)"
+              run: |
+                npm run serve &
+                npm run test
+              env:
+                UNCONTROLLED: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,12 @@ jobs:
               run: |
                 npm run serve &
                 npm run test
+              env:
+                PORT: 3000
             - name: "Run tests (uncontrolled)"
               run: |
                 npm run serve &
                 npm run test
               env:
                 UNCONTROLLED: true
+                PORT: 4000

--- a/core/jest.config.json
+++ b/core/jest.config.json
@@ -2,5 +2,6 @@
     "preset": "jest-puppeteer",
     "testEnvironment": "jest-environment-puppeteer",
     "transform": { "^.+\\.(ts|tsx|js|jsx)?$": "ts-jest" },
+    "testPathIgnorePatterns": ["test-utils"],
     "rootDir": "src"
 }

--- a/core/src/Groupper.ts
+++ b/core/src/Groupper.ts
@@ -37,7 +37,7 @@ class GroupperDummyManager extends DummyInputManager {
 export class Groupper extends TabsterPart<Types.GroupperProps> implements Types.Groupper {
     private _shouldTabInside = false;
     private _first: WeakHTMLElement | undefined;
-    public _dummyManager?: GroupperDummyManager;
+    _dummyManager?: GroupperDummyManager;
 
     constructor(
         tabster: Types.TabsterInternal,

--- a/core/src/Groupper.ts
+++ b/core/src/Groupper.ts
@@ -10,11 +10,39 @@ import { getTabsterOnElement } from './Instance';
 import { Keys } from './Keys';
 import { RootAPI } from './Root';
 import * as Types from './Types';
-import { getLastChild, TabsterPart, WeakHTMLElement } from './Utils';
+import { DummyInput, DummyInputManager, getLastChild, TabsterPart, WeakHTMLElement } from './Utils';
+
+class GroupperDummyManager extends DummyInputManager {
+    private _tabster: Types.TabsterCore;
+
+    constructor(element: WeakHTMLElement, tabster: Types.TabsterCore) {
+        super(tabster, element);
+        this._tabster = tabster;
+        this.firstDummy.onFocusIn = this._onFocusDummyInput;
+        this.lastDummy.onFocusIn = this._onFocusDummyInput;
+    }
+
+    dispose(): void {
+        this.firstDummy.dispose();
+        this.lastDummy.dispose();
+    }
+
+    private _onFocusDummyInput = (dummyInput: DummyInput) => {
+        const container = this._element.get();
+        if (container && !dummyInput.shouldMoveOut) {
+            if (dummyInput.isFirst) {
+                this._tabster.focusedElement.focusFirst({ container });
+            } else {
+                this._tabster.focusedElement.focusLast({ container });
+            }
+        }
+    }
+}
 
 export class Groupper extends TabsterPart<Types.GroupperProps> implements Types.Groupper {
     private _shouldTabInside = false;
     private _first: WeakHTMLElement | undefined;
+    public _dummyManager: GroupperDummyManager;
 
     constructor(
         tabster: Types.TabsterInternal,
@@ -23,6 +51,8 @@ export class Groupper extends TabsterPart<Types.GroupperProps> implements Types.
     ) {
         super(tabster, element, props);
         this.makeTabbable(false);
+
+        this._dummyManager = new GroupperDummyManager(this._element, tabster);
     }
 
     dispose(): void {
@@ -322,16 +352,18 @@ export class GroupperAPI implements Types.GroupperAPI, Types.GroupperInternalAPI
     }
 
     private _onKeyDown = (e: KeyboardEvent): void => {
-        if ((e.keyCode !== Keys.Enter) && (e.keyCode !== Keys.Esc)) {
+        if ((e.keyCode !== Keys.Enter) && (e.keyCode !== Keys.Esc) && (e.keyCode !== Keys.Tab)) {
             return;
         }
 
+        let isPrev = e.shiftKey;
         const element = this._tabster.focusedElement.getFocusedElement();
 
         if (element) {
-            let groupper = RootAPI.getTabsterContext(this._tabster, element)?.groupper;
+            let ctx = RootAPI.getTabsterContext(this._tabster, element);
+            let groupper = ctx?.groupper;
 
-            if (groupper) {
+            if (ctx && groupper) {
                 let next: HTMLElement | null | undefined;
 
                 if ((e.keyCode === Keys.Enter)) {
@@ -360,12 +392,16 @@ export class GroupperAPI implements Types.GroupperAPI, Types.GroupperInternalAPI
                             }
                         }
                     }
+                } else if (e.keyCode === Keys.Tab) {
+                    next = FocusedElementState.findNextTabbable(this._tabster, ctx, element, isPrev)?.element;
                 }
 
                 if (next) {
                     e.preventDefault();
 
                     nativeFocus(next);
+                } else {
+                    (groupper as Groupper)._dummyManager.moveOutWithDefaultAction(isPrev);
                 }
             }
         }

--- a/core/src/Groupper.ts
+++ b/core/src/Groupper.ts
@@ -22,11 +22,6 @@ class GroupperDummyManager extends DummyInputManager {
         this.lastDummy.onFocusIn = this._onFocusDummyInput;
     }
 
-    dispose(): void {
-        this.firstDummy.dispose();
-        this.lastDummy.dispose();
-    }
-
     private _onFocusDummyInput = (dummyInput: DummyInput) => {
         const container = this._element.get();
         if (container && !dummyInput.shouldMoveOut) {
@@ -42,7 +37,7 @@ class GroupperDummyManager extends DummyInputManager {
 export class Groupper extends TabsterPart<Types.GroupperProps> implements Types.Groupper {
     private _shouldTabInside = false;
     private _first: WeakHTMLElement | undefined;
-    public _dummyManager: GroupperDummyManager;
+    public _dummyManager?: GroupperDummyManager;
 
     constructor(
         tabster: Types.TabsterInternal,
@@ -52,11 +47,14 @@ export class Groupper extends TabsterPart<Types.GroupperProps> implements Types.
         super(tabster, element, props);
         this.makeTabbable(false);
 
-        this._dummyManager = new GroupperDummyManager(this._element, tabster);
+        if (!tabster.controlTab) {
+            this._dummyManager = new GroupperDummyManager(this._element, tabster);
+        }
     }
 
     dispose(): void {
         const element = this._element.get();
+        this._dummyManager?.dispose();
 
         if (element) {
             if (__DEV__) {
@@ -392,7 +390,7 @@ export class GroupperAPI implements Types.GroupperAPI, Types.GroupperInternalAPI
                             }
                         }
                     }
-                } else if (e.keyCode === Keys.Tab) {
+                } else if (e.keyCode === Keys.Tab && !this._tabster.controlTab) {
                     next = FocusedElementState.findNextTabbable(this._tabster, ctx, element, isPrev)?.element;
                 }
 
@@ -401,7 +399,7 @@ export class GroupperAPI implements Types.GroupperAPI, Types.GroupperInternalAPI
 
                     nativeFocus(next);
                 } else {
-                    (groupper as Groupper)._dummyManager.moveOutWithDefaultAction(isPrev);
+                    (groupper as Groupper)._dummyManager?.moveOutWithDefaultAction(isPrev);
                 }
             }
         }

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -285,7 +285,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     private _initTimer: number | undefined;
     private _dummyManager?: ModalizerAPIDummyManager;
     /** The currently active modalizer */
-    public activeModalizer: Types.Modalizer | undefined;
+    activeModalizer: Types.Modalizer | undefined;
     private _focusOutTimer: number | undefined;
     private _restoreModalizerFocusTimer: number | undefined;
     /**

--- a/core/src/Modalizer.ts
+++ b/core/src/Modalizer.ts
@@ -283,7 +283,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
     private _initTimer: number | undefined;
-    private _dummyManager: ModalizerAPIDummyManager;
+    private _dummyManager?: ModalizerAPIDummyManager;
     /** The currently active modalizer */
     public activeModalizer: Types.Modalizer | undefined;
     private _focusOutTimer: number | undefined;
@@ -299,7 +299,9 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         this._initTimer = this._win().setTimeout(this._init, 0);
         this._modalizers = {};
         const documentBody = this._win().document.body;
-        this._dummyManager = new ModalizerAPIDummyManager(this, tabster, new WeakHTMLElement(this._win, documentBody));
+        if (!tabster.controlTab) {
+            this._dummyManager = new ModalizerAPIDummyManager(this, tabster, new WeakHTMLElement(this._win, documentBody));
+        }
     }
 
     private _init = (): void => {
@@ -310,7 +312,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
 
     protected dispose(): void {
         const win = this._win();
-        this._dummyManager.dispose();
+        this._dummyManager?.dispose();
 
         if (this._initTimer) {
             win.clearTimeout(this._initTimer);
@@ -350,8 +352,8 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         const modalizer = new Modalizer(
             tabster, element,
             self._onModalizerDispose,
-            self._dummyManager.moveOutWithDefaultAction,
-            self._dummyManager.setTabbable,
+            self._dummyManager?.moveOutWithDefaultAction ?? (() => null),
+            self._dummyManager?.setTabbable ?? (() => null),
             props,
         );
 

--- a/core/src/Mover.ts
+++ b/core/src/Mover.ts
@@ -3,14 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { nativeFocus } from 'keyborg';
-
 import { FocusedElementState } from './State/FocusedElement';
 import { getTabsterOnElement } from './Instance';
 import { Keys } from './Keys';
 import { RootAPI } from './Root';
 import * as Types from './Types';
 import {
+    DummyInput,
+    DummyInputManager,
     getElementUId,
     isElementVerticallyVisibleInContainer,
     isElementVisibleInContainer,
@@ -18,7 +18,7 @@ import {
     scrollIntoView,
     TabsterPart,
     triggerEvent,
-    WeakHTMLElement
+    WeakHTMLElement,
 } from './Utils';
 
 const _inputSelector = [
@@ -28,6 +28,35 @@ const _inputSelector = [
 ].join(', ');
 
 const _isVisibleTimeout = 200;
+
+class MoverDummyManager extends DummyInputManager {
+    private _tabster: Types.TabsterCore;
+    private _getMemorized: () => WeakHTMLElement | undefined;
+
+    constructor(element: WeakHTMLElement, tabster: Types.TabsterCore, getMemorized: () => WeakHTMLElement | undefined) {
+        super(tabster, element);
+        this._tabster = tabster;
+        this._getMemorized = getMemorized;
+        this.firstDummy.onFocusIn = this._onFocusDummyInput;
+        this.lastDummy.onFocusIn = this._onFocusDummyInput;
+    }
+
+    private _onFocusDummyInput = (dummyInput: DummyInput) => {
+        const container = this._element.get();
+        if (container && !dummyInput.shouldMoveOut) {
+            let toFocus = dummyInput.isFirst
+                ? this._tabster.focusable.findFirst({ container }) 
+                : this._tabster.focusable.findLast({ container });
+
+            const memorized = this._getMemorized()?.get();
+            if (memorized) {
+                toFocus = memorized;
+            }
+
+            toFocus?.focus();
+        }
+    }
+}
 
 export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover {
     private _unobserve: (() => void) | undefined;
@@ -42,6 +71,7 @@ export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover 
     private _focusables: Record<string, WeakHTMLElement> = {};
     private _win: Types.GetWindow;
     private _onDispose: (mover: Mover) => void;
+    public _dummyManagner: MoverDummyManager;
 
     constructor(
         tabster: Types.TabsterInternal,
@@ -59,6 +89,8 @@ export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover 
         }
 
         this._onDispose = onDispose;
+        const getMemorized = () => props.memorizeCurrent ? this._current : undefined;
+        this._dummyManagner = new MoverDummyManager(this._element, tabster, getMemorized);
     }
 
     dispose(): void {
@@ -86,6 +118,8 @@ export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover 
             win.clearTimeout(this._onChangeTimer);
             this._onChangeTimer = undefined;
         }
+
+        this._dummyManagner.dispose();
     }
 
     setCurrent(element: HTMLElement | undefined): boolean {
@@ -204,7 +238,7 @@ export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover 
             return;
         }
 
-        let observer = new MutationObserver(mutations => {
+        let observer = new MutationObserver(() => {
             const win = this._win();
 
             if (this._domChangedTimer) {
@@ -560,13 +594,10 @@ export class MoverAPI implements Types.MoverAPI {
             case Keys.PageUp:
             case Keys.Home:
             case Keys.End:
+            case Keys.Tab:
                 break;
             default:
                 return;
-        }
-
-        if (e.shiftKey) {
-            return;
         }
 
         const tabster = this._tabster;
@@ -667,6 +698,8 @@ export class MoverAPI implements Types.MoverAPI {
             if (next) {
                 scrollIntoView(this._win, next, true);
             }
+        } else if (keyCode === Keys.Tab) {
+            next = FocusedElementState.findNextTabbable(tabster, ctx, focused, e.shiftKey)?.element;
         } else if (isGrid) {
             const fromRect = focused.getBoundingClientRect();
             let lastElement: HTMLElement | undefined;
@@ -735,7 +768,11 @@ export class MoverAPI implements Types.MoverAPI {
             e.preventDefault();
             e.stopImmediatePropagation();
 
-            nativeFocus(next);
+            next.focus();
+        } else {
+            if (keyCode === Keys.Tab) {
+                (mover as Mover)._dummyManagner.moveOutWithDefaultAction(e.shiftKey);
+            }
         }
     }
 

--- a/core/src/Mover.ts
+++ b/core/src/Mover.ts
@@ -71,7 +71,7 @@ export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover 
     private _focusables: Record<string, WeakHTMLElement> = {};
     private _win: Types.GetWindow;
     private _onDispose: (mover: Mover) => void;
-    public _dummyManagner?: MoverDummyManager;
+    _dummyManagner?: MoverDummyManager;
 
     constructor(
         tabster: Types.TabsterInternal,

--- a/core/src/Mover.ts
+++ b/core/src/Mover.ts
@@ -71,7 +71,7 @@ export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover 
     private _focusables: Record<string, WeakHTMLElement> = {};
     private _win: Types.GetWindow;
     private _onDispose: (mover: Mover) => void;
-    public _dummyManagner: MoverDummyManager;
+    public _dummyManagner?: MoverDummyManager;
 
     constructor(
         tabster: Types.TabsterInternal,
@@ -90,7 +90,9 @@ export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover 
 
         this._onDispose = onDispose;
         const getMemorized = () => props.memorizeCurrent ? this._current : undefined;
-        this._dummyManagner = new MoverDummyManager(this._element, tabster, getMemorized);
+        if (!tabster.controlTab) {
+            this._dummyManagner = new MoverDummyManager(this._element, tabster, getMemorized);
+        }
     }
 
     dispose(): void {
@@ -119,7 +121,7 @@ export class Mover extends TabsterPart<Types.MoverProps> implements Types.Mover 
             this._onChangeTimer = undefined;
         }
 
-        this._dummyManagner.dispose();
+        this._dummyManagner?.dispose();
     }
 
     setCurrent(element: HTMLElement | undefined): boolean {
@@ -698,7 +700,7 @@ export class MoverAPI implements Types.MoverAPI {
             if (next) {
                 scrollIntoView(this._win, next, true);
             }
-        } else if (keyCode === Keys.Tab) {
+        } else if (keyCode === Keys.Tab && !tabster.controlTab) {
             next = FocusedElementState.findNextTabbable(tabster, ctx, focused, e.shiftKey)?.element;
         } else if (isGrid) {
             const fromRect = focused.getBoundingClientRect();
@@ -771,7 +773,7 @@ export class MoverAPI implements Types.MoverAPI {
             next.focus();
         } else {
             if (keyCode === Keys.Tab) {
-                (mover as Mover)._dummyManagner.moveOutWithDefaultAction(e.shiftKey);
+                (mover as Mover)._dummyManagner?.moveOutWithDefaultAction(e.shiftKey);
             }
         }
     }

--- a/core/src/Root.ts
+++ b/core/src/Root.ts
@@ -3,12 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { nativeFocus } from 'keyborg';
-
 import { getTabsterOnElement } from './Instance';
-import { KeyboardNavigationState } from './State/KeyboardNavigation';
 import * as Types from './Types';
-import { DummyInput, getElementUId, TabsterPart, WeakHTMLElement } from './Utils';
+import { getElementUId, TabsterPart, WeakHTMLElement } from './Utils';
 
 export interface WindowWithTabsterInstance extends Window {
     __tabsterInstance?: Types.TabsterCore;
@@ -28,134 +25,32 @@ function _setInformativeStyle(weakElement: WeakHTMLElement, remove: boolean, id?
     }
 }
 
-interface DummyInputProps {
-    isFirst: boolean;
-    shouldMoveOut?: boolean;
-    isActive: boolean;
-}
-
 export class Root extends TabsterPart<Types.RootProps, undefined> implements Types.Root {
     readonly uid: string;
 
-    private _dummyInputFirst: DummyInput<DummyInputProps> | undefined;
-    private _dummyInputLast: DummyInput<DummyInputProps> | undefined;
-    private _forgetFocusedGrouppers: () => void;
     private _unobserve: (() => void) | undefined;
 
     constructor(
         tabster: Types.TabsterInternal,
         element: HTMLElement,
-        forgetFocusedGrouppers: () => void,
         props: Types.RootProps
     ) {
         super(tabster, element, props);
 
         const win = tabster.getWindow;
         this.uid = getElementUId(win, element);
-        this._forgetFocusedGrouppers = forgetFocusedGrouppers;
-
-        this._dummyInputFirst = new DummyInput(
-            win,
-            false,
-            this._onDummyInputFocus,
-            this._onDummyInputBlur,
-            { isFirst: true, isActive: true }
-        );
-
-        this._dummyInputLast = new DummyInput(
-            win,
-            false,
-            this._onDummyInputFocus,
-            this._onDummyInputBlur,
-            { isFirst: false, isActive: true }
-        );
 
         this._add();
-        this._addDummyInputs();
 
-        tabster.focusedElement.subscribe(this._onFocus);
-        this._observeMutations(element);
     }
 
     dispose(): void {
-        this._tabster.focusedElement.unsubscribe(this._onFocus);
-
         if (this._unobserve) {
             this._unobserve();
             this._unobserve = undefined;
         }
 
         this._remove();
-
-        const dif = this._dummyInputFirst;
-        if (dif) {
-            dif.dispose();
-            delete this._dummyInputFirst;
-        }
-
-        const dil = this._dummyInputLast;
-        if (dil) {
-            dil.dispose();
-            delete this._dummyInputLast;
-        }
-
-        this._forgetFocusedGrouppers = () => {/**/};
-    }
-
-    moveOutWithDefaultAction(backwards: boolean): void {
-        const first = this._dummyInputFirst;
-        const last = this._dummyInputLast;
-
-        if (first?.input && last?.input) {
-            if (backwards) {
-                first.props.shouldMoveOut = true;
-                nativeFocus(first.input);
-            } else {
-                last.props.shouldMoveOut = true;
-                nativeFocus(last.input);
-            }
-        }
-    }
-
-    private _observeMutations(element: HTMLElement): void {
-        if (this._unobserve || (typeof MutationObserver === 'undefined')) {
-            return;
-        }
-
-        let observer = new MutationObserver(mutations => {
-            this._addDummyInputs();
-        });
-
-        observer.observe(element, { childList: true });
-
-        this._unobserve = () => {
-            observer.disconnect();
-        };
-    }
-
-    private _onFocus = (e: HTMLElement | undefined) => {
-        if (e) {
-            const ctx = RootAPI.getTabsterContext(this._tabster, e);
-
-            if (!ctx || ctx.uncontrolled) {
-                this._setDummyInputsActive(false);
-                return;
-            }
-        }
-
-        this._setDummyInputsActive(true);
-    }
-
-    private _setDummyInputsActive(isActive: boolean) {
-        for (let dummy of [this._dummyInputFirst, this._dummyInputLast]) {
-            if (dummy && (dummy.props.isActive !== isActive) && dummy.input) {
-                // If the uncontrolled element is first/last in the application, focusing the
-                // dummy input will not let the focus to go outside of the application.
-                // So, we're making dummy inputs not tabbable if the uncontrolled element has focus.
-                dummy.input.tabIndex = isActive ? 0 : -1;
-                dummy.props.isActive = isActive;
-            }
-        }
     }
 
     private _add(): void {
@@ -165,75 +60,8 @@ export class Root extends TabsterPart<Types.RootProps, undefined> implements Typ
     }
 
     private _remove(): void {
-        this._removeDummyInputs();
-
         if (__DEV__) {
             _setInformativeStyle(this._element, true);
-        }
-    }
-
-    private _onDummyInputFocus = (input: HTMLDivElement, props: DummyInputProps): void => {
-        if (props.shouldMoveOut) {
-            // When we've reached the last focusable element, we want to let the browser
-            // to move the focus outside of the page. In order to do that we're synchronously
-            // calling focus() of the dummy input from the Tab key handler and allowing
-            // the default action to move the focus out.
-        } else {
-            // The only way a dummy input gets focused is during the keyboard navigation.
-            KeyboardNavigationState.setVal(this._tabster.keyboardNavigation, true);
-
-            this._forgetFocusedGrouppers();
-
-            const element = this._element.get();
-
-            if (element) {
-                let hasFocused = props.isFirst
-                    ? this._tabster.focusedElement.focusFirst({ container: element })
-                    : this._tabster.focusedElement.focusLast({ container: element });
-
-                if (hasFocused) {
-                    return;
-                }
-            }
-
-            input.blur();
-        }
-    }
-
-    private _onDummyInputBlur = (input: HTMLDivElement, props: DummyInputProps): void => {
-        props.shouldMoveOut = false;
-    }
-
-    private _addDummyInputs(): void {
-        const element = this._element.get();
-        const dif = this._dummyInputFirst?.input;
-        const dil = this._dummyInputLast?.input;
-
-        if (!element || !dif || !dil) {
-            return;
-        }
-
-        if (element.lastElementChild !== dil) {
-            element.appendChild(dil);
-        }
-
-        const firstElementChild = element.firstElementChild;
-
-        if (firstElementChild && (firstElementChild !== dif)) {
-            element.insertBefore(dif, firstElementChild);
-        }
-    }
-
-    private _removeDummyInputs(): void {
-        const dif = this._dummyInputFirst?.input;
-        const dil = this._dummyInputLast?.input;
-
-        if (dif?.parentElement) {
-            dif.parentElement.removeChild(dif);
-        }
-
-        if (dil?.parentElement) {
-            dil.parentElement.removeChild(dil);
         }
     }
 }
@@ -246,15 +74,13 @@ export class RootAPI implements Types.RootAPI {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
     private _initTimer: number | undefined;
-    private _forgetFocusedGrouppers: () => void;
     private _autoRoot: Types.RootProps | undefined;
     private _autoRootInstance: Root | undefined;
     rootById: { [id: string]: Types.Root } = {};
 
-    constructor(tabster: Types.TabsterCore, forgetFocusedGrouppers: () => void, autoRoot?: Types.RootProps) {
+    constructor(tabster: Types.TabsterCore, autoRoot?: Types.RootProps) {
         this._tabster = tabster;
         this._win = (tabster as Types.TabsterInternal).getWindow;
-        this._forgetFocusedGrouppers = forgetFocusedGrouppers;
         this._initTimer = this._win().setTimeout(this._init, 0);
         this._autoRoot = autoRoot;
     }
@@ -277,8 +103,6 @@ export class RootAPI implements Types.RootAPI {
             this._initTimer = undefined;
         }
 
-        this._forgetFocusedGrouppers = () => {/**/};
-
         this.rootById = {};
     }
 
@@ -295,7 +119,7 @@ export class RootAPI implements Types.RootAPI {
             validateRootProps(props);
         }
 
-        return new Root(tabster, element, (tabster.root as RootAPI)._forgetFocusedGrouppers, props) as Types.Root;
+        return new Root(tabster, element, props) as Types.Root;
     }
 
     static getRootByUId(getWindow: Types.GetWindow, id: string): Types.Root | undefined {
@@ -385,7 +209,6 @@ export class RootAPI implements Types.RootAPI {
                     rootAPI._autoRootInstance = new Root(
                         rootAPI._tabster as Types.TabsterInternal,
                         body,
-                        rootAPI._forgetFocusedGrouppers,
                         autoRoot
                     );
                 }

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -3,15 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { KeyborgFocusInEvent, KEYBORG_FOCUSIN, nativeFocus } from 'keyborg';
+import { KeyborgFocusInEvent, KEYBORG_FOCUSIN } from 'keyborg';
 
-import { Keys } from '../Keys';
 import { RootAPI } from '../Root';
 import { Subscribable } from './Subscribable';
 import * as Types from '../Types';
 import {
     documentContains,
-    DummyInput,
     getLastChild,
     shouldIgnoreFocus,
     WeakHTMLElement
@@ -44,7 +42,6 @@ export class FocusedElementState
         // Add these event listeners as capture - we want Tabster to run before user event handlers
         win.document.addEventListener(KEYBORG_FOCUSIN, this._onFocusIn, true);
         win.document.addEventListener('focusout', this._onFocusOut, true);
-        win.addEventListener('keydown', this._onKeyDown, true);
     }
 
     protected dispose(): void {
@@ -59,7 +56,6 @@ export class FocusedElementState
 
         win.document.removeEventListener(KEYBORG_FOCUSIN, this._onFocusIn, true);
         win.document.removeEventListener('focusout', this._onFocusOut, true);
-        win.removeEventListener('keydown', this._onKeyDown, true);
 
         delete FocusedElementState._lastResetElement;
 
@@ -330,84 +326,7 @@ export class FocusedElementState
         return next;
     }
 
-    private _onKeyDown = (e: KeyboardEvent): void => {
-        if (e.keyCode !== Keys.Tab) {
-            return;
-        }
-
-        let curElement = this.getVal();
-
-        if (!curElement || !curElement.ownerDocument || curElement.contentEditable === 'true') {
-            return;
-        }
-
-        const ctx = RootAPI.getTabsterContext(this._tabster, curElement, { checkRtl: true });
-
-        if (!ctx) {
-            return;
-        }
-
-        const isPrev = e.shiftKey;
-        const next = FocusedElementState.findNextTabbable(this._tabster, ctx, curElement, isPrev);
-
-        if (!next) {
-            return;
-        }
-
-        let uncontrolled = next.uncontrolled;
-
-        if (uncontrolled) {
-            if (!ctx.uncontrolled) {
-                // We have met an uncontrolled area, just allow default action.
-                this._moveToUncontrolled(uncontrolled, isPrev);
-            }
-            return;
-        }
-
-        const nextElement = next.element;
-
-        if (ctx.modalizer) {
-            const nextElementCtx = nextElement && RootAPI.getTabsterContext(this._tabster, nextElement);
-
-            if (
-                !nextElementCtx ||
-                (ctx.root.uid !== nextElementCtx.root.uid) ||
-                !nextElementCtx.modalizer?.isActive()
-            ) {
-                if (ctx.modalizer.onBeforeFocusOut()) {
-                    e.preventDefault();
-
-                    return;
-                }
-            }
-        }
-
-        if (nextElement) {
-            // For iframes just allow normal Tab behaviour
-            if (nextElement.tagName !== 'IFRAME') {
-                e.preventDefault();
-                nativeFocus(nextElement);
-            }
-        } else {
-            ctx.root.moveOutWithDefaultAction(isPrev);
-        }
-    }
-
     private _validateFocusedElement = (element: HTMLElement): void => {
         // TODO: Make sure this is not needed anymore and write tests.
-    }
-
-    private _moveToUncontrolled(uncontrolled: HTMLElement, isPrev: boolean): void {
-        const dummy: DummyInput<undefined> = new DummyInput(this._win, true, () => {/**/}, () => {/**/}, undefined);
-        const input = dummy.input;
-
-        if (input) {
-            const parent = uncontrolled.parentElement;
-
-            if (parent) {
-                parent.insertBefore(input, isPrev ? uncontrolled.nextElementSibling : uncontrolled);
-                nativeFocus(input);
-            }
-        }
     }
 }

--- a/core/src/State/FocusedElement.ts
+++ b/core/src/State/FocusedElement.ts
@@ -3,13 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import { KeyborgFocusInEvent, KEYBORG_FOCUSIN } from 'keyborg';
+import { KeyborgFocusInEvent, KEYBORG_FOCUSIN, nativeFocus } from 'keyborg';
 
+import { Keys } from '../Keys';
 import { RootAPI } from '../Root';
 import { Subscribable } from './Subscribable';
 import * as Types from '../Types';
 import {
     documentContains,
+    DummyInput,
     getLastChild,
     shouldIgnoreFocus,
     WeakHTMLElement
@@ -42,6 +44,9 @@ export class FocusedElementState
         // Add these event listeners as capture - we want Tabster to run before user event handlers
         win.document.addEventListener(KEYBORG_FOCUSIN, this._onFocusIn, true);
         win.document.addEventListener('focusout', this._onFocusOut, true);
+        if (this._tabster.controlTab) {
+            win.addEventListener('keydown', this._onKeyDown, true);
+        }
     }
 
     protected dispose(): void {
@@ -56,6 +61,9 @@ export class FocusedElementState
 
         win.document.removeEventListener(KEYBORG_FOCUSIN, this._onFocusIn, true);
         win.document.removeEventListener('focusout', this._onFocusOut, true);
+        if (this._tabster.controlTab) {
+            win.addEventListener('keydown', this._onKeyDown, true);
+        }
 
         delete FocusedElementState._lastResetElement;
 
@@ -328,5 +336,82 @@ export class FocusedElementState
 
     private _validateFocusedElement = (element: HTMLElement): void => {
         // TODO: Make sure this is not needed anymore and write tests.
+    }
+
+     private _onKeyDown = (e: KeyboardEvent): void => {
+        if (e.keyCode !== Keys.Tab) {
+            return;
+        }
+
+        let curElement = this.getVal();
+
+        if (!curElement || !curElement.ownerDocument || curElement.contentEditable === 'true') {
+            return;
+        }
+
+        const ctx = RootAPI.getTabsterContext(this._tabster, curElement, { checkRtl: true });
+
+        if (!ctx) {
+            return;
+        }
+
+        const isPrev = e.shiftKey;
+        const next = FocusedElementState.findNextTabbable(this._tabster, ctx, curElement, isPrev);
+
+        if (!next) {
+            return;
+        }
+
+        let uncontrolled = next.uncontrolled;
+
+        if (uncontrolled) {
+            if (!ctx.uncontrolled) {
+                // We have met an uncontrolled area, just allow default action.
+                this._moveToUncontrolled(uncontrolled, isPrev);
+            }
+            return;
+        }
+
+        const nextElement = next.element;
+
+        if (ctx.modalizer) {
+            const nextElementCtx = nextElement && RootAPI.getTabsterContext(this._tabster, nextElement);
+
+            if (
+                !nextElementCtx ||
+                (ctx.root.uid !== nextElementCtx.root.uid) ||
+                !nextElementCtx.modalizer?.isActive()
+            ) {
+                if (ctx.modalizer.onBeforeFocusOut()) {
+                    e.preventDefault();
+
+                    return;
+                }
+            }
+        }
+
+        if (nextElement) {
+            // For iframes just allow normal Tab behaviour
+            if (nextElement.tagName !== 'IFRAME') {
+                e.preventDefault();
+                nativeFocus(nextElement);
+            }
+        } else {
+            ctx.root.moveOutWithDefaultAction(isPrev);
+        }
+    }
+
+    private _moveToUncontrolled(uncontrolled: HTMLElement, isPrev: boolean): void {
+        const dummy: DummyInput = new DummyInput(this._win, { isPhantom: true, isFirst: true });
+        const input = dummy.input;
+
+        if (input) {
+            const parent = uncontrolled.parentElement;
+
+            if (parent) {
+                parent.insertBefore(input, isPrev ? uncontrolled.nextElementSibling : uncontrolled);
+                nativeFocus(input);
+            }
+        }
     }
 }

--- a/core/src/Tabster.ts
+++ b/core/src/Tabster.ts
@@ -86,9 +86,7 @@ class Tabster implements Types.TabsterCore, Types.TabsterInternal {
         this.keyboardNavigation = new KeyboardNavigationState(getWindow);
         this.focusedElement = new FocusedElementState(this, getWindow);
         this.focusable = new FocusableAPI(this, getWindow);
-        this.root = new RootAPI(this, () => {
-            (this.groupper as Types.GroupperInternalAPI | undefined)?.forgetCurrentGrouppers();
-        }, props?.autoRoot);
+        this.root = new RootAPI(this, props?.autoRoot);
         this.createRoot = RootAPI.createRoot;
         this.updateRoot = (root: Types.Root, removed?: boolean) => {
             RootAPI.onRoot(this.root, root, removed);

--- a/core/src/Tabster.ts
+++ b/core/src/Tabster.ts
@@ -49,6 +49,7 @@ class Tabster implements Types.TabsterCore, Types.TabsterInternal {
     focusable: Types.FocusableAPI;
     root: Types.RootAPI;
     uncontrolled: Types.UncontrolledAPI;
+    controlTab: boolean;
     internal: Types.InternalAPI;
 
     groupper?: Types.GroupperAPI;
@@ -92,6 +93,8 @@ class Tabster implements Types.TabsterCore, Types.TabsterInternal {
             RootAPI.onRoot(this.root, root, removed);
         };
         this.uncontrolled = new UncontrolledAPI(this);
+        this.controlTab = props?.controlTab ?? true;
+        console.log('controlledTab', this.controlTab);
 
         this.internal = {
             stopObserver: (): void => {

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -25,9 +25,14 @@ export interface TabsterDOMAttribute {
 
 export interface TabsterCoreProps {
     autoRoot?: RootProps;
+    /**
+     * Allows all tab key presses under the tabster root to be controlled by tabster
+     * @default true
+     */
+    controlTab?: boolean;
 }
 
-export interface TabsterCore {
+export interface TabsterCore extends Pick<TabsterCoreProps, 'controlTab'> {
     keyboardNavigation: KeyboardNavigationState;
     focusedElement: FocusedElementState;
     focusable: FocusableAPI;
@@ -553,6 +558,7 @@ export interface RootProps {
 export interface Root extends TabsterPart<RootProps> {
     readonly uid: string;
     dispose(): void;
+    moveOutWithDefaultAction(backwards: boolean): void;
 }
 
 export type RootConstructor = (

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -553,7 +553,6 @@ export interface RootProps {
 export interface Root extends TabsterPart<RootProps> {
     readonly uid: string;
     dispose(): void;
-    moveOutWithDefaultAction(backwards: boolean): void;
 }
 
 export type RootConstructor = (
@@ -592,10 +591,6 @@ export interface UncontrolledAPI {
 }
 
 export interface ModalizerAPI {
-    /**
-     * Gets the currently active modalizer if it exists
-     */
-    getActiveModalizer(): Modalizer | undefined;
     /**
      * Activates a Modalizer and focuses the first or default element within
      *

--- a/core/src/Utils.ts
+++ b/core/src/Utils.ts
@@ -550,28 +550,32 @@ export abstract class TabsterPart<P, D = undefined> implements Types.TabsterPart
 }
 
 export interface DummyInputProps {
+    /** The input is created to be used only once and autoremoved when focused. */
+    isPhantom?: boolean; 
+    /** Whether the input is before or after the content it is guarding  */
     isFirst: boolean;
-    focusin?: (e: FocusEvent) => void;
-    focusout?: (e: FocusEvent) => void;
-    isPhantom?: boolean; // The input is created to be used only once and autoremoved when focused.
 }
 
-export type DummyInputFocusCallback<P> = (input: HTMLDivElement, props: P) => void;
+export type DummyInputFocusCallback = (dummyInput: DummyInput) => void;
 
-export class DummyInput<P> {
-    private _onFocusIn: DummyInputFocusCallback<P> | undefined;
-    private _onFocusOut: DummyInputFocusCallback<P> | undefined;
-    private _isPhantom: boolean;
+/**
+ * Dummy HTML elements that are used as focus sentinels for the DOM enclosed within them
+ */
+export class DummyInput {
+    private _isPhantom: DummyInputProps['isPhantom'];
 
-    input: HTMLDivElement | undefined;
-    props: P;
+    public input: HTMLDivElement | undefined;
+    /** Flag that indicates focus is leaving the boundary of the dummy input */
+    public shouldMoveOut?: boolean;
+    public isFirst: DummyInputProps['isFirst'];
+    /** Called when the input is focused */
+    onFocusIn?: DummyInputFocusCallback;
+    /** Called when the input is blurred */
+    onFocusOut?: DummyInputFocusCallback;
 
     constructor(
         getWindow: Types.GetWindow,
-        isPhantom: boolean,
-        focusIn: DummyInputFocusCallback<P>,
-        focusOut: DummyInputFocusCallback<P>,
-        props: P
+        props: DummyInputProps
     ) {
         const input = getWindow().document.createElement('div');
 
@@ -594,10 +598,8 @@ export class DummyInput<P> {
         makeFocusIgnored(input);
 
         this.input = input;
-        this._isPhantom = isPhantom;
-        this._onFocusIn = focusIn;
-        this._onFocusOut = focusOut;
-        this.props = props;
+        this.isFirst = props.isFirst;
+        this._isPhantom = props.isPhantom ?? false;
 
         input.addEventListener('focusin', this._focusIn);
         input.addEventListener('focusout', this._focusOut);
@@ -610,8 +612,8 @@ export class DummyInput<P> {
             return;
         }
 
-        delete this._onFocusIn;
-        delete this._onFocusOut;
+        delete this.onFocusIn;
+        delete this.onFocusOut;
         delete this.input;
 
         input.removeEventListener('focusin', this._focusIn);
@@ -621,19 +623,109 @@ export class DummyInput<P> {
     }
 
     private _focusIn = (e: FocusEvent): void => {
-        if (this._onFocusIn && this.input) {
-            this._onFocusIn(this.input, this.props);
+        if (this.onFocusIn && this.input) {
+            this.onFocusIn(this);
         }
     }
 
     private _focusOut = (e: FocusEvent): void => {
-        if (this._onFocusOut && this.input) {
-            this._onFocusOut(this.input, this.props);
+        this.shouldMoveOut = false;
+
+        if (this.onFocusOut && this.input) {
+            this.onFocusOut(this);
         }
 
         if (this._isPhantom) {
             this.dispose();
         }
+    }
+}
+
+/**
+ * Parent class that encapsulates the behaviour of dummy inputs (focus sentinels)
+ */
+export class DummyInputManager {
+    private _unobserve: (() => void) | undefined;
+    protected _element: WeakHTMLElement;
+    protected firstDummy: DummyInput;
+    protected lastDummy: DummyInput;
+
+    constructor(tabster: Types.TabsterCore, element: WeakHTMLElement ) {
+        const win = (tabster as Types.TabsterInternal).getWindow;
+        this.firstDummy = new DummyInput(win, { isFirst: true });
+        this.lastDummy = new DummyInput(win, { isFirst: false });
+        this._element = element;
+        this._addDummyInputs();
+        this._observeMutations(win);
+    }
+
+    dispose(): void {
+        this.firstDummy.dispose();
+        this.lastDummy.dispose();
+    }
+
+    /**
+     * Prepares to move focus out of the given element by focusing
+     * one of the dummy inputs and setting the `shouldMoveOut` flag
+     * @param backwards focus moving to an element behind the given element
+     */
+    moveOutWithDefaultAction = (backwards: boolean): void => {
+        const first = this.firstDummy;
+        const last = this.lastDummy;
+
+        if (first?.input && last?.input) {
+            if (backwards) {
+                first.shouldMoveOut = true;
+                first.input.focus();
+            } else {
+                last.shouldMoveOut = true;
+                last.input.focus();
+            }
+        }
+    }
+
+    /**
+     * Adds dummy inputs as the first and last child of the given element
+     * Called each time the children under the element is mutated
+     */
+    private _addDummyInputs() {
+        const element = this._element.get();
+        const dif = this.firstDummy?.input;
+        const dil = this.lastDummy?.input;
+
+        if (!element || !dif || !dil) {
+            return;
+        }
+
+        if (element.lastElementChild !== dil) {
+            element.appendChild(dil);
+        }
+
+        const firstElementChild = element.firstElementChild;
+
+        if (firstElementChild && (firstElementChild !== dif)) {
+            element.insertBefore(dif, firstElementChild);
+        } 
+    }
+
+    /**
+     * Creates a mutation observer to ensure that on DOM changes, the dummy inputs
+     * stay as the first and last child elements
+     */
+    private _observeMutations(win: Types.GetWindow): void {
+        if (this._unobserve) {
+            return;
+        }
+
+        const observer = new MutationObserver(() => {
+            this._addDummyInputs();
+        });
+
+        observer.observe(win().document.body, { childList: true });
+
+        this._unobserve = () => {
+            observer.disconnect();
+        };
     }
 }
 

--- a/core/src/Utils.ts
+++ b/core/src/Utils.ts
@@ -564,10 +564,10 @@ export type DummyInputFocusCallback = (dummyInput: DummyInput) => void;
 export class DummyInput {
     private _isPhantom: DummyInputProps['isPhantom'];
 
-    public input: HTMLDivElement | undefined;
+    input: HTMLDivElement | undefined;
     /** Flag that indicates focus is leaving the boundary of the dummy input */
-    public shouldMoveOut?: boolean;
-    public isFirst: DummyInputProps['isFirst'];
+    shouldMoveOut?: boolean;
+    isFirst: DummyInputProps['isFirst'];
     /** Called when the input is focused */
     onFocusIn?: DummyInputFocusCallback;
     /** Called when the input is blurred */

--- a/core/src/__tests__/Focusable.test.tsx
+++ b/core/src/__tests__/Focusable.test.tsx
@@ -5,8 +5,9 @@
 
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute } from '../Tabster';
+import { runIfControlled } from './test-utils';
 
-xdescribe('Focusable', () => {
+runIfControlled('Focusable', () => {
     beforeAll(async () => {
         await BroTest.bootstrapTabsterPage();
     });

--- a/core/src/__tests__/Focusable.test.tsx
+++ b/core/src/__tests__/Focusable.test.tsx
@@ -6,7 +6,7 @@
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute } from '../Tabster';
 
-describe('Focusable', () => {
+xdescribe('Focusable', () => {
     beforeAll(async () => {
         await BroTest.bootstrapTabsterPage();
     });

--- a/core/src/__tests__/Root.test.tsx
+++ b/core/src/__tests__/Root.test.tsx
@@ -6,7 +6,9 @@
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute, Types as TabsterTypes } from '../Tabster';
 
-xdescribe('Root', () => {
+const runIfControlled = !process.env.UNCONTROLLED ? describe : xdescribe;
+
+runIfControlled('Root', () => {
     beforeAll(async () => {
         await BroTest.bootstrapTabsterPage();
     });

--- a/core/src/__tests__/Root.test.tsx
+++ b/core/src/__tests__/Root.test.tsx
@@ -6,7 +6,7 @@
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute, Types as TabsterTypes } from '../Tabster';
 
-describe('Root', () => {
+xdescribe('Root', () => {
     beforeAll(async () => {
         await BroTest.bootstrapTabsterPage();
     });

--- a/core/src/__tests__/Root.test.tsx
+++ b/core/src/__tests__/Root.test.tsx
@@ -5,8 +5,7 @@
 
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute, Types as TabsterTypes } from '../Tabster';
-
-const runIfControlled = !process.env.UNCONTROLLED ? describe : xdescribe;
+import { runIfControlled } from './test-utils';
 
 runIfControlled('Root', () => {
     beforeAll(async () => {

--- a/core/src/__tests__/Uncontrolled.test.tsx
+++ b/core/src/__tests__/Uncontrolled.test.tsx
@@ -6,7 +6,7 @@
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute } from '../Tabster';
 
-describe('Uncontrolled', () => {
+xdescribe('Uncontrolled', () => {
     beforeAll(async () => {
         await BroTest.bootstrapTabsterPage();
     });

--- a/core/src/__tests__/Uncontrolled.test.tsx
+++ b/core/src/__tests__/Uncontrolled.test.tsx
@@ -6,7 +6,9 @@
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute } from '../Tabster';
 
-xdescribe('Uncontrolled', () => {
+const runIfControlled = !process.env.UNCONTROLLED ? describe : xdescribe;
+
+runIfControlled('Uncontrolled', () => {
     beforeAll(async () => {
         await BroTest.bootstrapTabsterPage();
     });

--- a/core/src/__tests__/Uncontrolled.test.tsx
+++ b/core/src/__tests__/Uncontrolled.test.tsx
@@ -5,8 +5,7 @@
 
 import * as BroTest from '../../testing/BroTest';
 import { getTabsterAttribute } from '../Tabster';
-
-const runIfControlled = !process.env.UNCONTROLLED ? describe : xdescribe;
+import { runIfControlled } from './test-utils';
 
 runIfControlled('Uncontrolled', () => {
     beforeAll(async () => {

--- a/core/src/__tests__/test-utils.ts
+++ b/core/src/__tests__/test-utils.ts
@@ -1,1 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export const runIfControlled = !process.env.UNCONTROLLED ? describe : xdescribe;

--- a/core/src/__tests__/test-utils.ts
+++ b/core/src/__tests__/test-utils.ts
@@ -1,0 +1,1 @@
+export const runIfControlled = !process.env.UNCONTROLLED ? describe : xdescribe;

--- a/core/testing/BroTest.ts
+++ b/core/testing/BroTest.ts
@@ -31,7 +31,7 @@ declare var __tabsterInstance: any;
 
 export async function bootstrapTabsterPage() {
     // TODO configure this easier
-    await page.goto('http://localhost:8080');
+    await page.goto(`http://localhost:${process.env.PORT ?? '8080'}`);
     await expect(page.title()).resolves.toMatch('Tabster Test');
 
     // Waiting for the test app to set Tabster up.

--- a/test-container/src/global.d.ts
+++ b/test-container/src/global.d.ts
@@ -1,2 +1,3 @@
 declare const __DEV__: boolean;
 declare const __VERSION__: string;
+declare const __UNCONTROLLED__: string;

--- a/test-container/src/index.ts
+++ b/test-container/src/index.ts
@@ -8,7 +8,7 @@ import {
     getObservedElement
 } from 'tabster';
 
-const tabster = createTabster(window);
+const tabster = createTabster(window, { controlTab: !__UNCONTROLLED__});
 console.log('created tabster');
 
 getModalizer(tabster)

--- a/test-container/webpack.config.js
+++ b/test-container/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = {
         new webpack.DefinePlugin({
             '__DEV__': true,
             '__VERSION__': `'${version}'`,
+            '__UNCONTROLLED__': !!process.env.UNCONTROLLED,
         }),
         new HtmlWebpackPlugin({ title: 'Tabster Test' }),
         new CopyPlugin({

--- a/test-container/webpack.config.js
+++ b/test-container/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
     devtool: 'source-map',
 
     devServer: {
-        port: 8080,
+        port: process.env.PORT ?? 8080,
         contentBase: path.join(__dirname, 'dist'),
         writeToDisk: true,
     },


### PR DESCRIPTION
Abstracts the dummy input logic to a `DummyInputManager` class that can be reused.

The `DummyInputManager` automatically adds dummy focus sentinels as first and last child of an element and will be used in:
* Mover
* Groupper
* Modalizer

So that `FocusedElementState` no longer needs to control **every single tab key press under Root**. This makes it easier for users to adopt tabster gradually.

The new dummy input code path can be configured when creating tabster. **The current codepath is still the default**, where each tab key press is controlled

```tsx
createTabster(window, { controlTab: false });
```

Both codepaths can now be tested in the repo:

```
// Inserts dummy inputs and stops controlling tab
UNCONTROLLED=true npm test

// current main codepath
npm test
```
