### PR TITLE
fix shift+tab can't navigate outside of mover in uncontrolled mode

### DIFF
--- a/src/Focusable.ts
+++ b/src/Focusable.ts
@@ -389,11 +389,11 @@ export class FocusableAPI implements Types.FocusableAPI {
             state.nextGroupper = ctx.groupper.getElement();
         } else if (ctx.mover) {
             state.nextMover = ctx.mover.getElement();
-        } else if (ctx.uncontrolled && !state.nextUncontrolled) {
-            if (!ctx.groupper && !ctx.mover) {
+        } else if (ctx.uncontrolled) {
+            if (!state.nextUncontrolled) {
                 state.nextUncontrolled = ctx.uncontrolled;
-                return NodeFilter.FILTER_REJECT;
             }
+            return NodeFilter.FILTER_REJECT;
         }
 
         // We assume iframes are focusable because native tab behaviour would tab inside


### PR DESCRIPTION
In this example: https://codesandbox.io/s/throbbing-sea-0ciyy7?file=/src/App.js
Tab can navigate outside of mover, but Shift+Tab cannot.
note that the issue only happens when mover element is NOT the direct child of the element with uncontrolled attribute.

Behavior after fix:
Shift+Tab can always navigate outside of the mover in uncontrolled mode.
 