### PR TITLE
fix: get<API> should accept both Tabster and TabsterCore instance

### DIFF
--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -51,7 +51,7 @@ class Tabster implements Types.Tabster {
 /**
  * Extends Window to include an internal Tabster instance.
  */
-class TabsterCore implements Types.TabsterCore {
+export class TabsterCore implements Types.TabsterCore {
     private _storage: WeakMap<HTMLElement, Types.TabsterElementStorage>;
     private _unobserve: (() => void) | undefined;
     private _win: WindowWithTabsterInstance | undefined;
@@ -262,8 +262,10 @@ export function createTabster(
  * Creates a new groupper instance or returns an existing one
  * @param tabster Tabster instance
  */
-export function getGroupper(tabster: Types.Tabster): Types.GroupperAPI {
-    const tabsterCore = tabster.core;
+export function getGroupper(
+    tabster: Types.Tabster | TabsterCore
+): Types.GroupperAPI {
+    const tabsterCore = tabster instanceof TabsterCore ? tabster : tabster.core;
     if (!tabsterCore.groupper) {
         tabsterCore.groupper = new GroupperAPI(
             tabsterCore,
@@ -278,8 +280,8 @@ export function getGroupper(tabster: Types.Tabster): Types.GroupperAPI {
  * Creates a new mover instance or returns an existing one
  * @param tabster Tabster instance
  */
-export function getMover(tabster: Types.Tabster): Types.MoverAPI {
-    const tabsterCore = tabster.core;
+export function getMover(tabster: Types.Tabster | TabsterCore): Types.MoverAPI {
+    const tabsterCore = tabster instanceof TabsterCore ? tabster : tabster.core;
     if (!tabsterCore.mover) {
         tabsterCore.mover = new MoverAPI(tabsterCore, tabsterCore.getWindow);
     }
@@ -287,8 +289,10 @@ export function getMover(tabster: Types.Tabster): Types.MoverAPI {
     return tabsterCore.mover;
 }
 
-export function getOutline(tabster: Types.Tabster): Types.OutlineAPI {
-    const tabsterCore = tabster.core;
+export function getOutline(
+    tabster: Types.Tabster | TabsterCore
+): Types.OutlineAPI {
+    const tabsterCore = tabster instanceof TabsterCore ? tabster : tabster.core;
     if (!tabsterCore.outline) {
         tabsterCore.outline = new OutlineAPI(tabsterCore);
     }
@@ -302,10 +306,10 @@ export function getOutline(tabster: Types.Tabster): Types.OutlineAPI {
  * @param props Deloser props
  */
 export function getDeloser(
-    tabster: Types.Tabster,
+    tabster: Types.Tabster | TabsterCore,
     props?: { autoDeloser: Types.DeloserProps }
 ): Types.DeloserAPI {
-    const tabsterCore = tabster.core;
+    const tabsterCore = tabster instanceof TabsterCore ? tabster : tabster.core;
     if (!tabsterCore.deloser) {
         tabsterCore.deloser = new DeloserAPI(tabsterCore, props);
     }
@@ -317,8 +321,10 @@ export function getDeloser(
  * Creates a new modalizer instance or returns an existing one
  * @param tabster Tabster instance
  */
-export function getModalizer(tabster: Types.Tabster): Types.ModalizerAPI {
-    const tabsterCore = tabster.core;
+export function getModalizer(
+    tabster: Types.Tabster | TabsterCore
+): Types.ModalizerAPI {
+    const tabsterCore = tabster instanceof TabsterCore ? tabster : tabster.core;
     if (!tabsterCore.modalizer) {
         tabsterCore.modalizer = new ModalizerAPI(tabsterCore);
     }
@@ -327,9 +333,9 @@ export function getModalizer(tabster: Types.Tabster): Types.ModalizerAPI {
 }
 
 export function getObservedElement(
-    tabster: Types.Tabster
+    tabster: Types.Tabster | TabsterCore
 ): Types.ObservedElementAPI {
-    const tabsterCore = tabster.core;
+    const tabsterCore = tabster instanceof TabsterCore ? tabster : tabster.core;
     if (!tabsterCore.observedElement) {
         tabsterCore.observedElement = new ObservedElementAPI(tabsterCore);
     }
@@ -337,8 +343,11 @@ export function getObservedElement(
     return tabsterCore.observedElement;
 }
 
-export function getCrossOrigin(tabster: Types.Tabster): Types.CrossOriginAPI {
-    const tabsterCore = tabster.core;
+export function getCrossOrigin(
+    tabster: Types.Tabster | TabsterCore
+): Types.CrossOriginAPI {
+    const tabsterCore = tabster instanceof TabsterCore ? tabster : tabster.core;
+
     if (!tabsterCore.crossOrigin) {
         getDeloser(tabster);
         getModalizer(tabster);
@@ -352,8 +361,10 @@ export function getCrossOrigin(tabster: Types.Tabster): Types.CrossOriginAPI {
     return tabsterCore.crossOrigin;
 }
 
-export function getInternal(tabster: Types.Tabster): Types.InternalAPI {
-    const tabsterCore = tabster.core;
+export function getInternal(
+    tabster: Types.Tabster | TabsterCore
+): Types.InternalAPI {
+    const tabsterCore = tabster instanceof TabsterCore ? tabster : tabster.core;
     return tabsterCore.internal;
 }
 

--- a/tests/Tabster.test.tsx
+++ b/tests/Tabster.test.tsx
@@ -4,11 +4,42 @@
  */
 
 import * as React from "react";
+import { TabsterCore } from "src/Tabster";
 import * as BroTest from "./utils/BroTest";
 
 interface WindowWithTabster extends Window {
     __tabsterInstance: unknown;
 }
+
+describe("getAPI", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({});
+    });
+    it("should accept both Tabster and TabsterCore instances", async () => {
+        await new BroTest.BroTest(<div />)
+            .eval(() => {
+                // dispose default tabster on the test page
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                window.__tabsterInstance.dispose();
+                getTabsterTestVariables().createTabster?.(window);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                const tabsterCore: TabsterCore = window.__tabsterInstance;
+
+                getTabsterTestVariables().getModalizer(tabsterCore);
+                getTabsterTestVariables().getCrossOrigin(tabsterCore);
+                getTabsterTestVariables().getDeloser(tabsterCore);
+                getTabsterTestVariables().getMover(tabsterCore);
+                getTabsterTestVariables().getObservedElement(tabsterCore);
+                getTabsterTestVariables().getOutline(tabsterCore);
+                getTabsterTestVariables().getGroupper(tabsterCore);
+
+                return true;
+            })
+            .check((success) => expect(success).toBe(true));
+    });
+});
 
 describe("Tabster dispose", () => {
     beforeEach(async () => {

--- a/tests/index.html
+++ b/tests/index.html
@@ -15,7 +15,15 @@
                 getOutline,
             } from "../src";
 
-            const tabsterTest = {};
+            const tabsterTest = {
+                getCrossOrigin,
+                getDeloser,
+                getGroupper,
+                getModalizer,
+                getMover,
+                getObservedElement,
+                getOutline,
+            };
 
             const params = new URL(location.href).searchParams;
             const controlTab = params.get("controlTab") !== "false";

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -11,7 +11,18 @@ import {
     Frame,
     KeyInput,
 } from "puppeteer";
-import { createTabster, disposeTabster, Types } from "tabster";
+import {
+    createTabster,
+    disposeTabster,
+    Types,
+    getMover as getMoverBase,
+    getCrossOrigin as getCrossOriginBase,
+    getDeloser as getDeloserBase,
+    getModalizer as getModalizerBase,
+    getOutline as getOutlineBase,
+    getObservedElement as getObservedElementBase,
+    getGroupper as getGroupperBase,
+} from "tabster";
 
 // Importing the production version so that React doesn't complain in the test output.
 declare function require(name: string): any;
@@ -95,6 +106,14 @@ export interface BroTestTabsterTestVariables {
     groupper?: Types.GroupperAPI;
     observedElement?: Types.ObservedElementAPI;
     crossOrigin?: Types.CrossOriginAPI;
+
+    getMover: typeof getMoverBase;
+    getGroupper: typeof getGroupperBase;
+    getModalizer: typeof getModalizerBase;
+    getObservedElement: typeof getObservedElementBase;
+    getOutline: typeof getOutlineBase;
+    getDeloser: typeof getDeloserBase;
+    getCrossOrigin: typeof getCrossOriginBase;
 }
 
 export function getTestPageURL(parts: TabsterParts): string {


### PR DESCRIPTION
Fixes backwards compat issue of Tabster/TabsterCore instances introduced
with #136