### PR TITLE
fix: Support typescript 3.9 and rollup types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ storybook-static
 .idea/*
 .vs
 
-/dist
+dist/
+dts/
 /.rts2*
 /.rollup.cache
-

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ storybook-static
 
 /dist
 /.rts2*
+/.rollup.cache
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.2.2",
             "license": "MIT",
             "dependencies": {
+                "@rollup/plugin-typescript": "^8.3.1",
                 "keyborg": "^1.1.0",
                 "tslib": "^2.3.1"
             },
@@ -4506,11 +4507,27 @@
                 "rollup": "^1.20.0 || ^2.0.0"
             }
         },
+        "node_modules/@rollup/plugin-typescript": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.1.tgz",
+            "integrity": "sha512-84rExe3ICUBXzqNX48WZV2Jp3OddjTMX97O2Py6D1KJaGSwWp0mDHXj+bCGNJqWHIEKDIT2U0sDjhP4czKi6cA==",
+            "dependencies": {
+                "@rollup/pluginutils": "^3.1.0",
+                "resolve": "^1.17.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.14.0",
+                "tslib": "*",
+                "typescript": ">=3.7.0"
+            }
+        },
         "node_modules/@rollup/pluginutils": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
             "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-            "dev": true,
             "dependencies": {
                 "@types/estree": "0.0.39",
                 "estree-walker": "^1.0.1",
@@ -4526,8 +4543,7 @@
         "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
             "version": "0.0.39",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-            "dev": true
+            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
         },
         "node_modules/@sideway/address": {
             "version": "4.1.3",
@@ -16554,8 +16570,7 @@
         "node_modules/estree-walker": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-            "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-            "dev": true
+            "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
         },
         "node_modules/esutils": {
             "version": "2.0.3",
@@ -18162,7 +18177,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -18175,8 +18189,7 @@
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.5",
@@ -18600,7 +18613,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1"
             },
@@ -19816,7 +19828,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
             "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-            "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
             },
@@ -26494,8 +26505,7 @@
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "node_modules/path-strip-sep": {
             "version": "1.0.10",
@@ -26553,7 +26563,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -28508,7 +28517,6 @@
             "version": "1.22.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
             "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-            "dev": true,
             "dependencies": {
                 "is-core-module": "^2.8.1",
                 "path-parse": "^1.0.7",
@@ -28656,7 +28664,6 @@
             "version": "2.67.2",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.2.tgz",
             "integrity": "sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==",
-            "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -30296,7 +30303,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -31029,7 +31035,6 @@
             "version": "4.5.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -36414,11 +36419,19 @@
                 "magic-string": "^0.25.7"
             }
         },
+        "@rollup/plugin-typescript": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.1.tgz",
+            "integrity": "sha512-84rExe3ICUBXzqNX48WZV2Jp3OddjTMX97O2Py6D1KJaGSwWp0mDHXj+bCGNJqWHIEKDIT2U0sDjhP4czKi6cA==",
+            "requires": {
+                "@rollup/pluginutils": "^3.1.0",
+                "resolve": "^1.17.0"
+            }
+        },
         "@rollup/pluginutils": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
             "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-            "dev": true,
             "requires": {
                 "@types/estree": "0.0.39",
                 "estree-walker": "^1.0.1",
@@ -36428,8 +36441,7 @@
                 "@types/estree": {
                     "version": "0.0.39",
                     "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-                    "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-                    "dev": true
+                    "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
                 }
             }
         },
@@ -45868,8 +45880,7 @@
         "estree-walker": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-            "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-            "dev": true
+            "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
         },
         "esutils": {
             "version": "2.0.3",
@@ -47152,14 +47163,12 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "optional": true
         },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "function.prototype.name": {
             "version": "1.1.5",
@@ -47478,7 +47487,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -48396,7 +48404,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
             "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-            "dev": true,
             "requires": {
                 "has": "^1.0.3"
             }
@@ -53544,8 +53551,7 @@
         "path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "path-strip-sep": {
             "version": "1.0.10",
@@ -53596,8 +53602,7 @@
         "picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
         },
         "pify": {
             "version": "4.0.1",
@@ -55094,7 +55099,6 @@
             "version": "1.22.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
             "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-            "dev": true,
             "requires": {
                 "is-core-module": "^2.8.1",
                 "path-parse": "^1.0.7",
@@ -55204,7 +55208,6 @@
             "version": "2.67.2",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.2.tgz",
             "integrity": "sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==",
-            "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
             }
@@ -56530,8 +56533,7 @@
         "supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "dev": true
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
         },
         "symbol-tree": {
             "version": "3.2.4",
@@ -57093,8 +57095,7 @@
         "typescript": {
             "version": "4.5.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-            "dev": true
+            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
         },
         "uglify-js": {
             "version": "3.15.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
                 "release-it": "^14.12.4",
                 "rimraf": "^3.0.2",
                 "rollup": "^2.67.2",
+                "rollup-plugin-dts": "^4.2.0",
                 "rollup-plugin-sourcemaps": "^0.6.3",
                 "rollup-plugin-typescript2": "^0.31.2",
                 "tsconfig-paths-webpack-plugin": "^3.5.2",
@@ -28666,6 +28667,40 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/rollup-plugin-dts": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.0.tgz",
+            "integrity": "sha512-lx6irWVhz/x4//tIqRhzk4FOqGQ0n37ZM2wpPCn4uafl/EmiV92om7ZdAsq7Bzho6C+Xh5GfsyuP9H+Udv72Lg==",
+            "dev": true,
+            "dependencies": {
+                "magic-string": "^0.26.1"
+            },
+            "engines": {
+                "node": ">=v12.22.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Swatinem"
+            },
+            "optionalDependencies": {
+                "@babel/code-frame": "^7.16.7"
+            },
+            "peerDependencies": {
+                "rollup": "^2.55",
+                "typescript": "^4.1"
+            }
+        },
+        "node_modules/rollup-plugin-dts/node_modules/magic-string": {
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.1.tgz",
+            "integrity": "sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==",
+            "dev": true,
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/rollup-plugin-sourcemaps": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz",
@@ -55172,6 +55207,27 @@
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
+            }
+        },
+        "rollup-plugin-dts": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.0.tgz",
+            "integrity": "sha512-lx6irWVhz/x4//tIqRhzk4FOqGQ0n37ZM2wpPCn4uafl/EmiV92om7ZdAsq7Bzho6C+Xh5GfsyuP9H+Udv72Lg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.16.7",
+                "magic-string": "^0.26.1"
+            },
+            "dependencies": {
+                "magic-string": {
+                    "version": "0.26.1",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.1.tgz",
+                    "integrity": "sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==",
+                    "dev": true,
+                    "requires": {
+                        "sourcemap-codec": "^1.4.8"
+                    }
+                }
             }
         },
         "rollup-plugin-sourcemaps": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@rollup/plugin-replace": "^3.1.0",
-        "@rollup/plugin-typescript": "^8.3.1",
         "@storybook/addon-actions": "^6.4.19",
         "@storybook/addon-essentials": "^6.4.19",
         "@storybook/addon-links": "^6.4.19",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@rollup/plugin-replace": "^3.1.0",
+        "@rollup/plugin-typescript": "^8.3.1",
         "@storybook/addon-actions": "^6.4.19",
         "@storybook/addon-essentials": "^6.4.19",
         "@storybook/addon-links": "^6.4.19",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "release-it": "^14.12.4",
         "rimraf": "^3.0.2",
         "rollup": "^2.67.2",
+        "rollup-plugin-dts": "^4.2.0",
         "rollup-plugin-sourcemaps": "^0.6.3",
         "rollup-plugin-typescript2": "^0.31.2",
         "tsconfig-paths-webpack-plugin": "^3.5.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import { babel } from "@rollup/plugin-babel";
 import json from "@rollup/plugin-json";
 import replace from "@rollup/plugin-replace";
 import typescript from "rollup-plugin-typescript2";
+import dts from "rollup-plugin-dts";
 
 import pkg from "./package.json";
 
@@ -13,35 +14,47 @@ const extensions = [".ts"];
 /**
  * @type {import('rollup').RollupOptions}
  */
