### PR TITLE
feat: Allow circular focus trap in Modalizer

### DIFF
--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -120,12 +120,22 @@ export class Modalizer
 
         const focusedElement = this._tabster.focusedElement.getFocusedElement();
         const modalizerElement = this.getElement();
-        const findFn = isPrev ? "findPrev" : "findNext";
+        let findFn: "findPrev" | "findNext" | "findFirst" | "findLast" = isPrev
+            ? "findPrev"
+            : "findNext";
         let next: HTMLElement | null | undefined;
         if (focusedElement && modalizerElement?.contains(focusedElement)) {
             next = this._tabster.focusable[findFn]({
                 container: this.getElement(),
                 currentElement: focusedElement,
+            });
+        }
+
+        // circular focus trap for modalizer
+        if (!next && this._props.circular) {
+            findFn = isPrev ? "findLast" : "findFirst";
+            next = this._tabster.focusable[findFn]({
+                container: this.getElement(),
             });
         }
 

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -132,7 +132,7 @@ export class Modalizer
         }
 
         // circular focus trap for modalizer
-        if (!next && this._props.circular) {
+        if (!next && this._props.isTrapped) {
             findFn = isPrev ? "findLast" : "findFirst";
             next = this._tabster.focusable[findFn]({
                 container: this.getElement(),

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -4,7 +4,6 @@
  */
 
 import { KeyborgFocusInEvent, KEYBORG_FOCUSIN, nativeFocus } from "keyborg";
-import { Modalizer } from "src/Modalizer";
 
 import { Keys } from "../Keys";
 import { RootAPI } from "../Root";

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -483,7 +483,7 @@ export class FocusedElementState
             if (
                 !nextElement &&
                 ctx.modalizer.isActive() &&
-                ctx.modalizer.getProps().circular
+                ctx.modalizer.getProps().isTrapped
             ) {
                 const findFn = isPrev ? "findLast" : "findFirst";
                 nextElement = this._tabster.focusable[findFn]({

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -4,6 +4,7 @@
  */
 
 import { KeyborgFocusInEvent, KEYBORG_FOCUSIN, nativeFocus } from "keyborg";
+import { Modalizer } from "src/Modalizer";
 
 import { Keys } from "../Keys";
 import { RootAPI } from "../Root";
@@ -460,7 +461,7 @@ export class FocusedElementState
             return;
         }
 
-        const nextElement = next.element;
+        let nextElement = next.element;
 
         if (ctx.modalizer) {
             const nextElementCtx =
@@ -477,6 +478,18 @@ export class FocusedElementState
 
                     return;
                 }
+            }
+
+            // circular focus trap for modalizer
+            if (
+                !nextElement &&
+                ctx.modalizer.isActive() &&
+                ctx.modalizer.getProps().circular
+            ) {
+                const findFn = isPrev ? "findLast" : "findFirst";
+                nextElement = this._tabster.focusable[findFn]({
+                    container: ctx.modalizer.getElement(),
+                });
             }
         }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -606,7 +606,7 @@ export interface ModalizerProps {
     isNoFocusFirst?: boolean;
     isNoFocusDefault?: boolean;
     /** A focus trap variant, keeps focus inside the modal when tabbing */
-    circular?: boolean;
+    isTrapped?: boolean;
 }
 
 export type ModalizerEventDetails = { eventName: "beforefocusout" };

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -605,6 +605,8 @@ export interface ModalizerProps {
     isAlwaysAccessible?: boolean;
     isNoFocusFirst?: boolean;
     isNoFocusDefault?: boolean;
+    /** A focus trap variant, keeps focus inside the modal when tabbing */
+    circular?: boolean;
 }
 
 export type ModalizerEventDetails = { eventName: "beforefocusout" };

--- a/stories/Modalizer/ModalDialog.ts
+++ b/stories/Modalizer/ModalDialog.ts
@@ -13,16 +13,7 @@ import {
 export type ModalDialogProps = TabsterTypes.ModalizerProps;
 
 export const createModalDialog = (props: ModalDialogProps) => {
-    const {
-        id = "modalizer",
-        isAlwaysAccessible,
-        isNoFocusDefault,
-        isNoFocusFirst,
-        isOthersAccessible,
-    } = props;
-
     const tabster = getCurrentTabster(window);
-
     const dialog = document.createElement("div");
     dialog.classList.add("lightbox");
     dialog.classList.add("hidden");
@@ -94,11 +85,7 @@ export const createModalDialog = (props: ModalDialogProps) => {
     const attr = getTabsterAttribute(
         {
             modalizer: {
-                id,
-                isAlwaysAccessible,
-                isNoFocusDefault,
-                isNoFocusFirst,
-                isOthersAccessible,
+                ...props,
             },
         },
         true

--- a/stories/Modalizer/Modalizer.stories.ts
+++ b/stories/Modalizer/Modalizer.stories.ts
@@ -21,3 +21,6 @@ const SimpleFocusableCollection: Story<ModalDialogProps> = (args) => {
 };
 
 export const Basic = SimpleFocusableCollection.bind({});
+
+export const circular = SimpleFocusableCollection.bind({});
+circular.args = { circular: true };

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -22,8 +22,8 @@ describe("Modalizer", () => {
                 </div>
                 <div aria-label="modal" id="modal" {...modalizerAttr}>
                     <button id="foo">Foo</button>
-                    <button>Bar</button>
-                    <button>Baz</button>
+                    <button id="bar">Bar</button>
+                    <button id="baz">Baz</button>
                 </div>
             </div>
         );
@@ -147,6 +147,17 @@ describe("Modalizer", () => {
         it("should allow focus into modalizer", async () => {
             await new BroTest.BroTest(getTestHtml({ isOthersAccessible: true }))
                 .focusElement("#outside")
+                .pressTab()
+                .activeElement((el) => expect(el?.attributes.id).toBe("foo"));
+        });
+
+        it("should implement circular focus trap", async () => {
+            await new BroTest.BroTest(getTestHtml({ circular: true }))
+                .focusElement("#foo")
+                .pressTab()
+                .activeElement((el) => expect(el?.attributes.id).toBe("bar"))
+                .pressTab()
+                .activeElement((el) => expect(el?.attributes.id).toBe("baz"))
                 .pressTab()
                 .activeElement((el) => expect(el?.attributes.id).toBe("foo"));
         });

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -152,7 +152,7 @@ describe("Modalizer", () => {
         });
 
         it("should implement circular focus trap", async () => {
-            await new BroTest.BroTest(getTestHtml({ circular: true }))
+            await new BroTest.BroTest(getTestHtml({ isTrapped: true }))
                 .focusElement("#foo")
                 .pressTab()
                 .activeElement((el) => expect(el?.attributes.id).toBe("bar"))


### PR DESCRIPTION
Implements a new prop for Modalizer `isTrapped` which allows focus to
stay within the Modalizer and never leave the it. The prop is
implemented for both controlled an uncontrolled code paths in Tabster.

Fixes #122