### PR TITLE
Do not handle the FocusedElement onKeyDown when using Ctrl + Tab

### DIFF
--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -426,7 +426,7 @@ export class FocusedElementState
     };
 
     private _onKeyDown = (e: KeyboardEvent): void => {
-        if (e.keyCode !== Keys.Tab) {
+        if (e.keyCode !== Keys.Tab || e.ctrlKey) {
             return;
         }
 

--- a/tests/FocusedElement.test.tsx
+++ b/tests/FocusedElement.test.tsx
@@ -6,6 +6,7 @@
 import * as React from "react";
 import { getTabsterAttribute } from "tabster";
 import * as BroTest from "./utils/BroTest";
+import { BrowserElement } from "./utils/BroTest";
 
 describe("onKeyDown", () => {
     beforeAll(async () => {
@@ -34,5 +35,25 @@ describe("onKeyDown", () => {
             .activeElement((el) =>
                 expect(el?.attributes["aria-hidden"]).toEqual("true")
             );
+    });
+
+    it("Should not handle event on Ctrl+Tab", async () => {
+        const testHtml = (
+            <div id="root" {...getTabsterAttribute({ root: {} })}>
+                <div tabIndex={0}>
+                    <button>Button1</button>
+                    <button>Button2</button>
+                </div>
+                <button>Don't focus</button>
+            </div>
+        );
+
+        let focusedElement: BrowserElement | null;
+        await new BroTest.BroTest(testHtml)
+            .activeElement((el) => (focusedElement = el))
+            .pressTab(false /* shift */, true /* ctrlKey */)
+            .activeElement((el) => {
+                expect(el).toEqual(focusedElement);
+            });
     });
 });

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -123,7 +123,7 @@ async function sleep(time: number) {
     });
 }
 
-interface BrowserElement {
+export interface BrowserElement {
     tag: string;
     textContent: string | null;
     attributes: { [name: string]: string };
@@ -466,17 +466,25 @@ export class BroTest implements PromiseLike<undefined> {
         return this;
     }
 
-    private _pressKey(key: KeyInput, shift?: boolean) {
+    private _pressKey(key: KeyInput, shift?: boolean, ctrl?: boolean) {
         this._chain.push(
             new BroTestItemCallback(this._frameStack, async () => {
                 if (shift) {
                     await page.keyboard.down("Shift");
                 }
 
+                if (ctrl) {
+                    await page.keyboard.down("Control");
+                }
+
                 await page.keyboard.press(key);
 
                 if (shift) {
                     await page.keyboard.up("Shift");
+                }
+
+                if (ctrl) {
+                    await page.keyboard.up("Control");
                 }
             })
         );
@@ -502,8 +510,8 @@ export class BroTest implements PromiseLike<undefined> {
         return this;
     }
 
-    pressTab(shift?: boolean) {
-        return this._pressKey("Tab", shift);
+    pressTab(shift?: boolean, ctrlKey?: boolean) {
+        return this._pressKey("Tab", shift, ctrlKey);
     }
     pressEsc(shift?: boolean) {
         return this._pressKey("Escape", shift);


### PR DESCRIPTION
On a native app, where the host does not own the Ctrl + Tab hotkey, Tabster is handling the ctrl+tab hotkey as Tab.

Code Change.
Check whether the event contains CtrlKey before handling the onKeyEvent