### PR TITLE
fix(DummyInputManager): Mutation observer should be on declared element

### DIFF
--- a/core/jest-puppeteer.config.js
+++ b/core/jest-puppeteer.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     launch: {
-        headless: true,
+        headless: false,
         devtools: true,
     }
 }

--- a/core/src/Utils.ts
+++ b/core/src/Utils.ts
@@ -721,11 +721,14 @@ export class DummyInputManager {
             this._addDummyInputs();
         });
 
-        observer.observe(win().document.body, { childList: true });
+        const element = this._element.get();
+        if (element) {
+            observer.observe(element, { childList: true });
 
-        this._unobserve = () => {
-            observer.disconnect();
-        };
+            this._unobserve = () => {
+                observer.disconnect();
+            };
+        }
     }
 }
 

--- a/core/src/__tests__/DummyInputManager.test.tsx
+++ b/core/src/__tests__/DummyInputManager.test.tsx
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as BroTest from '../../testing/BroTest';
+import { getTabsterAttribute, Types } from '../Tabster';
+import { runIfUnControlled } from './test-utils';
+
+runIfUnControlled('DummyInputManager', () => {
+  beforeAll(async () => {
+    await BroTest.bootstrapTabsterPage();
+  });
+  describe('should update dummy inputs when DOM children update for', () => {
+    const evaluateDummy = (dummyAttribute: string, elementId: string) => {
+      const mover = document.getElementById(elementId) as HTMLElement;
+      return { 
+        first: mover.firstElementChild?.hasAttribute(dummyAttribute),
+        last: mover.lastElementChild?.hasAttribute(dummyAttribute),
+      };
+    };
+
+    const checkDummy = (res: ReturnType<typeof evaluateDummy>) => {
+      expect(res.first).toBe(true);
+      expect(res.last).toBe(true);
+    };
+
+    const appendElement = (elementId: string) => {
+        const mover = document.getElementById(elementId) as HTMLElement;
+        const newElement = document.createElement('button');
+        newElement.textContent = 'New element append';
+        mover.appendChild(newElement);
+    };
+
+    const prependElement = (elementId: string) => {
+        const mover = document.getElementById(elementId) as HTMLElement;
+        const newElement = document.createElement('button');
+        newElement.textContent = 'New element prepend';
+        mover.prepend(newElement);
+    };
+
+    it('mover', async () => {
+      const attr = getTabsterAttribute({
+        mover: {
+          direction: Types.MoverDirections.Vertical,
+          cyclic: true,
+        }
+      });
+      const moverId = 'mover';
+
+      const testHtml = (
+        <div {...attr} id={moverId}>
+          <button>Button1</button>
+          <button>Button2</button>
+          <button>Button3</button>
+          <button>Button4</button>
+        </div>
+      );
+
+      await new BroTest.BroTest(testHtml)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, moverId)
+      .check(checkDummy)
+      .eval(appendElement, moverId)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, moverId)
+      .check(checkDummy)
+      .eval(prependElement, moverId)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, moverId)
+      .check(checkDummy);
+    });
+
+    it('groupper', async() => {
+      const attr = getTabsterAttribute({
+        groupper: {}
+      });
+      const groupperId = 'groupper';
+
+      const testHtml = (
+        <div {...attr} id={groupperId}>
+          <button>Button1</button>
+          <button>Button2</button>
+          <button>Button3</button>
+          <button>Button4</button>
+        </div>
+      );
+
+      await new BroTest.BroTest(testHtml)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, groupperId)
+      .check(checkDummy)
+      .eval(appendElement, groupperId)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, groupperId)
+      .check(checkDummy)
+      .eval(prependElement, groupperId)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, groupperId)
+      .check(checkDummy);
+    });
+
+    it('modalizerAPI', async() => {
+      const attr = getTabsterAttribute({
+        modalizer: {id: 'modalizer'}
+      });
+
+      const modalizerAPIId = 'modalizerAPI';
+
+      const testHtml = (
+        <div {...attr}>
+          <button>Button1</button>
+          <button>Button2</button>
+          <button>Button3</button>
+          <button>Button4</button>
+        </div>
+      );
+
+      await new BroTest.BroTest(testHtml)
+      .eval((modalizerAPIId) => {
+        document.body.setAttribute('id', modalizerAPIId);
+      }, modalizerAPIId)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, modalizerAPIId)
+      .check(checkDummy)
+      .eval(appendElement, modalizerAPIId)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, modalizerAPIId)
+      .check(checkDummy)
+      .eval(prependElement, modalizerAPIId)
+      .eval(evaluateDummy, Types.TabsterDummyInputAttributeName, modalizerAPIId)
+      .check(checkDummy);
+    });
+  });
+});

--- a/core/src/__tests__/test-utils.ts
+++ b/core/src/__tests__/test-utils.ts
@@ -4,3 +4,4 @@
  */
 
 export const runIfControlled = !process.env.UNCONTROLLED ? describe : xdescribe;
+export const runIfUnControlled = process.env.UNCONTROLLED ? describe : xdescribe;


### PR DESCRIPTION
Fixes the `DummyInputManager` so that the element API is observed
instead of document body. Also adds tests for this