### PR TITLE
fix: Dispose `__tabsterDummy` on DummyInputManagerCore

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -941,6 +941,8 @@ class DummyInputManagerCore {
         ));
 
         if (wrappers.length === 0) {
+            delete (this._element?.get() as HTMLElementWithDummyInputs)
+                .__tabsterDummy;
             if (this._unobserve) {
                 this._unobserve();
                 delete this._unobserve;


### PR DESCRIPTION
When a `DummyInputManagerCore` is created it attaches itself to a HTML
element. When it is disposed it does not remove itself from the HTML
element.

When a new tabster core is created it will still use the undisposed
`DummyInputManagerCore` and causes a leak where a disposed tabster core
is being used