-const config = {
-    input: "./src/index.ts",
-    output: [
-        { file: pkg.main, format: "cjs", sourcemap: true },
-        { file: pkg.module, format: "es", sourcemap: true },
-    ],
-    external: ["tslib", "keyborg"],
-    plugins: [
-        typescript({
-            tsconfig: "src/tsconfig.lib.json",
-            tsconfigOverride: {
-                compilerOptions: { emitDeclarationOnly: false },
-            },
-        }),
-        babel({
-            babelHelpers: "bundled",
-            extensions,
-            exclude: "node_modules/**",
-        }),
-        json(),
-        replace({
-            preventAssignment: true,
-            __DEV__: `process.env.NODE_ENV === 'development'`,
-            __VERSION__: JSON.stringify(pkg.version),
-        }),
-        commonjs({ extensions }),
-        resolve({ extensions, mainFields: ["module", "main"] }),
-        sourceMaps(),
-    ],
-};
+const config = [
+    {
+        input: "./src/index.ts",
+        output: [
+            { file: pkg.main, format: "cjs", sourcemap: true },
+            { file: pkg.module, format: "es", sourcemap: true },
+        ],
+        external: ["tslib", "keyborg"],
+        plugins: [
+            typescript({
+                useTsconfigDeclarationDir: true,
+                tsconfig: "src/tsconfig.lib.json",
+                tsconfigOverride: {
+                    compilerOptions: {
+                        // https://github.com/ezolenko/rollup-plugin-typescript2/issues/268
+                        emitDeclarationOnly: true,
+                    },
+                },
+            }),
+            babel({
+                babelHelpers: "bundled",
+                extensions,
+                exclude: "node_modules/**",
+            }),
+            json(),
+            replace({
+                preventAssignment: true,
+                __DEV__: `process.env.NODE_ENV === 'development'`,
+                __VERSION__: JSON.stringify(pkg.version),
+            }),
+            commonjs({ extensions }),
+            resolve({ extensions, mainFields: ["module", "main"] }),
+            sourceMaps(),
+        ],
+    },
+    {
+        // path to your declaration files root
+        input: "./dist/dts/index.d.ts",
+        output: [{ file: "dist/index.d.ts", format: "es" }],
+        plugins: [dts()],
+    },
+];
 
 export default config;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import sourceMaps from "rollup-plugin-sourcemaps";
 import { babel } from "@rollup/plugin-babel";
 import json from "@rollup/plugin-json";
 import replace from "@rollup/plugin-replace";
