### PR TITLE
feat: Add `ignoreKeydown` focusable attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "lint": "eslint src/ --fix",
         "lint:check": "eslint src/",
         "test": "node tests/utils/runner.js",
-        "test:uncontrolled": "STORYBOOK_UNCONTROLLED=true npm test",
+        "test:uncontrolled": "STORYBOOK_UNCONTROLLED=true node tests/utils/runner.js",
         "test:root-dummy-inputs": "STORYBOOK_UNCONTROLLED=true STORYBOOK_ROOT_DUMMY_INPUTS=true npm test",
         "prepublishOnly": "npm run build",
         "release": "release-it",

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -340,6 +340,7 @@ export class RootAPI implements Types.RootAPI {
         let curElement: Node | null = element;
         let allMoversGrouppers: Types.TabsterContext["allMoversGrouppers"];
         let instances: Types.TabsterContextMoverGroupper[] | undefined;
+        const ignoreKeydown: Types.FocusableProps["ignoreKeydown"] = {};
 
         if (options.allMoversGrouppers) {
             instances = [];
@@ -421,6 +422,13 @@ export class RootAPI implements Types.RootAPI {
                 root = tabsterOnElement.root;
             }
 
+            if (tabsterOnElement.focusable?.ignoreKeydown) {
+                Object.assign(
+                    ignoreKeydown,
+                    tabsterOnElement.focusable.ignoreKeydown
+                );
+            }
+
             curElement = curElement.parentElement;
         }
 
@@ -460,6 +468,7 @@ export class RootAPI implements Types.RootAPI {
                   uncontrolled,
                   allMoversGrouppers,
                   isExcludedFromMover,
+                  ignoreKeydown,
               }
             : undefined;
     }

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -445,7 +445,11 @@ export class FocusedElementState
             checkRtl: true,
         });
 
-        if (!ctx || (!controlTab && !ctx.mover && !ctx.groupper)) {
+        if (
+            !ctx ||
+            (!controlTab && !ctx.mover && !ctx.groupper) ||
+            ctx.ignoreKeydown[e.key as "Tab"]
+        ) {
             return;
         }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -330,6 +330,13 @@ export interface FocusableProps {
      * Exclude element (and all subelements) from Mover navigation.
      */
     excludeFromMover?: boolean;
+    /**
+     * Prevents tabster from handling the keydown event
+     */
+    ignoreKeydown?: {
+        Tab?: boolean;
+        Escape?: boolean;
+    };
 }
 
 export interface FocusableAcceptElementState {
@@ -697,6 +704,7 @@ export interface TabsterContext {
         instances: TabsterContextMoverGroupper[];
     };
     isExcludedFromMover?: boolean;
+    ignoreKeydown: NonNullable<FocusableProps["ignoreKeydown"]>;
 }
 
 export interface RootFocusEventDetails {

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -284,6 +284,11 @@ describe("NestedMovers", () => {
                 direction: Types.MoverDirections.Vertical,
                 cyclic: true,
             },
+            focusable: {
+                ignoreKeydown: {
+                    Tab: true,
+                },
+            },
         });
 
         await new BroTest.BroTest(

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -277,6 +277,43 @@ describe("NestedMovers", () => {
             .pressUp()
             .activeElement((el) => expect(el?.textContent).toEqual("Nested4"));
     });
+
+    it("should allow user to prevent default and control tab focus", async () => {
+        const attr = getTabsterAttribute({
+            mover: {
+                direction: Types.MoverDirections.Vertical,
+                cyclic: true,
+            },
+        });
+
+        await new BroTest.BroTest(
+            (
+                <div>
+                    <button id="target">Target</button>
+                    <button>Skipped</button>
+                    <div {...attr} id="mover">
+                        <button id="start">Mover Item</button>
+                        <button>Mover Item</button>
+                        <button>Mover Item</button>
+                        <button>Mover Item</button>
+                    </div>
+                </div>
+            )
+        )
+            .eval(() => {
+                document
+                    .getElementById("mover")
+                    ?.addEventListener("keydown", (e) => {
+                        if (e.key === "Tab" && e.shiftKey) {
+                            e.preventDefault();
+                            document.getElementById("target")?.focus();
+                        }
+                    });
+            })
+            .focusElement("#start")
+            .pressTab(true)
+            .activeElement((el) => expect(el?.textContent).toEqual("Target"));
+    });
 });
 
 describe("Mover memorizing current", () => {


### PR DESCRIPTION
Adds a focusable attribute called `ignoreKeydown` to let users bail out of tabster keydown handling. This can be useful when users would like to custom handle `Tab` behaviour inside APIs like the `Mover` 