### PR TITLE
fix: re-export getCurrentTabster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
     forceCleanup,
     getTabsterAttribute,
     setTabsterAttribute,
+    getCurrentTabster,
     getGroupper,
     getMover,
     getCrossOrigin,


### PR DESCRIPTION
getCurrentTabster was removed in #136 to promote usage of lightweight
tabster instance. However this is actually a breaking change. Reexport
the utility function.