### PR TITLE
chore: remove unused packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26518,21 +26518,6 @@
                 "microevent.ts": "~0.1.1"
             }
         },
-        "workspace-tools": {
-            "version": "0.18.2",
-            "resolved": "https://registry.npmjs.org/workspace-tools/-/workspace-tools-0.18.2.tgz",
-            "integrity": "sha512-XEW7VrD5XmYNLli89cHGQESf6Jgh45ELlKJQHbAAwd67XfC+Tf+hpJZ+GLFsKPIzJ+xIUvnJE6F71ScsMfu7KA==",
-            "dev": true,
-            "requires": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "find-up": "^4.1.0",
-                "git-url-parse": "^11.1.2",
-                "globby": "^11.0.0",
-                "jju": "^1.4.0",
-                "multimatch": "^4.0.0",
-                "read-yaml-file": "^2.0.0"
-            }
-        },
         "wrap-ansi": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
         "tslib": "^2.3.1"
     },
     "devDependencies": {
-        "@azure/data-tables": "^13.0.0",
         "@babel/core": "^7.16.7",
         "@babel/plugin-proposal-class-properties": "^7.16.7",
         "@babel/plugin-transform-react-jsx": "^7.16.7",
@@ -90,7 +89,6 @@
         "rollup-plugin-sourcemaps": "^0.6.3",
         "rollup-plugin-typescript2": "^0.31.1",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
-        "typescript": "^4.5.4",
-        "workspace-tools": "^0.18.2"
+        "typescript": "^4.5.4"
     }
 }


### PR DESCRIPTION
Fixes #89.

Used version in this repo (1.1.4) already has required packages as dependencies:

https://github.com/microsoft/fluentui/blob/63afcc3438d77ac815a683f79898854922263a27/packages/bundle-size/package.json#L13-L26