### PR TITLE
fix: eslint should ignore js files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
         "plugin:@typescript-eslint/recommended",
         "prettier"
     ],
+    "ignorePatterns": ["**/*.js"],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": "tsconfig.json",


### PR DESCRIPTION
Doesn't impact CI, but removes annoying errors on the IDE even though the eslint command is not configured to lint anything other than `src`