### PR TITLE
chore(CrossOrigin): Refactor static variables to be a static function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ storybook-static
 
 # Miscellaneous user files
 *.user
-.vscode
 .DS_STORE
 .idea/*
 .vs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "prettier.configPath": ".prettierrc.json"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -414,7 +414,7 @@ class FocusElementTransaction extends CrossOriginTransaction<
 > {
     type = CrossOriginTransactionTypes.FocusElement;
 
-    static shouldSelfRespond = () => true;
+    static shouldSelfRespond () { return true; }
 
     static shouldForward(
         tabster: Types.TabsterCore,
@@ -734,7 +734,7 @@ class GetElementTransaction extends CrossOriginTransaction<
 > {
     type = CrossOriginTransactionTypes.GetElement;
 
-    static shouldSelfRespond = () => true;
+    static shouldSelfRespond() { return true; };
 
     static findElement(
         tabster: Types.TabsterCore,

--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -414,7 +414,9 @@ class FocusElementTransaction extends CrossOriginTransaction<
 > {
     type = CrossOriginTransactionTypes.FocusElement;
 
-    static shouldSelfRespond () { return true; }
+    static shouldSelfRespond() {
+        return true;
+    }
 
     static shouldForward(
         tabster: Types.TabsterCore,
@@ -734,7 +736,9 @@ class GetElementTransaction extends CrossOriginTransaction<
 > {
     type = CrossOriginTransactionTypes.GetElement;
 
-    static shouldSelfRespond() { return true; };
+    static shouldSelfRespond() {
+        return true;
+    }
 
     static findElement(
         tabster: Types.TabsterCore,


### PR DESCRIPTION
Static variables cannot be tree shaken terser/terser#724, therefore
transform the trivial arrow function to be an actual function since
`this` is never used.