### PR TITLE
Mutation observer should not be used in test environment

### DIFF
--- a/core/src/Utils.ts
+++ b/core/src/Utils.ts
@@ -656,7 +656,12 @@ export class DummyInputManager {
         this.lastDummy = new DummyInput(win, { isFirst: false });
         this._element = element;
         this._addDummyInputs();
-        this._observeMutations(win);
+
+        // older versions of testing frameworks like JSDOM don't support MutationObserver
+        // https://github.com/jsdom/jsdom/issues/639
+        if (process.env.NODE_ENV !== 'test') {
+            this._observeMutations(win);
+        }
     }
 
     dispose(): void {


### PR DESCRIPTION
In older versions of JSOM jsdom/jsdom#639 mutation observer is not fully
supported and will throw on tests.

Wraps the usage of MutationObserver around the `process.env.NODE_ENV`
guard to protect for this scenario