### PR TITLE
fix: remove postinstall script to fix package installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "url": "git+https://github.com/microsoft/tabster"
     },
     "scripts": {
-        "build": "npm run clean && npm run build-bundle && npm run build-docs && npm run build-storybook",
+        "build": "npm run clean && npm run build-bundle && npm run build-storybook",
         "build-bundle": "rollup -c",
         "build-docs": "cd docs && npm run build",
         "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "lint:check": "eslint src/",
         "test": "jest",
         "test:uncontrolled": "STORYBOOK_UNCONTROLLED=true npm test",
-        "postinstall": "cd docs && npm install",
         "prepublishOnly": "npm run build",
         "release": "release-it",
         "serve": "npx http-serve storybook-static",


### PR DESCRIPTION
All `tabster` releases are unusable because the `postinstall` step is
trying to `cd` into a directory that does not exist in the published
artifact.

Also removes the `build-docs` command from the `build` command until we docs is intergrated into the repo correctly