### PR TITLE
fix(Modalizer): Only apply keydown listener in uncontrolled mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,35 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Setup
+
+* npm install
+
+## Available commands
+
+### build
+
+`npm run build` - builds codebase.
+
+### start
+
+`npm start` - runs storybook.
+
+`npm start:storybook` - to run storybook in the uncontrolled codepath of tabster.
+
+### test
+
+`npm run test` - to run all tests
+
+`npm run test:uncontrolled` - to run all tests in the uncontrolled codepath of tabster.
+
+Tests need to be run in browser, so make sure storybook is running before running tests.
+
+### format
+
+`npm run format` - to use prettier to format the codebase.
+
+### lint
+
+`npm run lint` - runs eslint on the codebase.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Setup
 
-* npm install
+-   npm install
 
 ## Available commands
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
         "lint": "eslint src/ --fix",
         "lint:check": "eslint src/",
         "test": "jest",
+        "test:uncontrolled": "STORYBOOK_UNCONTROLLED=true npm test",
         "prepublishOnly": "npm run build",
         "serve": "npx http-serve storybook-static",
         "start": "npm run storybook",
+        "start:uncontrolled": "STORYBOOK_UNCONTROLLED=true npm run storybook",
         "storybook": "start-storybook -p 8080"
     },
     "dependencies": {

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -83,7 +83,7 @@ export class Modalizer
         this._moveOutWithDefault = moveOutWithDefault;
         this._onActiveChange = onActiveChange;
         if (!tabster.controlTab) {
-         element.addEventListener("keydown", this._onKeyDown);
+            element.addEventListener("keydown", this._onKeyDown);
         }
 
         const parentElement = element.parentElement;

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -82,7 +82,9 @@ export class Modalizer
         this._onDispose = onDispose;
         this._moveOutWithDefault = moveOutWithDefault;
         this._onActiveChange = onActiveChange;
-        element.addEventListener("keydown", this._onKeyDown);
+        if (!tabster.controlTab) {
+         element.addEventListener("keydown", this._onKeyDown);
+        }
 
         const parentElement = element.parentElement;
         if (parentElement) {

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -284,6 +284,7 @@ export class Modalizer
     }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function validateModalizerProps(props: Types.ModalizerProps): void {
     // TODO: Implement validation.
 }

--- a/src/__tests__/Modalizer.test.tsx
+++ b/src/__tests__/Modalizer.test.tsx
@@ -23,6 +23,7 @@ describe("Modalizer", () => {
                 <div aria-label="modal" id="modal" {...modalizerAttr}>
                     <button id="foo">Foo</button>
                     <button>Bar</button>
+                    <button>Baz</button>
                 </div>
             </div>
         );
@@ -85,7 +86,11 @@ describe("Modalizer", () => {
             .pressTab()
             .activeElement((el) => expect(el?.textContent).toBe("Bar"))
             .pressTab()
+            .activeElement((el) => expect(el?.textContent).toBe("Baz"))
+            .pressTab()
             .activeElement((el) => expect(el).toBeNull())
+            .pressTab(true)
+            .activeElement((el) => expect(el?.textContent).toBe("Baz"))
             .pressTab(true)
             .activeElement((el) => expect(el?.textContent).toBe("Bar"))
             .pressTab(true)


### PR DESCRIPTION
Fixes #77 by only adding the `keydown` tab handler when tabster is not
controlling tab

The current test actually worked in the buggy state 😨 because there were only 2 focusable elements inside the modalizer, so the second tab press would also find the same element and focus it. Added a third focusable element to catch this bug