### PR TITLE
Strip internal tabster APIs with `@internal` and have single `TabsterCore` type usage

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,7 @@ const config = [
                     compilerOptions: {
                         // https://github.com/ezolenko/rollup-plugin-typescript2/issues/268
                         emitDeclarationOnly: false,
+                        stripInternal: true,
                     },
                 },
             }),

--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -594,7 +594,7 @@ class StateTransaction extends CrossOriginTransaction<
             transactions.ctx.focusOwnerTimestamp = timestamp;
 
             if (!isSelfResponse && beginData.rootUId && beginData.deloserUId) {
-                const deloserAPI = (tabster as Types.TabsterInternal).deloser;
+                const deloserAPI = tabster.deloser;
 
                 if (deloserAPI) {
                     const history = DeloserAPI.getHistory(deloserAPI);
@@ -621,7 +621,7 @@ class StateTransaction extends CrossOriginTransaction<
 
             CrossOriginFocusedElementState.setVal(
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                (tabster as Types.TabsterInternal).crossOrigin!.focusedElement,
+                tabster.crossOrigin!.focusedElement,
                 element,
                 {
                     isFocusedProgrammatically:
@@ -647,7 +647,7 @@ class StateTransaction extends CrossOriginTransaction<
         ) {
             CrossOriginFocusedElementState.setVal(
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                (tabster as Types.TabsterInternal).crossOrigin!.focusedElement,
+                tabster.crossOrigin!.focusedElement,
                 undefined,
                 {}
             );
@@ -666,7 +666,7 @@ class StateTransaction extends CrossOriginTransaction<
         if (name && element) {
             CrossOriginObservedElementState.trigger(
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                (tabster as Types.TabsterInternal).crossOrigin!.observedElement,
+                tabster.crossOrigin!.observedElement,
                 element,
                 { name, details: beginData.observedDetails }
             );
@@ -689,7 +689,7 @@ class StateTransaction extends CrossOriginTransaction<
 
         return forwardResult.then(() => {
             if (deadUId === transactions.ctx.focusOwner) {
-                const deloserAPI = (tabster as Types.TabsterInternal).deloser;
+                const deloserAPI = tabster.deloser;
 
                 if (deloserAPI) {
                     DeloserAPI.forceRestoreFocus(deloserAPI);
@@ -727,7 +727,7 @@ class StateTransaction extends CrossOriginTransaction<
         if (context.origOutlineSetup) {
             context.origOutlineSetup.call(
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                (tabster as Types.TabsterInternal).outline!,
+                tabster.outline!,
                 props
             );
         }
@@ -771,9 +771,9 @@ class GetElementTransaction extends CrossOriginTransaction<
                 element = ref && ref.get();
             } else if (data.observedName) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                element = (
-                    tabster as Types.TabsterInternal
-                ).observedElement!.getElement(data.observedName);
+                element = tabster.observedElement!.getElement(
+                    data.observedName
+                );
             }
         }
 
@@ -846,7 +846,7 @@ class GetElementTransaction extends CrossOriginTransaction<
                     let isResolved = false;
 
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    (tabster as Types.TabsterInternal)
+                    tabster
                         .observedElement!.waitElement(
                             name,
                             timeout,
@@ -922,7 +922,7 @@ class RestoreFocusInDeloserTransaction extends CrossOriginTransaction<
         const begin = !forwardRet && data.beginData;
         const uid = begin && begin.deloserUId;
         const deloser = uid && transactions.ctx.deloserByUId[uid];
-        const deloserAPI = (tabster as Types.TabsterInternal).deloser;
+        const deloserAPI = tabster.deloser;
 
         if (begin && deloser && deloserAPI) {
             const history = DeloserAPI.getHistory(deloserAPI);
@@ -1397,8 +1397,7 @@ class CrossOriginTransactions {
                     force: true,
                 });
 
-                const deloserAPI = (this._tabster as Types.TabsterInternal)
-                    .deloser;
+                const deloserAPI = this._tabster.deloser;
 
                 if (deloserAPI) {
                     DeloserAPI.forceRestoreFocus(deloserAPI);
@@ -1468,9 +1467,7 @@ export class CrossOriginElement implements Types.CrossOriginElement {
         noAccessibleCheck?: boolean
     ): Promise<boolean> {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return (
-            this._tabster as Types.TabsterInternal
-        ).crossOrigin!.focusedElement.focus(
+        return this._tabster.crossOrigin!.focusedElement.focus(
             this,
             noFocusedProgrammaticallyFlag,
             noAccessibleCheck
@@ -1639,9 +1636,7 @@ export class CrossOriginObservedElementState
         ).then((element) =>
             this._lastRequestFocusId === requestId && element
                 ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  (
-                      this._tabster as Types.TabsterInternal
-                  ).crossOrigin!.focusedElement.focus(element, true)
+                  this._tabster.crossOrigin!.focusedElement.focus(element, true)
                 : false
         );
     }
@@ -1668,7 +1663,7 @@ export class CrossOriginAPI implements Types.CrossOriginAPI {
 
     constructor(tabster: Types.TabsterCore) {
         this._tabster = tabster;
-        this._win = (tabster as Types.TabsterInternal).getWindow;
+        this._win = tabster.getWindow;
         this._ctx = {
             ignoreKeyboardNavigationStateUpdate: false,
             deloserByUId: {},
@@ -1713,18 +1708,13 @@ export class CrossOriginAPI implements Types.CrossOriginAPI {
         );
         tabster.focusedElement.subscribe(this._onFocus);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        (tabster as Types.TabsterInternal).observedElement!.subscribe(
-            this._onObserved
-        );
+        tabster.observedElement!.subscribe(this._onObserved);
 
         if (!this._ctx.origOutlineSetup) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            this._ctx.origOutlineSetup = (
-                tabster as Types.TabsterInternal
-            ).outline!.setup;
+            this._ctx.origOutlineSetup = tabster.outline!.setup;
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            (tabster as Types.TabsterInternal).outline!.setup =
-                this._outlineSetup;
+            tabster.outline!.setup = this._outlineSetup;
         }
 
         this._transactions
@@ -1763,9 +1753,7 @@ export class CrossOriginAPI implements Types.CrossOriginAPI {
             this._onKeyboardNavigationStateChanged
         );
         tabster.focusedElement.unsubscribe(this._onFocus);
-        (tabster as Types.TabsterInternal).observedElement?.unsubscribe(
-            this._onObserved
-        );
+        tabster.observedElement?.unsubscribe(this._onObserved);
 
         this._transactions.dispose();
         CrossOriginFocusedElementState.dispose(this.focusedElement);

--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -50,7 +50,7 @@ export class DeloserItem extends DeloserItemBase<Types.Deloser> {
     }
 
     async resetFocus(): Promise<boolean> {
-        const getWindow = (this._tabster as Types.TabsterInternal).getWindow;
+        const getWindow = this._tabster.getWindow;
         return getPromise(getWindow).resolve(this._deloser.resetFocus());
     }
 }
@@ -362,7 +362,7 @@ export class Deloser
     private _onDispose: (deloser: Deloser) => void;
 
     constructor(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         onDispose: (deloser: Deloser) => void,
         props: Types.DeloserProps
@@ -670,7 +670,7 @@ export class DeloserAPI implements Types.DeloserAPI {
         props?: { autoDeloser: Types.DeloserProps }
     ) {
         this._tabster = tabster;
-        this._win = (tabster as Types.TabsterInternal).getWindow;
+        this._win = tabster.getWindow;
         this._history = new DeloserHistory(tabster);
         this._initTimer = this._win().setTimeout(this._init, 0);
 
@@ -717,7 +717,7 @@ export class DeloserAPI implements Types.DeloserAPI {
     }
 
     static createDeloser(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         props: Types.DeloserProps
     ): Types.Deloser {
@@ -878,8 +878,7 @@ export class DeloserAPI implements Types.DeloserAPI {
             }
         }
 
-        const tabsteri = tabster as Types.TabsterInternal;
-        const deloserAPI = tabsteri.deloser && (tabsteri.deloser as DeloserAPI);
+        const deloserAPI = tabster.deloser && (tabster.deloser as DeloserAPI);
 
         if (deloserAPI) {
             if (deloserAPI._autoDeloserInstance) {
@@ -893,9 +892,9 @@ export class DeloserAPI implements Types.DeloserAPI {
 
                 if (body) {
                     deloserAPI._autoDeloserInstance = new Deloser(
-                        tabsteri,
+                        tabster,
                         body,
-                        (tabsteri.deloser as DeloserAPI)._onDeloserDispose,
+                        (tabster.deloser as DeloserAPI)._onDeloserDispose,
                         autoDeloserProps
                     );
                 }

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -48,7 +48,7 @@ export class Groupper
     _dummyManager?: GroupperDummyManager;
 
     constructor(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         onDispose: (groupper: Groupper) => void,
         props: Types.GroupperProps
@@ -364,7 +364,7 @@ export class GroupperAPI
     }
 
     static createGroupper(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         props: Types.GroupperProps
     ): Types.Groupper {

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -9,11 +9,11 @@ export function getTabsterOnElement(
     tabster: Types.TabsterCore,
     element: HTMLElement
 ): Types.TabsterOnElement | undefined {
-    return (tabster as Types.TabsterInternal).storageEntry(element)?.tabster;
+    return tabster.storageEntry(element)?.tabster;
 }
 
 export function updateTabsterByAttribute(
-    tabster: Types.TabsterInternal,
+    tabster: Types.TabsterCore,
     element: HTMLElement,
     dispose?: boolean
 ): void {
@@ -21,9 +21,8 @@ export function updateTabsterByAttribute(
         dispose || tabster._noop
             ? undefined
             : element.getAttribute(Types.TabsterAttributeName);
-    const tabsteri = tabster as Types.TabsterInternal;
 
-    let entry = tabsteri.storageEntry(element);
+    let entry = tabster.storageEntry(element);
     let newAttr: Types.TabsterAttributeOnElement | undefined;
 
     if (newAttrValue) {
@@ -60,7 +59,7 @@ export function updateTabsterByAttribute(
 
     if (!entry) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        entry = (tabster as Types.TabsterInternal).storageEntry(element, true)!;
+        entry = tabster.storageEntry(element, true)!;
     }
 
     if (!entry.tabster) {
@@ -79,13 +78,13 @@ export function updateTabsterByAttribute(
                 const root = tabsterOnElement[key];
 
                 if (root) {
-                    tabsteri.updateRoot(root, true);
+                    tabster.updateRoot(root, true);
                 }
             } else if (key === "modalizer") {
                 const modalizer = tabsterOnElement.modalizer;
 
-                if (tabsteri.updateModalizer && modalizer) {
-                    tabsteri.updateModalizer(modalizer, true);
+                if (tabster.updateModalizer && modalizer) {
+                    tabster.updateModalizer(modalizer, true);
                 }
             }
 
@@ -105,8 +104,8 @@ export function updateTabsterByAttribute(
 
                 case "observed":
                     delete tabsterOnElement[key];
-                    if (tabsteri.updateObserved) {
-                        tabsteri.updateObserved(element);
+                    if (tabster.updateObserved) {
+                        tabster.updateObserved(element);
                     }
                     break;
 
@@ -129,9 +128,9 @@ export function updateTabsterByAttribute(
                         newTabsterProps.deloser as Types.DeloserProps
                     );
                 } else {
-                    if (tabsteri.createDeloser) {
-                        tabsterOnElement.deloser = tabsteri.createDeloser(
-                            tabsteri,
+                    if (tabster.createDeloser) {
+                        tabsterOnElement.deloser = tabster.createDeloser(
+                            tabster,
                             element,
                             newTabsterProps.deloser as Types.DeloserProps
                         );
@@ -149,13 +148,13 @@ export function updateTabsterByAttribute(
                         newTabsterProps.root as Types.RootProps
                     );
                 } else {
-                    tabsterOnElement.root = tabsteri.createRoot(
-                        tabsteri,
+                    tabsterOnElement.root = tabster.createRoot(
+                        tabster,
                         element,
                         newTabsterProps.root as Types.RootProps
                     );
                 }
-                tabsteri.updateRoot(tabsterOnElement.root);
+                tabster.updateRoot(tabsterOnElement.root);
                 break;
 
             case "modalizer":
@@ -164,9 +163,9 @@ export function updateTabsterByAttribute(
                         newTabsterProps.modalizer as Types.ModalizerProps
                     );
                 } else {
-                    if (tabsteri.createModalizer) {
-                        tabsterOnElement.modalizer = tabsteri.createModalizer(
-                            tabsteri,
+                    if (tabster.createModalizer) {
+                        tabsterOnElement.modalizer = tabster.createModalizer(
+                            tabster,
                             element,
                             newTabsterProps.modalizer as Types.ModalizerProps
                         );
@@ -188,9 +187,9 @@ export function updateTabsterByAttribute(
                         newTabsterProps.groupper as Types.GroupperProps
                     );
                 } else {
-                    if (tabsteri.createGroupper) {
-                        tabsterOnElement.groupper = tabsteri.createGroupper(
-                            tabsteri,
+                    if (tabster.createGroupper) {
+                        tabsterOnElement.groupper = tabster.createGroupper(
+                            tabster,
                             element,
                             newTabsterProps.groupper as Types.GroupperProps
                         );
@@ -208,9 +207,9 @@ export function updateTabsterByAttribute(
                         newTabsterProps.mover as Types.MoverProps
                     );
                 } else {
-                    if (tabsteri.createMover) {
-                        tabsterOnElement.mover = tabsteri.createMover(
-                            tabsteri,
+                    if (tabster.createMover) {
+                        tabsterOnElement.mover = tabster.createMover(
+                            tabster,
                             element,
                             newTabsterProps.mover as Types.MoverProps
                         );
@@ -223,9 +222,9 @@ export function updateTabsterByAttribute(
                 break;
 
             case "observed":
-                if (tabsteri.updateObserved) {
+                if (tabster.updateObserved) {
                     tabsterOnElement.observed = newTabsterProps.observed;
-                    tabsteri.updateObserved(element);
+                    tabster.updateObserved(element);
                 } else if (__DEV__) {
                     console.error(
                         "ObservedElement API used before initializing, please call `getObservedElement()`"
@@ -238,7 +237,7 @@ export function updateTabsterByAttribute(
                 break;
 
             case "outline":
-                if (tabsteri.outline) {
+                if (tabster.outline) {
                     tabsterOnElement.outline = newTabsterProps.outline;
                 } else if (__DEV__) {
                     console.error(
@@ -261,7 +260,7 @@ export function updateTabsterByAttribute(
             delete entry.tabster;
             delete entry.attr;
         }
-        tabsteri.storageEntry(element, false);
+        tabster.storageEntry(element, false);
     }
 }
 
@@ -272,10 +271,7 @@ export function augmentAttribute(
     value?: string | null // Restore original value when undefined.
 ): void {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const entry = (tabster as Types.TabsterInternal).storageEntry(
-        element,
-        true
-    )!;
+    const entry = tabster.storageEntry(element, true)!;
 
     if (!entry.aug) {
         if (value === undefined) {
@@ -311,6 +307,6 @@ export function augmentAttribute(
 
     if (value === undefined && Object.keys(entry.aug).length === 0) {
         delete entry.aug;
-        (tabster as Types.TabsterInternal).storageEntry(element, false);
+        tabster.storageEntry(element, false);
     }
 }

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -69,7 +69,7 @@ export class Modalizer
     private _onActiveChange: (active: boolean) => void;
 
     constructor(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         onDispose: (modalizer: Modalizer) => void,
         moveOutWithDefault: (backwards: boolean) => void,
@@ -349,7 +349,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
 
     constructor(tabster: Types.TabsterCore) {
         this._tabster = tabster;
-        this._win = (tabster as Types.TabsterInternal).getWindow;
+        this._win = tabster.getWindow;
         this._initTimer = this._win().setTimeout(this._init, 0);
         this._modalizers = {};
         const documentBody = this._win().document.body;
@@ -398,7 +398,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     }
 
     static createModalizer(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         props: Types.ModalizerProps
     ): Types.Modalizer {
@@ -406,8 +406,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
             validateModalizerProps(props);
         }
 
-        const self = (tabster as Types.TabsterInternal)
-            .modalizer as ModalizerAPI;
+        const self = tabster.modalizer as ModalizerAPI;
         const modalizer = new Modalizer(
             tabster,
             element,
@@ -497,7 +496,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     }
 
     static updateModalizer(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         modalizer: Types.Modalizer,
         removed?: boolean
     ): void {

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -84,7 +84,7 @@ export class Mover
     _dummyManagner?: MoverDummyManager;
 
     constructor(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         onDispose: (mover: Mover) => void,
         props: Types.MoverProps
@@ -591,7 +591,7 @@ export class MoverAPI implements Types.MoverAPI {
     }
 
     static createMover(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         props: Types.MoverProps
     ): Types.Mover {

--- a/src/MutationEvent.ts
+++ b/src/MutationEvent.ts
@@ -15,9 +15,9 @@ import {
 
 export function observeMutations(
     doc: HTMLDocument,
-    tabster: Types.TabsterInternal,
+    tabster: Types.TabsterCore,
     updateTabsterByAttribute: (
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElementWithUID,
         dispose?: boolean
     ) => void,

--- a/src/Outline.ts
+++ b/src/Outline.ts
@@ -89,7 +89,7 @@ export class OutlineAPI implements Types.OutlineAPI {
 
     constructor(tabster: Types.TabsterCore) {
         this._tabster = tabster;
-        this._win = (tabster as Types.TabsterInternal).getWindow;
+        this._win = tabster.getWindow;
         this._initTimer = this._win().setTimeout(this._init, 0);
     }
 

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -105,7 +105,7 @@ export class Root
     private _onDispose: (root: Root) => void;
 
     constructor(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         onDispose: (root: Root) => void,
         props: Types.RootProps
@@ -251,7 +251,7 @@ export class RootAPI implements Types.RootAPI {
 
     constructor(tabster: Types.TabsterCore, autoRoot?: Types.RootProps) {
         this._tabster = tabster;
-        this._win = (tabster as Types.TabsterInternal).getWindow;
+        this._win = tabster.getWindow;
         this._initTimer = this._win().setTimeout(this._init, 0);
         this._autoRoot = autoRoot;
         this.eventTarget = new EventTarget();
@@ -290,7 +290,7 @@ export class RootAPI implements Types.RootAPI {
     }
 
     static createRoot(
-        tabster: Types.TabsterInternal,
+        tabster: Types.TabsterCore,
         element: HTMLElement,
         props: Types.RootProps
     ): Types.Root {
@@ -434,7 +434,7 @@ export class RootAPI implements Types.RootAPI {
 
                 if (body) {
                     rootAPI._autoRootInstance = new Root(
-                        rootAPI._tabster as Types.TabsterInternal,
+                        rootAPI._tabster,
                         body,
                         rootAPI._onRootDispose,
                         autoRoot

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -23,7 +23,7 @@ export class FocusedElementState
 {
     private static _lastResetElement: WeakHTMLElement | undefined;
 
-    private _tabster: Types.TabsterInternal;
+    private _tabster: Types.TabsterCore;
     private _initTimer: number | undefined;
     private _win: Types.GetWindow;
     private _nextVal:
@@ -34,7 +34,7 @@ export class FocusedElementState
         | undefined;
     private _lastVal: WeakHTMLElement | undefined;
 
-    constructor(tabster: Types.TabsterInternal, getWindow: Types.GetWindow) {
+    constructor(tabster: Types.TabsterCore, getWindow: Types.GetWindow) {
         super();
 
         this._tabster = tabster;

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -49,7 +49,7 @@ export class ObservedElementAPI
     constructor(tabster: Types.TabsterCore) {
         super();
         this._tabster = tabster;
-        this._win = (tabster as Types.TabsterInternal).getWindow;
+        this._win = tabster.getWindow;
         this._initTimer = this._win().setTimeout(this._init, 0);
     }
 

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -33,7 +33,7 @@ export { Types };
 /**
  * Extends Window to include an internal Tabster instance.
  */
-class Tabster implements Types.TabsterCore, Types.TabsterInternal {
+class Tabster implements Types.TabsterCore {
     private _storage: WeakMap<HTMLElement, Types.TabsterElementStorage>;
     private _unobserve: (() => void) | undefined;
     private _win: WindowWithTabsterInstance | undefined;
@@ -289,18 +289,16 @@ export function createTabster(
  * @param tabster Tabster instance
  */
 export function getGroupper(tabster: Types.TabsterCore): Types.GroupperAPI {
-    const tabsterInternal = tabster as Types.TabsterInternal;
-
-    if (!tabsterInternal.groupper) {
-        const groupper = new GroupperAPI(tabster, tabsterInternal.getWindow);
-        tabsterInternal.groupper = groupper;
-        tabsterInternal.createGroupper = GroupperAPI.createGroupper;
-        tabsterInternal.groupperDispose = () => {
+    if (!tabster.groupper) {
+        const groupper = new GroupperAPI(tabster, tabster.getWindow);
+        tabster.groupper = groupper;
+        tabster.createGroupper = GroupperAPI.createGroupper;
+        tabster.groupperDispose = () => {
             GroupperAPI.dispose(groupper);
         };
     }
 
-    return tabsterInternal.groupper;
+    return tabster.groupper;
 }
 
 /**
@@ -308,32 +306,28 @@ export function getGroupper(tabster: Types.TabsterCore): Types.GroupperAPI {
  * @param tabster Tabster instance
  */
 export function getMover(tabster: Types.TabsterCore): Types.MoverAPI {
-    const tabsterInternal = tabster as Types.TabsterInternal;
-
-    if (!tabsterInternal.mover) {
-        const mover = new MoverAPI(tabster, tabsterInternal.getWindow);
-        tabsterInternal.mover = mover;
-        tabsterInternal.createMover = MoverAPI.createMover;
-        tabsterInternal.moverDispose = () => {
+    if (!tabster.mover) {
+        const mover = new MoverAPI(tabster, tabster.getWindow);
+        tabster.mover = mover;
+        tabster.createMover = MoverAPI.createMover;
+        tabster.moverDispose = () => {
             MoverAPI.dispose(mover);
         };
     }
 
-    return tabsterInternal.mover;
+    return tabster.mover;
 }
 
 export function getOutline(tabster: Types.TabsterCore): Types.OutlineAPI {
-    const tabsterInternal = tabster as Types.TabsterInternal;
-
-    if (!tabsterInternal.outline) {
+    if (!tabster.outline) {
         const outline = new OutlineAPI(tabster);
-        tabsterInternal.outline = outline;
-        tabsterInternal.outlineDispose = () => {
+        tabster.outline = outline;
+        tabster.outlineDispose = () => {
             OutlineAPI.dispose(outline);
         };
     }
 
-    return tabsterInternal.outline;
+    return tabster.outline;
 }
 
 /**
@@ -345,18 +339,16 @@ export function getDeloser(
     tabster: Types.TabsterCore,
     props?: { autoDeloser: Types.DeloserProps }
 ): Types.DeloserAPI {
-    const tabsterInternal = tabster as Types.TabsterInternal;
-
-    if (!tabsterInternal.deloser) {
+    if (!tabster.deloser) {
         const deloser = new DeloserAPI(tabster, props);
-        tabsterInternal.deloser = deloser;
-        tabsterInternal.createDeloser = DeloserAPI.createDeloser;
-        tabsterInternal.deloserDispose = () => {
+        tabster.deloser = deloser;
+        tabster.createDeloser = DeloserAPI.createDeloser;
+        tabster.deloserDispose = () => {
             DeloserAPI.dispose(deloser);
         };
     }
 
-    return tabsterInternal.deloser;
+    return tabster.deloser;
 }
 
 /**
@@ -364,50 +356,43 @@ export function getDeloser(
  * @param tabster Tabster instance
  */
 export function getModalizer(tabster: Types.TabsterCore): Types.ModalizerAPI {
-    const tabsterInternal = tabster as Types.TabsterInternal;
-
-    if (!tabsterInternal.modalizer) {
+    if (!tabster.modalizer) {
         const modalizer = new ModalizerAPI(tabster);
-        tabsterInternal.modalizer = modalizer;
-        tabsterInternal.createModalizer = ModalizerAPI.createModalizer;
-        tabsterInternal.updateModalizer = (
+        tabster.modalizer = modalizer;
+        tabster.createModalizer = ModalizerAPI.createModalizer;
+        tabster.updateModalizer = (
             modalizer: Types.Modalizer,
             removed?: boolean
         ) => {
-            ModalizerAPI.updateModalizer(tabsterInternal, modalizer, removed);
+            ModalizerAPI.updateModalizer(tabster, modalizer, removed);
         };
-        tabsterInternal.modalizerDispose = () => {
+        tabster.modalizerDispose = () => {
             ModalizerAPI.dispose(modalizer);
         };
     }
 
-    return tabsterInternal.modalizer;
+    return tabster.modalizer;
 }
 
 export function getObservedElement(
     tabster: Types.TabsterCore
 ): Types.ObservedElementAPI {
-    const tabsterInternal = tabster as Types.TabsterInternal;
-
-    if (!tabsterInternal.observedElement) {
+    if (!tabster.observedElement) {
         const observedElement = new ObservedElementAPI(tabster);
-        tabsterInternal.observedElement = observedElement;
-        tabsterInternal.updateObserved =
-            observedElement.onObservedElementUpdate;
-        tabsterInternal.observedElementDispose = () => {
+        tabster.observedElement = observedElement;
+        tabster.updateObserved = observedElement.onObservedElementUpdate;
+        tabster.observedElementDispose = () => {
             ObservedElementAPI.dispose(observedElement);
         };
     }
 
-    return tabsterInternal.observedElement;
+    return tabster.observedElement;
 }
 
 export function getCrossOrigin(
     tabster: Types.TabsterCore
 ): Types.CrossOriginAPI {
-    const tabsterInternal = tabster as Types.TabsterInternal;
-
-    if (!tabsterInternal.crossOrigin) {
+    if (!tabster.crossOrigin) {
         getDeloser(tabster);
         getModalizer(tabster);
         getMover(tabster);
@@ -415,17 +400,17 @@ export function getCrossOrigin(
         getOutline(tabster);
         getObservedElement(tabster);
         const crossOrigin = new CrossOriginAPI(tabster);
-        tabsterInternal.crossOrigin = crossOrigin;
-        tabsterInternal.crossOriginDispose = () => {
+        tabster.crossOrigin = crossOrigin;
+        tabster.crossOriginDispose = () => {
             CrossOriginAPI.dispose(crossOrigin);
         };
     }
 
-    return tabsterInternal.crossOrigin;
+    return tabster.crossOrigin;
 }
 
 export function getInternal(tabster: Types.TabsterCore): Types.InternalAPI {
-    return (tabster as Types.TabsterInternal).internal;
+    return tabster.internal;
 }
 
 export function disposeTabster(tabster: Types.TabsterCore): void {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -31,15 +31,6 @@ export interface TabsterCoreProps {
     rootDummyInputs?: boolean;
 }
 
-export interface TabsterCore
-    extends Pick<TabsterCoreProps, "controlTab" | "rootDummyInputs"> {
-    keyboardNavigation: KeyboardNavigationState;
-    focusedElement: FocusedElementState;
-    focusable: FocusableAPI;
-    root: RootAPI;
-    uncontrolled: UncontrolledAPI;
-}
-
 export type GetTabster = () => TabsterCore;
 export type GetWindow = () => Window;
 
@@ -298,7 +289,7 @@ export interface Deloser extends TabsterPart<DeloserProps> {
 }
 
 export type DeloserConstructor = (
-    tabster: TabsterInternal,
+    tabster: TabsterCore,
     element: HTMLElement,
     props: DeloserProps
 ) => Deloser;
@@ -525,7 +516,7 @@ export interface Mover extends TabsterPart<MoverProps> {
 }
 
 export type MoverConstructor = (
-    tabster: TabsterInternal,
+    tabster: TabsterCore,
     element: HTMLElement,
     props: MoverProps
 ) => Mover;
@@ -567,7 +558,7 @@ export interface Groupper extends TabsterPart<GroupperProps> {
 }
 
 export type GroupperConstructor = (
-    tabster: TabsterInternal,
+    tabster: TabsterCore,
     element: HTMLElement,
     props: GroupperProps
 ) => Groupper;
@@ -612,7 +603,7 @@ export interface Modalizer extends TabsterPart<ModalizerProps> {
 }
 
 export type ModalizerConstructor = (
-    tabster: TabsterInternal,
+    tabster: TabsterCore,
     element: HTMLElement,
     props: ModalizerProps
 ) => Modalizer;
@@ -628,7 +619,7 @@ export interface Root extends TabsterPart<RootProps> {
 }
 
 export type RootConstructor = (
-    tabster: TabsterInternal,
+    tabster: TabsterCore,
     element: HTMLElement,
     props: RootProps
 ) => Root;
@@ -786,45 +777,77 @@ export interface InternalAPI {
     resumeObserver(syncState: boolean): void;
 }
 
-export interface TabsterInternal extends TabsterCore {
+export interface TabsterCore
+    extends Pick<TabsterCoreProps, "controlTab" | "rootDummyInputs"> {
     storageEntry(
         element: HTMLElement,
         addremove?: boolean
     ): TabsterElementStorageEntry | undefined;
     getWindow: GetWindow;
 
-    groupper?: GroupperAPI;
-    mover?: MoverAPI;
-    outline?: OutlineAPI;
-    deloser?: DeloserAPI;
-    modalizer?: ModalizerAPI;
-    observedElement?: ObservedElementAPI;
-    crossOrigin?: CrossOriginAPI;
+    keyboardNavigation: KeyboardNavigationState;
+    focusedElement: FocusedElementState;
+    focusable: FocusableAPI;
+    root: RootAPI;
     uncontrolled: UncontrolledAPI;
+
+    /** @internal */
+    groupper?: GroupperAPI;
+    /** @internal */
+    mover?: MoverAPI;
+    /** @internal */
+    outline?: OutlineAPI;
+    /** @internal */
+    deloser?: DeloserAPI;
+    /** @internal */
+    modalizer?: ModalizerAPI;
+    /** @internal */
+    observedElement?: ObservedElementAPI;
+    /** @internal */
+    crossOrigin?: CrossOriginAPI;
+    /** @internal */
     internal: InternalAPI;
 
+    /** @internal */
     groupperDispose?: DisposeFunc;
+    /** @internal */
     moverDispose?: DisposeFunc;
+    /** @internal */
     outlineDispose?: DisposeFunc;
+    /** @internal */
     rootDispose?: DisposeFunc;
+    /** @internal */
     deloserDispose?: DisposeFunc;
+    /** @internal */
     modalizerDispose?: DisposeFunc;
+    /** @internal */
     observedElementDispose?: DisposeFunc;
+    /** @internal */
     crossOriginDispose?: DisposeFunc;
 
+    /** @internal */
     createRoot: RootConstructor;
+    /** @internal */
     updateRoot: (root: Root, removed?: boolean) => void;
+    /** @internal */
     createGroupper?: GroupperConstructor;
+    /** @internal */
     createMover?: MoverConstructor;
+    /** @internal */
     createDeloser?: DeloserConstructor;
+    /** @internal */
     createModalizer?: ModalizerConstructor;
+    /** @internal */
     updateObserved?: (element: HTMLElement) => void;
+    /** @internal */
     updateModalizer?: (modalizer: Modalizer, removed?: boolean) => void;
 
     // The version of the tabster package this instance is on
+    /** @internal */
     _version: string;
 
     // No operation flag for the debugging purposes
+    /** @internal */
     _noop: boolean;
 }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -621,17 +621,13 @@ let _lastTabsterPartId = 0;
 export abstract class TabsterPart<P, D = undefined>
     implements Types.TabsterPart<P>
 {
-    protected _tabster: Types.TabsterInternal;
+    protected _tabster: Types.TabsterCore;
     protected _element: WeakHTMLElement<HTMLElement, D>;
     protected _props: P;
 
     readonly id: string;
 
-    constructor(
-        tabster: Types.TabsterInternal,
-        element: HTMLElement,
-        props: P
-    ) {
+    constructor(tabster: Types.TabsterCore, element: HTMLElement, props: P) {
         const getWindow = tabster.getWindow;
         this._tabster = tabster;
         this._element = new WeakHTMLElement(getWindow, element);
@@ -836,7 +832,7 @@ class DummyInputManagerCore {
             throw new Error("No element");
         }
 
-        this._getWindow = (tabster as Types.TabsterInternal).getWindow;
+        this._getWindow = tabster.getWindow;
 
         const instance = el.__tabsterDummy;
 

--- a/src/tsconfig.lib.json
+++ b/src/tsconfig.lib.json
@@ -4,7 +4,6 @@
         "target": "ES2019",
         "outDir": "../dist",
         "declarationDir": "../dist/dts",
-        "stripInternal": true,
         "sourceMap": true
     },
     "include": ["**/*.ts"]

--- a/src/tsconfig.lib.json
+++ b/src/tsconfig.lib.json
@@ -4,6 +4,7 @@
         "target": "ES2019",
         "outDir": "../dist",
         "declarationDir": "../dist/dts",
+        "stripInternal": true,
         "sourceMap": true
     },
     "include": ["**/*.ts"]

--- a/tests/Internal.test.tsx
+++ b/tests/Internal.test.tsx
@@ -6,8 +6,8 @@
 import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
-interface WindowWithTabsterInternal extends Window {
-    __tabsterInstance: Types.TabsterInternal;
+interface WindowWithTabsterCore extends Window {
+    __tabsterInstance: Types.TabsterCore;
 }
 
 describe("Internal", () => {
@@ -34,12 +34,12 @@ describe("Internal", () => {
                     ?.setAttribute("data-tabster", '{"groupper": {}}');
             })
             .eval(() => {
-                const tabster = (window as unknown as WindowWithTabsterInternal)
+                const tabster = (window as unknown as WindowWithTabsterCore)
                     .__tabsterInstance;
                 tabster.internal.stopObserver();
             })
             .eval((): string | void => {
-                const tabster = (window as unknown as WindowWithTabsterInternal)
+                const tabster = (window as unknown as WindowWithTabsterCore)
                     .__tabsterInstance;
                 const el1 = document.getElementById("element1");
                 const el2 = document.getElementById("element2");
@@ -58,7 +58,7 @@ describe("Internal", () => {
                     ?.setAttribute("data-tabster", '{"groupper": {}}');
             })
             .eval((): string | void => {
-                const tabster = (window as unknown as WindowWithTabsterInternal)
+                const tabster = (window as unknown as WindowWithTabsterCore)
                     .__tabsterInstance;
                 const el1 = document.getElementById("element1");
                 const el2 = document.getElementById("element2");
@@ -72,12 +72,12 @@ describe("Internal", () => {
                 expect(res).toEqual("true-false");
             })
             .eval(() => {
-                const tabster = (window as unknown as WindowWithTabsterInternal)
+                const tabster = (window as unknown as WindowWithTabsterCore)
                     .__tabsterInstance;
                 tabster.internal.resumeObserver(true);
             })
             .eval((): string | void => {
-                const tabster = (window as unknown as WindowWithTabsterInternal)
+                const tabster = (window as unknown as WindowWithTabsterCore)
                     .__tabsterInstance;
                 const el1 = document.getElementById("element1");
                 const el2 = document.getElementById("element2");

--- a/tests/KeyboardNavigationState.test.tsx
+++ b/tests/KeyboardNavigationState.test.tsx
@@ -5,7 +5,7 @@
 
 import { getTabsterAttribute } from "tabster";
 import * as BroTest from "./utils/BroTest";
-import { WindowWithTabsterInternal } from "./utils/test-utils";
+import { WindowWithTabsterCore } from "./utils/test-utils";
 
 describe("keyboard navigation state", () => {
     beforeAll(async () => {
@@ -28,7 +28,7 @@ describe("keyboard navigation state", () => {
     });
 
     const getKeyboardNavigationState = () => {
-        const win = window as unknown as WindowWithTabsterInternal;
+        const win = window as unknown as WindowWithTabsterCore;
         return win.__tabsterInstance.keyboardNavigation.isNavigatingWithKeyboard();
     };
 

--- a/tests/ObservedElement.test.tsx
+++ b/tests/ObservedElement.test.tsx
@@ -6,8 +6,8 @@
 import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
-interface WindowWithTabsterInternal extends Window {
-    __tabsterInstance: Types.TabsterInternal;
+interface WindowWithTabsterCore extends Window {
+    __tabsterInstance: Types.TabsterCore;
 }
 
 describe("Focusable", () => {
@@ -36,7 +36,7 @@ describe("Focusable", () => {
             })
             .eval((name) => {
                 return (
-                    window as unknown as WindowWithTabsterInternal
+                    window as unknown as WindowWithTabsterCore
                 ).__tabsterInstance.observedElement?.requestFocus(name, 0)
                     .result;
             }, name)
@@ -53,7 +53,7 @@ describe("Focusable", () => {
         )
             .eval((name) => {
                 const request = (
-                    window as unknown as WindowWithTabsterInternal
+                    window as unknown as WindowWithTabsterCore
                 ).__tabsterInstance.observedElement?.requestFocus(
                     name,
                     5000
@@ -81,7 +81,7 @@ describe("Focusable", () => {
             .eval(() => {
                 return new Promise((resolve) => {
                     const request1 = (
-                        window as unknown as WindowWithTabsterInternal
+                        window as unknown as WindowWithTabsterCore
                     ).__tabsterInstance.observedElement?.requestFocus(
                         "button1",
                         10005000
@@ -89,7 +89,7 @@ describe("Focusable", () => {
 
                     setTimeout(() => {
                         const request2 = (
-                            window as unknown as WindowWithTabsterInternal
+                            window as unknown as WindowWithTabsterCore
                         ).__tabsterInstance.observedElement?.requestFocus(
                             "button2",
                             10005000
@@ -154,7 +154,7 @@ describe("Focusable", () => {
         )
             .eval((name) => {
                 (
-                    window as unknown as WindowWithTabsterInternal
+                    window as unknown as WindowWithTabsterCore
                 ).__tabsterInstance.observedElement?.requestFocus(name, 100500);
             }, name)
             .wait(500)
@@ -189,7 +189,7 @@ describe("Focusable", () => {
         )
             .eval((name) => {
                 (
-                    window as unknown as WindowWithTabsterInternal
+                    window as unknown as WindowWithTabsterCore
                 ).__tabsterInstance.observedElement?.requestFocus(name, 100500);
             }, name)
             .wait(300)

--- a/tests/Root.test.tsx
+++ b/tests/Root.test.tsx
@@ -5,10 +5,9 @@
 
 import { getTabsterAttribute, Types as TabsterTypes } from "tabster";
 import * as BroTest from "./utils/BroTest";
-import { runIfControlled, WindowWithTabsterInternal } from "./utils/test-utils";
+import { runIfControlled, WindowWithTabsterCore } from "./utils/test-utils";
 
-interface WindowWithTabsterInternalAndFocusState
-    extends WindowWithTabsterInternal {
+interface WindowWithTabsterCoreAndFocusState extends WindowWithTabsterCore {
     __tabsterFocusedRoot?: {
         events: {
             elementId?: string;
@@ -130,9 +129,9 @@ runIfControlled("Root", () => {
         )
             .eval(() => {
                 const win =
-                    window as unknown as WindowWithTabsterInternalAndFocusState;
+                    window as unknown as WindowWithTabsterCoreAndFocusState;
 
-                const focusedRoot: WindowWithTabsterInternalAndFocusState["__tabsterFocusedRoot"] =
+                const focusedRoot: WindowWithTabsterCoreAndFocusState["__tabsterFocusedRoot"] =
                     (win.__tabsterFocusedRoot = {
                         events: [],
                     });
@@ -174,13 +173,12 @@ runIfControlled("Root", () => {
                 expect(el?.textContent).toEqual("Button1");
             })
             .eval(() => {
-                return (
-                    window as unknown as WindowWithTabsterInternalAndFocusState
-                ).__tabsterFocusedRoot;
+                return (window as unknown as WindowWithTabsterCoreAndFocusState)
+                    .__tabsterFocusedRoot;
             })
             .check(
                 (
-                    res: WindowWithTabsterInternalAndFocusState["__tabsterFocusedRoot"]
+                    res: WindowWithTabsterCoreAndFocusState["__tabsterFocusedRoot"]
                 ) => {
                     expect(res).toEqual({
                         events: [
@@ -202,13 +200,12 @@ runIfControlled("Root", () => {
                 expect(el?.textContent).toBeUndefined();
             })
             .eval(() => {
-                return (
-                    window as unknown as WindowWithTabsterInternalAndFocusState
-                ).__tabsterFocusedRoot;
+                return (window as unknown as WindowWithTabsterCoreAndFocusState)
+                    .__tabsterFocusedRoot;
             })
             .check(
                 (
-                    res: WindowWithTabsterInternalAndFocusState["__tabsterFocusedRoot"]
+                    res: WindowWithTabsterCoreAndFocusState["__tabsterFocusedRoot"]
                 ) => {
                     expect(res).toEqual({
                         events: [
@@ -231,13 +228,12 @@ runIfControlled("Root", () => {
                 expect(el?.textContent).toEqual("Button2");
             })
             .eval(() => {
-                return (
-                    window as unknown as WindowWithTabsterInternalAndFocusState
-                ).__tabsterFocusedRoot;
+                return (window as unknown as WindowWithTabsterCoreAndFocusState)
+                    .__tabsterFocusedRoot;
             })
             .check(
                 (
-                    res: WindowWithTabsterInternalAndFocusState["__tabsterFocusedRoot"]
+                    res: WindowWithTabsterCoreAndFocusState["__tabsterFocusedRoot"]
                 ) => {
                     expect(res).toEqual({
                         events: [
@@ -266,13 +262,12 @@ runIfControlled("Root", () => {
             })
             .pressTab(true)
             .eval(() => {
-                return (
-                    window as unknown as WindowWithTabsterInternalAndFocusState
-                ).__tabsterFocusedRoot;
+                return (window as unknown as WindowWithTabsterCoreAndFocusState)
+                    .__tabsterFocusedRoot;
             })
             .check(
                 (
-                    res: WindowWithTabsterInternalAndFocusState["__tabsterFocusedRoot"]
+                    res: WindowWithTabsterCoreAndFocusState["__tabsterFocusedRoot"]
                 ) => {
                     expect(res).toEqual({
                         events: [
@@ -302,13 +297,12 @@ runIfControlled("Root", () => {
             )
             .eval(() => {
                 document.getElementById("button1")?.focus();
-                return (
-                    window as unknown as WindowWithTabsterInternalAndFocusState
-                ).__tabsterFocusedRoot;
+                return (window as unknown as WindowWithTabsterCoreAndFocusState)
+                    .__tabsterFocusedRoot;
             })
             .check(
                 (
-                    res: WindowWithTabsterInternalAndFocusState["__tabsterFocusedRoot"]
+                    res: WindowWithTabsterCoreAndFocusState["__tabsterFocusedRoot"]
                 ) => {
                     expect(res).toEqual({
                         events: [

--- a/tests/utils/test-utils.ts
+++ b/tests/utils/test-utils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { TabsterInternal } from "../../src/Types";
+import { TabsterCore } from "../../src/Types";
 
 export const runIfControlled = !process.env.STORYBOOK_UNCONTROLLED
     ? describe
@@ -14,6 +14,6 @@ export const runIfUnControlled =
         ? describe
         : xdescribe;
 
-export interface WindowWithTabsterInternal extends Window {
-    __tabsterInstance: TabsterInternal;
+export interface WindowWithTabsterCore extends Window {
+    __tabsterInstance: TabsterCore;
 }


### PR DESCRIPTION
Refactors the types to have a single `Tabster` type and removes the `TabsterInternal` type that was used only internally (but still leaking externally).

None of the APIs marked with `@internal` will be visible to users and their types are stripped at build time. This means that even internally in the code only once `TabsterCore` type is used