### PR TITLE
use internal class functions instead of static functions

### DIFF
--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -1489,12 +1489,8 @@ export class CrossOriginFocusedElementState
         this._transactions = transactions;
     }
 
-    protected dispose() {
+    dispose() {
         super.dispose();
-    }
-
-    static dispose(instance: Types.CrossOriginFocusedElementState) {
-        (instance as CrossOriginFocusedElementState).dispose();
     }
 
     async focus(
@@ -1588,12 +1584,8 @@ export class CrossOriginObservedElementState
         this._transactions = transactions;
     }
 
-    protected dispose() {
+    dispose() {
         super.dispose();
-    }
-
-    static dispose(instance: Types.CrossOriginObservedElementState) {
-        (instance as CrossOriginObservedElementState).dispose();
     }
 
     async getElement(
@@ -1741,7 +1733,7 @@ export class CrossOriginAPI implements Types.CrossOriginAPI {
             });
     };
 
-    protected dispose(): void {
+    dispose(): void {
         if (this._initTimer) {
             this._win().clearTimeout(this._initTimer);
             this._initTimer = undefined;
@@ -1756,14 +1748,10 @@ export class CrossOriginAPI implements Types.CrossOriginAPI {
         tabster.observedElement?.unsubscribe(this._onObserved);
 
         this._transactions.dispose();
-        CrossOriginFocusedElementState.dispose(this.focusedElement);
-        CrossOriginObservedElementState.dispose(this.observedElement);
+        this.focusedElement.dispose();
+        this.observedElement.dispose();
 
         this._ctx.deloserByUId = {};
-    }
-
-    static dispose(instance: Types.CrossOriginAPI) {
-        (instance as CrossOriginAPI).dispose();
     }
 
     private _onKeyboardNavigationStateChanged = (value: boolean): void => {

--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -1489,10 +1489,6 @@ export class CrossOriginFocusedElementState
         this._transactions = transactions;
     }
 
-    dispose() {
-        super.dispose();
-    }
-
     async focus(
         element: Types.CrossOriginElement,
         noFocusedProgrammaticallyFlag?: boolean,
@@ -1582,10 +1578,6 @@ export class CrossOriginObservedElementState
         super();
         this._tabster = tabster;
         this._transactions = transactions;
-    }
-
-    dispose() {
-        super.dispose();
     }
 
     async getElement(

--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -686,7 +686,7 @@ export class DeloserAPI implements Types.DeloserAPI {
         this._tabster.focusedElement.subscribe(this._onFocus);
     };
 
-    protected dispose(): void {
+    dispose(): void {
         const win = this._win();
 
         if (this._initTimer) {
@@ -712,12 +712,7 @@ export class DeloserAPI implements Types.DeloserAPI {
         delete this._curDeloser;
     }
 
-    static dispose(instance: Types.DeloserAPI): void {
-        (instance as DeloserAPI).dispose();
-    }
-
-    static createDeloser(
-        tabster: Types.TabsterCore,
+    createDeloser(
         element: HTMLElement,
         props: Types.DeloserProps
     ): Types.Deloser {
@@ -726,16 +721,18 @@ export class DeloserAPI implements Types.DeloserAPI {
         }
 
         const deloser = new Deloser(
-            tabster,
+            this._tabster,
             element,
-            (tabster.deloser as DeloserAPI)._onDeloserDispose,
+            this._onDeloserDispose,
             props
         );
 
         if (
-            element.contains(tabster.focusedElement.getFocusedElement() ?? null)
+            element.contains(
+                this._tabster.focusedElement.getFocusedElement() ?? null
+            )
         ) {
-            (tabster.deloser as DeloserAPI)._activate(deloser);
+            this._activate(deloser);
         }
 
         return deloser;

--- a/src/Focusable.ts
+++ b/src/Focusable.ts
@@ -32,12 +32,8 @@ export class FocusableAPI implements Types.FocusableAPI {
         this._win = getWindow;
     }
 
-    protected dispose(): void {
+    dispose(): void {
         /**/
-    }
-
-    static dispose(instance: Types.FocusableAPI): void {
-        (instance as FocusableAPI).dispose();
     }
 
     private _getBody(): HTMLElement | undefined {

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -310,9 +310,7 @@ function validateGroupperProps(props: Types.GroupperProps): void {
     // TODO: Implement validation.
 }
 
-export class GroupperAPI
-    implements Types.GroupperAPI, Types.GroupperInternalAPI
-{
+export class GroupperAPI implements Types.GroupperAPI {
     private _tabster: Types.TabsterCore;
     private _initTimer: number | undefined;
     private _win: Types.GetWindow;
@@ -336,7 +334,7 @@ export class GroupperAPI
         win.addEventListener("keydown", this._onKeyDown, true);
     };
 
-    protected dispose(): void {
+    dispose(): void {
         const win = this._win();
 
         this._current = {};
@@ -359,29 +357,19 @@ export class GroupperAPI
         });
     }
 
-    static dispose(instance: Types.GroupperAPI): void {
-        (instance as GroupperAPI).dispose();
-    }
-
-    static createGroupper(
-        tabster: Types.TabsterCore,
-        element: HTMLElement,
-        props: Types.GroupperProps
-    ): Types.Groupper {
+    createGroupper(element: HTMLElement, props: Types.GroupperProps) {
         if (__DEV__) {
             validateGroupperProps(props);
         }
 
-        const self = tabster.groupper as GroupperAPI;
-
         const newGroupper = new Groupper(
-            tabster,
+            this._tabster,
             element,
-            self._onGroupperDispose,
+            this._onGroupperDispose,
             props
         );
 
-        self._grouppers[newGroupper.id] = newGroupper;
+        this._grouppers[newGroupper.id] = newGroupper;
 
         return newGroupper;
     }

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -78,13 +78,13 @@ export function updateTabsterByAttribute(
                 const root = tabsterOnElement[key];
 
                 if (root) {
-                    tabster.updateRoot(root, true);
+                    tabster.root.onRoot(root, true);
                 }
             } else if (key === "modalizer") {
                 const modalizer = tabsterOnElement.modalizer;
 
-                if (tabster.updateModalizer && modalizer) {
-                    tabster.updateModalizer(modalizer, true);
+                if (tabster.modalizer && modalizer) {
+                    tabster.modalizer.updateModalizer(modalizer, true);
                 }
             }
 
@@ -104,8 +104,10 @@ export function updateTabsterByAttribute(
 
                 case "observed":
                     delete tabsterOnElement[key];
-                    if (tabster.updateObserved) {
-                        tabster.updateObserved(element);
+                    if (tabster.observedElement) {
+                        tabster.observedElement.onObservedElementUpdate(
+                            element
+                        );
                     }
                     break;
 
@@ -128,12 +130,12 @@ export function updateTabsterByAttribute(
                         newTabsterProps.deloser as Types.DeloserProps
                     );
                 } else {
-                    if (tabster.createDeloser) {
-                        tabsterOnElement.deloser = tabster.createDeloser(
-                            tabster,
-                            element,
-                            newTabsterProps.deloser as Types.DeloserProps
-                        );
+                    if (tabster.deloser) {
+                        tabsterOnElement.deloser =
+                            tabster.deloser.createDeloser(
+                                element,
+                                newTabsterProps.deloser as Types.DeloserProps
+                            );
                     } else if (__DEV__) {
                         console.error(
                             "Deloser API used before initializing, please call `getDeloser()`"
@@ -148,13 +150,12 @@ export function updateTabsterByAttribute(
                         newTabsterProps.root as Types.RootProps
                     );
                 } else {
-                    tabsterOnElement.root = tabster.createRoot(
-                        tabster,
+                    tabsterOnElement.root = tabster.root.createRoot(
                         element,
                         newTabsterProps.root as Types.RootProps
                     );
                 }
-                tabster.updateRoot(tabsterOnElement.root);
+                tabster.root.onRoot(tabsterOnElement.root);
                 break;
 
             case "modalizer":
@@ -163,12 +164,12 @@ export function updateTabsterByAttribute(
                         newTabsterProps.modalizer as Types.ModalizerProps
                     );
                 } else {
-                    if (tabster.createModalizer) {
-                        tabsterOnElement.modalizer = tabster.createModalizer(
-                            tabster,
-                            element,
-                            newTabsterProps.modalizer as Types.ModalizerProps
-                        );
+                    if (tabster.modalizer) {
+                        tabsterOnElement.modalizer =
+                            tabster.modalizer.createModalizer(
+                                element,
+                                newTabsterProps.modalizer as Types.ModalizerProps
+                            );
                     } else if (__DEV__) {
                         console.error(
                             "Modalizer API used before initializing, please call `getModalizer()`"
@@ -187,12 +188,12 @@ export function updateTabsterByAttribute(
                         newTabsterProps.groupper as Types.GroupperProps
                     );
                 } else {
-                    if (tabster.createGroupper) {
-                        tabsterOnElement.groupper = tabster.createGroupper(
-                            tabster,
-                            element,
-                            newTabsterProps.groupper as Types.GroupperProps
-                        );
+                    if (tabster.groupper) {
+                        tabsterOnElement.groupper =
+                            tabster.groupper.createGroupper(
+                                element,
+                                newTabsterProps.groupper as Types.GroupperProps
+                            );
                     } else if (__DEV__) {
                         console.error(
                             "Groupper API used before initializing, please call `getGroupper()`"
@@ -207,9 +208,8 @@ export function updateTabsterByAttribute(
                         newTabsterProps.mover as Types.MoverProps
                     );
                 } else {
-                    if (tabster.createMover) {
-                        tabsterOnElement.mover = tabster.createMover(
-                            tabster,
+                    if (tabster.mover) {
+                        tabsterOnElement.mover = tabster.mover.createMover(
                             element,
                             newTabsterProps.mover as Types.MoverProps
                         );
@@ -222,9 +222,9 @@ export function updateTabsterByAttribute(
                 break;
 
             case "observed":
-                if (tabster.updateObserved) {
+                if (tabster.observedElement) {
                     tabsterOnElement.observed = newTabsterProps.observed;
-                    tabster.updateObserved(element);
+                    tabster.observedElement.onObservedElementUpdate(element);
                 } else if (__DEV__) {
                     console.error(
                         "ObservedElement API used before initializing, please call `getObservedElement()`"

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -368,7 +368,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         this._tabster.focusedElement.subscribe(this._onFocus);
     };
 
-    protected dispose(): void {
+    dispose(): void {
         const win = this._win();
         this._dummyManager?.dispose();
 
@@ -393,12 +393,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         delete this.activeModalizer;
     }
 
-    static dispose(instance: Types.ModalizerAPI): void {
-        (instance as ModalizerAPI).dispose();
-    }
-
-    static createModalizer(
-        tabster: Types.TabsterCore,
+    createModalizer(
         element: HTMLElement,
         props: Types.ModalizerProps
     ): Types.Modalizer {
@@ -406,28 +401,29 @@ export class ModalizerAPI implements Types.ModalizerAPI {
             validateModalizerProps(props);
         }
 
-        const self = tabster.modalizer as ModalizerAPI;
         const modalizer = new Modalizer(
-            tabster,
+            this._tabster,
             element,
-            self._onModalizerDispose,
-            self._dummyManager?.moveOutWithDefaultAction ?? (() => null),
-            self._dummyManager?.setTabbable ?? (() => null),
+            this._onModalizerDispose,
+            this._dummyManager?.moveOutWithDefaultAction ?? (() => null),
+            this._dummyManager?.setTabbable ?? (() => null),
             props
         );
 
-        self._modalizers[props.id] = modalizer;
+        this._modalizers[props.id] = modalizer;
 
         // Adding a modalizer which is already focused, activate it
         if (
-            element.contains(tabster.focusedElement.getFocusedElement() ?? null)
+            element.contains(
+                this._tabster.focusedElement.getFocusedElement() ?? null
+            )
         ) {
-            const prevModalizer = self.activeModalizer;
+            const prevModalizer = this.activeModalizer;
             if (prevModalizer) {
                 prevModalizer.setActive(false);
             }
-            self.activeModalizer = modalizer;
-            self.activeModalizer.setActive(true);
+            this.activeModalizer = modalizer;
+            this.activeModalizer.setActive(true);
         }
 
         return modalizer;
@@ -495,22 +491,16 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         return false;
     }
 
-    static updateModalizer(
-        tabster: Types.TabsterCore,
-        modalizer: Types.Modalizer,
-        removed?: boolean
-    ): void {
-        if (removed && tabster.modalizer) {
-            const self = tabster.modalizer as ModalizerAPI;
-
+    updateModalizer(modalizer: Types.Modalizer, removed?: boolean): void {
+        if (removed) {
             if (modalizer.isActive()) {
                 modalizer.setActive(false);
             }
 
-            delete self._modalizers[modalizer.userId];
+            delete this._modalizers[modalizer.userId];
 
-            if (self.activeModalizer === modalizer) {
-                self.activeModalizer = undefined;
+            if (this.activeModalizer === modalizer) {
+                this.activeModalizer = undefined;
             }
         }
     }

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -557,7 +557,7 @@ export class MoverAPI implements Types.MoverAPI {
         win.addEventListener("keydown", this._onKeyDown, true);
     };
 
-    protected dispose(): void {
+    dispose(): void {
         const win = this._win();
 
         this._tabster.focusedElement.unsubscribe(this._onFocus);
@@ -586,27 +586,18 @@ export class MoverAPI implements Types.MoverAPI {
         });
     }
 
-    static dispose(instance: Types.MoverAPI): void {
-        (instance as MoverAPI).dispose();
-    }
-
-    static createMover(
-        tabster: Types.TabsterCore,
-        element: HTMLElement,
-        props: Types.MoverProps
-    ): Types.Mover {
+    createMover(element: HTMLElement, props: Types.MoverProps): Types.Mover {
         if (__DEV__) {
             validateMoverProps(props);
         }
 
-        const self = tabster.mover as MoverAPI;
         const newMover = new Mover(
-            tabster,
+            this._tabster,
             element,
-            self._onMoverDispose,
+            this._onMoverDispose,
             props
         );
-        self._movers[newMover.id] = newMover;
+        this._movers[newMover.id] = newMover;
         return newMover;
     }
 

--- a/src/Outline.ts
+++ b/src/Outline.ts
@@ -133,7 +133,7 @@ export class OutlineAPI implements Types.OutlineAPI {
         }
     }
 
-    protected dispose(): void {
+    dispose(): void {
         const win = this._win();
 
         if (this._initTimer) {
@@ -169,10 +169,6 @@ export class OutlineAPI implements Types.OutlineAPI {
         delete this._curPos;
         delete this._curOutlineElements;
         delete this._fullScreenElement;
-    }
-
-    static dispose(instance: Types.OutlineAPI): void {
-        (instance as OutlineAPI).dispose();
     }
 
     private _onFullScreenChanged = (e: Event): void => {

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -261,7 +261,7 @@ export class RootAPI implements Types.RootAPI {
         this._initTimer = undefined;
     };
 
-    protected dispose(): void {
+    dispose(): void {
         const win = this._win();
 
         if (this._autoRootInstance) {
@@ -285,29 +285,19 @@ export class RootAPI implements Types.RootAPI {
         this.rootById = {};
     }
 
-    static dispose(instance: Types.RootAPI): void {
-        (instance as RootAPI).dispose();
-    }
-
-    static createRoot(
-        tabster: Types.TabsterCore,
-        element: HTMLElement,
-        props: Types.RootProps
-    ): Types.Root {
+    createRoot(element: HTMLElement, props: Types.RootProps): Types.Root {
         if (__DEV__) {
             validateRootProps(props);
         }
 
-        const self = tabster.root as RootAPI;
-
         const newRoot = new Root(
-            tabster,
+            this._tabster,
             element,
-            self._onRootDispose,
+            this._onRootDispose,
             props
         ) as Types.Root;
 
-        self._roots[newRoot.id] = newRoot;
+        this._roots[newRoot.id] = newRoot;
 
         return newRoot;
     }
@@ -460,15 +450,11 @@ export class RootAPI implements Types.RootAPI {
             : undefined;
     }
 
-    static onRoot(
-        instance: Types.RootAPI,
-        root: Types.Root,
-        removed?: boolean
-    ): void {
+    onRoot(root: Types.Root, removed?: boolean): void {
         if (removed) {
-            delete (instance as RootAPI).rootById[root.uid];
+            delete this.rootById[root.uid];
         } else {
-            (instance as RootAPI).rootById[root.uid] = root;
+            this.rootById[root.uid] = root;
         }
     }
 

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -55,7 +55,7 @@ export class FocusedElementState
         }
     };
 
-    protected dispose(): void {
+    dispose(): void {
         super.dispose();
 
         const win = this._win();
@@ -79,10 +79,6 @@ export class FocusedElementState
 
         delete this._nextVal;
         delete this._lastVal;
-    }
-
-    static dispose(instance: Types.FocusedElementState): void {
-        (instance as FocusedElementState).dispose();
     }
 
     static forgetMemorized(

--- a/src/State/KeyboardNavigation.ts
+++ b/src/State/KeyboardNavigation.ts
@@ -20,7 +20,7 @@ export class KeyboardNavigationState
         this._keyborg.subscribe(this._onChange);
     }
 
-    protected dispose(): void {
+    dispose(): void {
         super.dispose();
 
         if (this._keyborg) {
@@ -35,10 +35,6 @@ export class KeyboardNavigationState
     private _onChange = (isNavigatingWithKeyboard: boolean) => {
         this.setVal(isNavigatingWithKeyboard, undefined);
     };
-
-    static dispose(instance: Types.KeyboardNavigationState): void {
-        (instance as KeyboardNavigationState).dispose();
-    }
 
     static setVal(instance: Types.KeyboardNavigationState, val: boolean): void {
         (instance as KeyboardNavigationState)._keyborg?.setVal(val);

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -58,7 +58,7 @@ export class ObservedElementAPI
         this._tabster.focusedElement.subscribe(this._onFocus);
     };
 
-    protected dispose(): void {
+    dispose(): void {
         const win = this._win();
 
         if (this._initTimer) {
@@ -116,10 +116,6 @@ export class ObservedElementAPI
 
             delete this._waiting[key];
         }
-    }
-
-    static dispose(instance: Types.ObservedElementAPI): void {
-        (instance as ObservedElementAPI).dispose();
     }
 
     /**

--- a/src/State/Subscribable.ts
+++ b/src/State/Subscribable.ts
@@ -11,7 +11,7 @@ export abstract class Subscribable<A, B = undefined>
     protected _val: A | undefined;
     private _callbacks: Types.SubscribableCallback<A, B>[] = [];
 
-    protected dispose(): void {
+    dispose(): void {
         this._callbacks = [];
         delete this._val;
     }


### PR DESCRIPTION
Since we now strip `@internal` types from the final API, `dispose` and other internal public functions won't be visible to end users. We can remove most static functions from APIs