### PR TITLE
chore: add tslib to deps of tabster

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -24,7 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "keyborg": "^1.0.0"
+    "keyborg": "^1.0.0",
+    "tslib": "^2.1.0"
   },
   "//": "core-js needs to be present for storybook: https://github.com/storybookjs/storybook/blob/master/MIGRATION.md#core-js-dependency-errors",
   "devDependencies": {


### PR DESCRIPTION
Currently in `dist` there are imports of `tslib`, but it's not declared as a dependency:

![image](https://user-images.githubusercontent.com/14183168/141317716-4c7310db-d228-4bfc-8afd-acf96dca9aa4.png)
https://cdn.jsdelivr.net/npm/tabster@1.0.6/dist/tabster.esm.js
