### PR TITLE
Big find elements refactoring

### DIFF
--- a/src/Focusable.ts
+++ b/src/Focusable.ts
@@ -243,7 +243,9 @@ export class FocusableAPI implements Types.FocusableAPI {
             return null;
         }
 
-        const prepareForNextElement = (shouldContinueIfNotFound?: boolean): boolean => {
+        const prepareForNextElement = (
+            shouldContinueIfNotFound?: boolean
+        ): boolean => {
             const foundElement = acceptElementState.foundElement;
 
             if (foundElement) {
@@ -287,8 +289,11 @@ export class FocusableAPI implements Types.FocusableAPI {
 
         let foundElement: HTMLElement | null | undefined;
         do {
-            foundElement = (isBackward ? walker.previousNode() : walker.nextNode()) as (HTMLElement | null) || undefined;
-        } while (prepareForNextElement())
+            foundElement =
+                ((isBackward
+                    ? walker.previousNode()
+                    : walker.nextNode()) as HTMLElement | null) || undefined;
+        } while (prepareForNextElement());
 
         if (!findAll) {
             const nextUncontrolled = acceptElementState.nextUncontrolled;
@@ -360,7 +365,11 @@ export class FocusableAPI implements Types.FocusableAPI {
             if (shouldIgnoreFocus(element)) {
                 return NodeFilter.FILTER_SKIP;
             }
-        } else if (ctx.uncontrolled && !state.nextUncontrolled) {
+        } else if (
+            ctx.uncontrolled &&
+            !state.nextUncontrolled &&
+            this._tabster.focusable.isFocusable(element, undefined, true, true)
+        ) {
             if (!ctx.groupper && !ctx.mover) {
                 state.nextUncontrolled = ctx.uncontrolled;
                 return NodeFilter.FILTER_REJECT;

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -29,9 +29,7 @@ class GroupperDummyManager extends DummyInputManager {
                 const input = dummyInput.input;
 
                 if (input) {
-                    const ctx = RootAPI.getTabsterContext(tabster, input, {
-                        checkRtl: true,
-                    });
+                    const ctx = RootAPI.getTabsterContext(tabster, input);
 
                     if (ctx) {
                         const next = FocusedElementState.findNextTabbable(

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -367,8 +367,8 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         this._win = tabster.getWindow;
         this._initTimer = this._win().setTimeout(this._init, 0);
         this._modalizers = {};
-        const documentBody = this._win().document.body;
         if (!tabster.controlTab) {
+            const documentBody = this._win().document.body;
             this._dummyManager = new ModalizerAPIDummyManager(
                 this,
                 tabster,

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -223,7 +223,7 @@ export class Mover
 
     findNextTabbable(
         currentElement?: HTMLElement,
-        prev?: boolean
+        isBackward?: boolean
     ): Types.NextTabbable | null {
         const container = this.getElement();
         const currentIsDummy =
@@ -245,7 +245,7 @@ export class Mover
         };
 
         if (this._props.tabbable || currentIsDummy) {
-            next = prev
+            next = isBackward
                 ? focusable.findPrev({
                       currentElement,
                       container,

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -422,9 +422,7 @@ export type FindNextProps = Pick<
 
 export type FindDefaultProps = Pick<
     FindFocusableProps,
-    | "container"
-    | "includeProgrammaticallyFocusable"
-    | "ignoreAccessibiliy"
+    "container" | "includeProgrammaticallyFocusable" | "ignoreAccessibiliy"
 >;
 
 export type FindAllProps = Pick<

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -663,7 +663,8 @@ export interface DummyInputProps {
 
 export type DummyInputFocusCallback = (
     dummyInput: DummyInput,
-    isBackward: boolean
+    isBackward: boolean,
+    relatedTarget: HTMLElement | null
 ) => void;
 
 /**
@@ -783,13 +784,12 @@ export class DummyInput {
         const input = this.input;
 
         if (this.onFocusIn && input) {
+            const relatedTarget = e.relatedTarget as HTMLElement | null;
+
             this.onFocusIn(
                 this,
-                this._isBackward(
-                    true,
-                    input,
-                    e.relatedTarget as HTMLElement | null
-                )
+                this._isBackward(true, input, relatedTarget),
+                relatedTarget
             );
         }
     };
@@ -800,13 +800,12 @@ export class DummyInput {
         const input = this.input;
 
         if (this.onFocusOut && input) {
+            const relatedTarget = e.relatedTarget as HTMLElement | null;
+
             this.onFocusOut(
                 this,
-                this._isBackward(
-                    false,
-                    input,
-                    e.relatedTarget as HTMLElement | null
-                )
+                this._isBackward(false, input, relatedTarget),
+                relatedTarget
             );
         }
 
@@ -1045,27 +1044,34 @@ class DummyInputManagerCore {
     private _onFocus(
         isIn: boolean,
         dummyInput: DummyInput,
-        isBackward: boolean
+        isBackward: boolean,
+        relatedTarget: HTMLElement | null
     ): void {
         const wrapper = this._getCurrent();
 
         if (wrapper) {
-            wrapper.manager.getHandler(isIn)?.(dummyInput, isBackward);
+            wrapper.manager.getHandler(isIn)?.(
+                dummyInput,
+                isBackward,
+                relatedTarget
+            );
         }
     }
 
     private _onFocusIn = (
         dummyInput: DummyInput,
-        isBackward: boolean
+        isBackward: boolean,
+        relatedTarget: HTMLElement | null
     ): void => {
-        this._onFocus(true, dummyInput, isBackward);
+        this._onFocus(true, dummyInput, isBackward, relatedTarget);
     };
 
     private _onFocusOut = (
         dummyInput: DummyInput,
-        isBackward: boolean
+        isBackward: boolean,
+        relatedTarget: HTMLElement | null
     ): void => {
-        this._onFocus(false, dummyInput, isBackward);
+        this._onFocus(false, dummyInput, isBackward, relatedTarget);
     };
 
     /**

--- a/tests/DummyInputManager.test.tsx
+++ b/tests/DummyInputManager.test.tsx
@@ -226,7 +226,7 @@ runIfUnControlled("DummyInputManager", () => {
                     Types.TabsterDummyInputAttributeName,
                     groupperId
                 )
-                .check(checkDummyInside)
+                .check(checkDummyOutside)
                 .eval(appendElement, groupperId)
                 .wait(1)
                 .eval(
@@ -234,7 +234,7 @@ runIfUnControlled("DummyInputManager", () => {
                     Types.TabsterDummyInputAttributeName,
                     groupperId
                 )
-                .check(checkDummyInside)
+                .check(checkDummyOutside)
                 .eval(prependElement, groupperId)
                 .wait(1)
                 .eval(
@@ -242,7 +242,7 @@ runIfUnControlled("DummyInputManager", () => {
                     Types.TabsterDummyInputAttributeName,
                     groupperId
                 )
-                .check(checkDummyInside);
+                .check(checkDummyOutside);
         });
 
         it("modalizerAPI", async () => {

--- a/tests/Groupper.test.tsx
+++ b/tests/Groupper.test.tsx
@@ -250,6 +250,7 @@ describe("Groupper tabbing forward and backwards", () => {
                 <div {...getTabsterAttribute({ root: {} })}>
                     <button>Button1</button>
                     <div
+                        tabIndex={0}
                         {...getTabsterAttribute({
                             groupper: {
                                 tabbability:
@@ -270,7 +271,7 @@ describe("Groupper tabbing forward and backwards", () => {
             })
             .pressTab()
             .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button2");
+                expect(el?.textContent).toEqual("Button2Button3");
             })
             .pressTab()
             .activeElement((el) => {
@@ -278,7 +279,7 @@ describe("Groupper tabbing forward and backwards", () => {
             })
             .pressTab(true)
             .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button2");
+                expect(el?.textContent).toEqual("Button2Button3");
             })
             .pressTab(true)
             .activeElement((el) => {
@@ -291,6 +292,7 @@ describe("Groupper tabbing forward and backwards", () => {
             (
                 <div {...getTabsterAttribute({ root: {} })}>
                     <div
+                        tabIndex={0}
                         {...getTabsterAttribute({
                             groupper: {
                                 tabbability:
@@ -306,7 +308,7 @@ describe("Groupper tabbing forward and backwards", () => {
         )
             .pressTab()
             .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button1");
+                expect(el?.textContent).toEqual("Button1Button2");
             })
             .pressTab()
             .activeElement((el) => {
@@ -314,7 +316,7 @@ describe("Groupper tabbing forward and backwards", () => {
             })
             .pressTab(true)
             .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button1");
+                expect(el?.textContent).toEqual("Button1Button2");
             })
             .pressTab(true)
             .activeElement((el) => {

--- a/tests/Groupper.test.tsx
+++ b/tests/Groupper.test.tsx
@@ -6,6 +6,7 @@
 import * as React from "react";
 import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
+import { runIfUnControlled } from "./utils/test-utils";
 
 const groupperItem = (
     tabsterAttr: Types.TabsterDOMAttribute,
@@ -322,5 +323,54 @@ describe("Groupper tabbing forward and backwards", () => {
             .activeElement((el) => {
                 expect(el?.textContent).toBeUndefined();
             });
+    });
+});
+
+// TODO: Address contentEditables in a controlled groupper (likely by having dummy inputs around).
+runIfUnControlled("Groupper", () => {
+    beforeAll(async () => {
+        await BroTest.bootstrapTabsterPage({ groupper: true });
+    });
+
+    describe("Groupper with contentEditable", () => {
+        it("should handle contentEditable in a trapped groupper", async () => {
+            await new BroTest.BroTest(
+                (
+                    <div {...getTabsterAttribute({ root: {} })}>
+                        <button>Button1</button>
+                        <div
+                            {...getTabsterAttribute({
+                                groupper: {
+                                    tabbability:
+                                        Types.GroupperTabbabilities
+                                            .LimitedTrapFocus,
+                                },
+                            })}
+                        >
+                            <div tabIndex={0} contentEditable="true">
+                                ContentEditable
+                            </div>
+                        </div>
+                        <button>Button2</button>
+                    </div>
+                )
+            )
+                .pressTab()
+                .activeElement((el) => {
+                    expect(el?.textContent).toEqual("Button1");
+                })
+                .pressTab()
+                .activeElement((el) => {
+                    expect(el?.textContent).toEqual("ContentEditable");
+                })
+                .pressTab()
+                .activeElement((el) => {
+                    expect(el?.textContent).toEqual("ContentEditable");
+                })
+                .pressTab(true)
+                .activeElement((el) => {
+                    expect(el?.textContent).toEqual("ContentEditable");
+                });
+        });
     });
 });

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -763,7 +763,7 @@ describe("Mover with visibilityAware", () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
-    it("should memorize current element and move to it when tabbing from outside of the Mover", async () => {
+    it("should tab to first/last visible element when tabbing from outside of the Mover", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>

--- a/tests/Uncontrolled.test.tsx
+++ b/tests/Uncontrolled.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import * as React from "react";
-import { getTabsterAttribute, Types } from "tabster";
+import { getTabsterAttribute } from "tabster";
 import * as BroTest from "./utils/BroTest";
 import { runIfControlled } from "./utils/test-utils";
 
@@ -17,6 +17,7 @@ runIfControlled("Uncontrolled", () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
+                    <button aria-hidden="true">Button0</button>
                     <div {...getTabsterAttribute({ uncontrolled: {} })}>
                         <button>Button1</button>
                         <button aria-hidden="true">Button2</button>
@@ -299,68 +300,6 @@ runIfControlled("Uncontrolled", () => {
             .pressTab(true)
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button1");
-            });
-    });
-
-    it("should properly transition between uncontrolled areas", async () => {
-        await new BroTest.BroTest(
-            (
-                <div {...getTabsterAttribute({ root: {} })}>
-                    <div {...getTabsterAttribute({ uncontrolled: {} })}>
-                        <button>Button1</button>
-                        <button>Button2</button>
-                    </div>
-                    <ul {...getTabsterAttribute({ mover: {} })}>
-                        <li
-                            {...getTabsterAttribute({
-                                groupper: {
-                                    tabbability:
-                                        Types.GroupperTabbabilities
-                                            .LimitedTrapFocus,
-                                },
-                            })}
-                        >
-                            <button
-                                {...getTabsterAttribute({ uncontrolled: {} })}
-                            >
-                                Button3
-                            </button>
-                        </li>
-                        <li
-                            {...getTabsterAttribute({
-                                groupper: {
-                                    tabbability:
-                                        Types.GroupperTabbabilities
-                                            .LimitedTrapFocus,
-                                },
-                            })}
-                        >
-                            <button
-                                {...getTabsterAttribute({ uncontrolled: {} })}
-                            >
-                                Button4
-                            </button>
-                        </li>
-                    </ul>
-                </div>
-            )
-        )
-            .pressTab()
-            .pressTab()
-            .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button2");
-            })
-            .pressTab()
-            .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button3");
-            })
-            .pressDown()
-            .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button4");
-            })
-            .pressTab(true)
-            .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button2");
             });
     });
 

--- a/tests/Uncontrolled.test.tsx
+++ b/tests/Uncontrolled.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import * as React from "react";
-import { getTabsterAttribute } from "tabster";
+import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
 import { runIfControlled } from "./utils/test-utils";
 
@@ -335,6 +335,120 @@ runIfControlled("Uncontrolled", () => {
             .pressTab(true)
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button3");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            });
+    });
+
+    it("should handle Mover inside Uncontrolled", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div {...getTabsterAttribute({ uncontrolled: {} })}>
+                        <button>Button1</button>
+                        <div>
+                            <div
+                                {...getTabsterAttribute({
+                                    mover: { memorizeCurrent: true },
+                                })}
+                            >
+                                <button>Mover-Button1</button>
+                                <button>Mover-Button2</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Mover-Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toBeUndefined();
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Mover-Button1");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Mover-Button2");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Mover-Button2");
+            });
+    });
+
+    it("should handle Groupper inside Uncontrolled", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div {...getTabsterAttribute({ uncontrolled: {} })}>
+                        <button>Button1</button>
+                        <div>
+                            <div
+                                tabIndex={0}
+                                {...getTabsterAttribute({
+                                    groupper: {
+                                        tabbability:
+                                            Types.GroupperTabbabilities.Limited,
+                                    },
+                                })}
+                            >
+                                <button>Groupper-Button1</button>
+                                <button>Groupper-Button2</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual(
+                    "Groupper-Button1Groupper-Button2"
+                );
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toBeUndefined();
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual(
+                    "Groupper-Button1Groupper-Button2"
+                );
+            })
+            .pressEnter()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Groupper-Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Groupper-Button2");
+            })
+            .pressEsc()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual(
+                    "Groupper-Button1Groupper-Button2"
+                );
             })
             .pressTab(true)
             .activeElement((el) => {


### PR DESCRIPTION
This change addresses two issues:

1. Historically, we were adding new features without seeing the whole picture as we see it now. 
2. We weren't fully aware of how TreeWalker actually works when you walk backwards in the DOM.

These two things have lead us into a state when the implementation of finding elements is rather patchy and at this point it is hard to understand and hard to adjust for new corner cases (because whenever something new gets fixed, something old gets broken).

Plus it fixes a bunch of connected bugs (primarily the Shift+Tab ones).