### PR TITLE
fix: keep `process.env.NODE_ENV` check for test environment

### DIFF
--- a/core/src/Tabster.ts
+++ b/core/src/Tabster.ts
@@ -94,7 +94,6 @@ class Tabster implements Types.TabsterCore, Types.TabsterInternal {
         };
         this.uncontrolled = new UncontrolledAPI(this);
         this.controlTab = props?.controlTab ?? true;
-        console.log('controlledTab', this.controlTab);
 
         this.internal = {
             stopObserver: (): void => {

--- a/core/src/Utils.ts
+++ b/core/src/Utils.ts
@@ -661,7 +661,7 @@ export class DummyInputManager {
         // https://github.com/jsdom/jsdom/issues/639
         // use this way of getting NODE_ENV because tsdx does not support a test environment
         // https://github.com/jaredpalmer/tsdx/issues/167
-        if (typeof process !== 'undefined' && process.env["NODE_ENV"] !== "test") {
+        if (typeof process === 'undefined' || process.env["NODE_ENV"] !== "test") {
             this._observeMutations(win);
         }
     }

--- a/core/src/Utils.ts
+++ b/core/src/Utils.ts
@@ -659,7 +659,9 @@ export class DummyInputManager {
 
         // older versions of testing frameworks like JSDOM don't support MutationObserver
         // https://github.com/jsdom/jsdom/issues/639
-        if (process.env.NODE_ENV !== 'test') {
+        // use this way of getting NODE_ENV because tsdx does not support test environment
+        // https://github.com/jaredpalmer/tsdx/issues/167
+        if (process.env["NODE_ENV"] !== "test") {
             this._observeMutations(win);
         }
     }

--- a/core/src/Utils.ts
+++ b/core/src/Utils.ts
@@ -659,9 +659,9 @@ export class DummyInputManager {
 
         // older versions of testing frameworks like JSDOM don't support MutationObserver
         // https://github.com/jsdom/jsdom/issues/639
-        // use this way of getting NODE_ENV because tsdx does not support test environment
+        // use this way of getting NODE_ENV because tsdx does not support a test environment
         // https://github.com/jaredpalmer/tsdx/issues/167
-        if (process.env["NODE_ENV"] !== "test") {
+        if (typeof process !== 'undefined' && process.env["NODE_ENV"] !== "test") {
             this._observeMutations(win);
         }
     }


### PR DESCRIPTION
tsdx does not support any other environments apart from the
`production` and `development` jaredpalmer/tsdx#167

write the `process.env.NODE_ENV` as `process.env.["NODE_ENV"]` so that
tsdx does not auto replace this