-import typescript from "@rollup/plugin-typescript";
+import typescript from "rollup-plugin-typescript2";
 import dts from "rollup-plugin-dts";
 
 import pkg from "./package.json";
@@ -24,8 +24,14 @@ const config = [
         external: ["tslib", "keyborg"],
         plugins: [
             typescript({
-                tsconfig: "./src/tsconfig.lib.json",
-                emitDeclarationOnly: true,
+                useTsconfigDeclarationDir: true,
+                tsconfig: "src/tsconfig.lib.json",
+                tsconfigOverride: {
+                    compilerOptions: {
+                        // https://github.com/ezolenko/rollup-plugin-typescript2/issues/268
+                        emitDeclarationOnly: false,
+                    },
+                },
             }),
             babel({
                 babelHelpers: "bundled",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import sourceMaps from "rollup-plugin-sourcemaps";
 import { babel } from "@rollup/plugin-babel";
 import json from "@rollup/plugin-json";
 import replace from "@rollup/plugin-replace";
-import typescript from "rollup-plugin-typescript2";
+import typescript from "@rollup/plugin-typescript";
 import dts from "rollup-plugin-dts";
 
 import pkg from "./package.json";
@@ -24,14 +24,8 @@ const config = [
         external: ["tslib", "keyborg"],
         plugins: [
             typescript({
-                useTsconfigDeclarationDir: true,
-                tsconfig: "src/tsconfig.lib.json",
-                tsconfigOverride: {
-                    compilerOptions: {
-                        // https://github.com/ezolenko/rollup-plugin-typescript2/issues/268
-                        emitDeclarationOnly: true,
-                    },
-                },
+                tsconfig: "./src/tsconfig.lib.json",
+                emitDeclarationOnly: true,
             }),
             babel({
                 babelHelpers: "bundled",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,9 +44,10 @@ const config = [
         ],
     },
     {
-        // path to your declaration files root
         input: "./dist/dts/index.d.ts",
         output: [{ file: "dist/index.d.ts", format: "es" }],
+        // rolls up all dts files into a single dts file
+        // so that internal types don't leak
         plugins: [dts()],
     },
 ];

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -24,7 +24,6 @@ import {
     createElementTreeWalker,
     createWeakMap,
     disposeInstanceContext,
-    setBasics as overrideBasics,
     startFakeWeakRefsCleanup,
     stopFakeWeakRefsCleanupAndClearStorage,
 } from "./Utils";
@@ -253,8 +252,6 @@ class Tabster implements Types.TabsterCore, Types.TabsterInternal {
         cleanupFakeWeakRefs(tabster.getWindow, true);
     }
 }
-
-export { overrideBasics };
 
 export function forceCleanup(tabster: Tabster): void {
     // The only legit case for calling this method is when you've completely removed

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -9,12 +9,6 @@ export const DeloserEventName = "tabster:deloser";
 export const ModalizerEventName = "tabster:modalizer";
 export const MoverEventName = "tabster:mover";
 
-export interface InternalBasics {
-    Promise?: PromiseConstructor;
-    WeakRef?: WeakRefConstructor;
-    WeakMap?: WeakMapConstructor;
-}
-
 export interface TabsterEventWithDetails<D> extends Event {
     details: D;
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -31,7 +31,7 @@ export interface TabsterDOMRect {
 
 export interface InstanceContext {
     elementByUId: { [uid: string]: WeakHTMLElement<HTMLElementWithUID> };
-    basics: Types.InternalBasics;
+    basics: InternalBasics;
     WeakRef?: WeakRefConstructor;
     containerBoundingRectCache: {
         [id: string]: {
@@ -589,10 +589,16 @@ export function getWeakRef(
     return context.basics.WeakRef;
 }
 
-export function setBasics(win: Window, basics: Types.InternalBasics): void {
+interface InternalBasics {
+    Promise?: PromiseConstructor;
+    WeakRef?: WeakRefConstructor;
+    WeakMap?: WeakMapConstructor;
+}
+
+export function setBasics(win: Window, basics: InternalBasics): void {
     const context = getInstanceContext(() => win);
 
-    let key: keyof Types.InternalBasics;
+    let key: keyof InternalBasics;
 
     key = "Promise";
     if (key in basics) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ export {
     getOutline,
     getCurrentTabster,
     getInternal,
-    overrideBasics,
     makeNoOp,
     isNoOp,
     Types,

--- a/src/tsconfig.lib.json
+++ b/src/tsconfig.lib.json
@@ -2,8 +2,8 @@
     "extends": "../tsconfig.json",
     "compilerOptions": {
         "target": "ES2019",
-        "outDir": "dist",
-        "declarationDir": "dts",
+        "outDir": "../dist",
+        "declarationDir": "../dist/dts",
         "sourceMap": true
     },
     "include": ["**/*.ts"]

--- a/src/tsconfig.lib.json
+++ b/src/tsconfig.lib.json
@@ -2,7 +2,8 @@
     "extends": "../tsconfig.json",
     "compilerOptions": {
         "target": "ES2019",
-        "outDir": "../dist",
+        "outDir": "dist",
+        "declarationDir": "dts",
         "sourceMap": true
     },
     "include": ["**/*.ts"]


### PR DESCRIPTION
Removes `overrideBasic` from exports since it was never used downstream.

Also rollup types into a single `index.d.ts` file with rollup to avoid
leaking internal types to consumers.

The result is that tabster can be built with Typescript 3.9