### PR TITLE
chore: refactor `create` functions to be functions not variables

### DIFF
--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -716,11 +716,11 @@ export class DeloserAPI implements Types.DeloserAPI {
         (instance as DeloserAPI).dispose();
     }
 
-    static createDeloser: Types.DeloserConstructor = (
+    static createDeloser(
         tabster: Types.TabsterInternal,
         element: HTMLElement,
         props: Types.DeloserProps
-    ): Types.Deloser => {
+    ): Types.Deloser {
         if (__DEV__) {
             validateDeloserProps(props);
         }
@@ -739,7 +739,7 @@ export class DeloserAPI implements Types.DeloserAPI {
         }
 
         return deloser;
-    };
+    }
 
     getActions(element: HTMLElement): Types.DeloserElementActions | undefined {
         for (let e: HTMLElement | null = element; e; e = e.parentElement) {

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -351,17 +351,17 @@ export class GroupperAPI
         (instance as GroupperAPI).dispose();
     }
 
-    static createGroupper: Types.GroupperConstructor = (
+    static createGroupper(
         tabster: Types.TabsterInternal,
         element: HTMLElement,
         props: Types.GroupperProps
-    ): Types.Groupper => {
+    ): Types.Groupper {
         if (__DEV__) {
             validateGroupperProps(props);
         }
 
         return new Groupper(tabster, element, props);
-    };
+    }
 
     forgetCurrentGrouppers(): void {
         this._current = {};

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -405,11 +405,11 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         (instance as ModalizerAPI).dispose();
     }
 
-    static createModalizer: Types.ModalizerConstructor = (
+    static createModalizer(
         tabster: Types.TabsterInternal,
         element: HTMLElement,
         props: Types.ModalizerProps
-    ): Types.Modalizer => {
+    ): Types.Modalizer {
         if (__DEV__) {
             validateModalizerProps(props);
         }
@@ -440,7 +440,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         }
 
         return modalizer;
-    };
+    }
 
     private _onModalizerDispose = (modalizer: Modalizer) => {
         modalizer.setActive(false);

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -571,11 +571,11 @@ export class MoverAPI implements Types.MoverAPI {
         (instance as MoverAPI).dispose();
     }
 
-    static createMover: Types.MoverConstructor = (
+    static createMover(
         tabster: Types.TabsterInternal,
         element: HTMLElement,
         props: Types.MoverProps
-    ): Types.Mover => {
+    ): Types.Mover {
         if (__DEV__) {
             validateMoverProps(props);
         }
@@ -589,7 +589,7 @@ export class MoverAPI implements Types.MoverAPI {
         );
         self._movers[newMover.id] = newMover;
         return newMover;
-    };
+    }
 
     private _onMoverDispose = (mover: Mover) => {
         delete this._movers[mover.id];

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -264,17 +264,17 @@ export class RootAPI implements Types.RootAPI {
         (instance as RootAPI).dispose();
     }
 
-    static createRoot: Types.RootConstructor = (
+    static createRoot(
         tabster: Types.TabsterInternal,
         element: HTMLElement,
         props: Types.RootProps
-    ): Types.Root => {
+    ): Types.Root {
         if (__DEV__) {
             validateRootProps(props);
         }
 
         return new Root(tabster, element, props) as Types.Root;
-    };
+    }
 
     static getRootByUId(
         getWindow: Types.GetWindow,


### PR DESCRIPTION
Using static variables breaks tree shaking of entire classes