### PR TITLE
fix(Groupper): Putting dummy inputs inside the groupper container when it is <li>, <td> or <th>.

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -62,7 +62,13 @@ class GroupperDummyManager extends DummyInputManager {
                                     tabster,
                                     ctx,
                                     undefined,
-                                    input,
+                                    dummyInput.isOutside
+                                        ? input
+                                        : (container[
+                                              isBackward
+                                                  ? "nextElementSibling"
+                                                  : "previousElementSibling"
+                                          ] as HTMLElement | null) || undefined,
                                     isBackward
                                 )?.element;
                             }

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -16,6 +16,7 @@ import {
     DummyInputManagerPriorities,
     TabsterPart,
     WeakHTMLElement,
+    getAdjacentElement,
 } from "./Utils";
 
 class GroupperDummyManager extends DummyInputManager {
@@ -64,11 +65,10 @@ class GroupperDummyManager extends DummyInputManager {
                                     undefined,
                                     dummyInput.isOutside
                                         ? input
-                                        : (container[
-                                              isBackward
-                                                  ? "nextElementSibling"
-                                                  : "previousElementSibling"
-                                          ] as HTMLElement | null) || undefined,
+                                        : getAdjacentElement(
+                                              container,
+                                              !isBackward
+                                          ),
                                     isBackward
                                 )?.element;
                             }

--- a/tests/CrossOrigin.test.tsx
+++ b/tests/CrossOrigin.test.tsx
@@ -10,7 +10,7 @@ import * as BroTest from "./utils/BroTest";
 describe("CrossOrigin", () => {
     const tabsterParts = { crossOrigin: true };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage(tabsterParts);
     });
 

--- a/tests/Deloser.test.tsx
+++ b/tests/Deloser.test.tsx
@@ -8,7 +8,7 @@ import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
 describe("Deloser", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ deloser: true, groupper: true });
     });
 

--- a/tests/DummyInputManager.test.tsx
+++ b/tests/DummyInputManager.test.tsx
@@ -9,7 +9,7 @@ import * as BroTest from "./utils/BroTest";
 import { runIfUnControlled } from "./utils/test-utils";
 
 runIfUnControlled("DummyInputManager", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({
             mover: true,
             groupper: true,
@@ -335,6 +335,53 @@ runIfUnControlled("DummyInputManager", () => {
                         containerId
                     )
                     .check(checkDummyOutside);
+            }
+        );
+
+        it.each<["li" | "td" | "th"]>([["li"], ["td"], ["th"]])(
+            "should add dummy inputs inside the container for <li>, <td> and <th>",
+            async (tagName) => {
+                const attr = getTabsterAttribute({
+                    groupper: {
+                        tabbability:
+                            Types.GroupperTabbabilities.LimitedTrapFocus,
+                    },
+                });
+                const containerId = "inside";
+                const Tag = tagName;
+                const testHtml = (
+                    <div>
+                        <table>
+                            <Tag {...attr} id={containerId}>
+                                <button>Button1</button>
+                                <button>Button2</button>
+                            </Tag>
+                        </table>
+                    </div>
+                );
+                await new BroTest.BroTest(testHtml)
+                    .eval(
+                        evaluateDummy,
+                        Types.TabsterDummyInputAttributeName,
+                        containerId
+                    )
+                    .check(checkDummyInside)
+                    .eval(appendElement, containerId)
+                    .wait(1)
+                    .eval(
+                        evaluateDummy,
+                        Types.TabsterDummyInputAttributeName,
+                        containerId
+                    )
+                    .check(checkDummyInside)
+                    .eval(prependElement, containerId)
+                    .wait(1)
+                    .eval(
+                        evaluateDummy,
+                        Types.TabsterDummyInputAttributeName,
+                        containerId
+                    )
+                    .check(checkDummyInside);
             }
         );
     });

--- a/tests/Focusable.test.tsx
+++ b/tests/Focusable.test.tsx
@@ -9,7 +9,7 @@ import * as BroTest from "./utils/BroTest";
 import { runIfControlled } from "./utils/test-utils";
 
 runIfControlled("Focusable", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true, groupper: true });
     });
 

--- a/tests/FocusedElement.test.tsx
+++ b/tests/FocusedElement.test.tsx
@@ -9,7 +9,7 @@ import * as BroTest from "./utils/BroTest";
 import { BrowserElement } from "./utils/BroTest";
 
 describe("onKeyDown", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({});
     });
 

--- a/tests/Internal.test.tsx
+++ b/tests/Internal.test.tsx
@@ -8,7 +8,7 @@ import { getTabsterAttribute } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
 describe("Internal", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ groupper: true });
     });
 

--- a/tests/KeyboardNavigationState.test.tsx
+++ b/tests/KeyboardNavigationState.test.tsx
@@ -8,7 +8,7 @@ import { getTabsterAttribute } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
 describe("keyboard navigation state", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true, groupper: true });
     });
 

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -30,7 +30,7 @@ describe("Modalizer", () => {
         );
     };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ modalizer: true });
     });
 
@@ -183,7 +183,7 @@ describe("New Modalizer that already has focus", () => {
         );
     };
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ modalizer: true });
     });
 

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -6,9 +6,10 @@
 import * as React from "react";
 import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
+import { runIfUnControlled } from "./utils/test-utils";
 
 describe("Mover", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
@@ -205,7 +206,7 @@ describe("Mover", () => {
 });
 
 describe("NestedMovers", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
@@ -322,7 +323,7 @@ describe("NestedMovers", () => {
 });
 
 describe("Mover memorizing current", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
@@ -425,7 +426,7 @@ describe("Mover memorizing current", () => {
 });
 
 describe("Mover with excluded part", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
@@ -587,7 +588,7 @@ describe("Mover with excluded part", () => {
 });
 
 describe("Mover with inputs inside", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
@@ -759,7 +760,7 @@ describe("Mover with inputs inside", () => {
 });
 
 describe("Mover with visibilityAware", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -6,7 +6,6 @@
 import * as React from "react";
 import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
-import { runIfUnControlled } from "./utils/test-utils";
 
 describe("Mover", () => {
     beforeEach(async () => {

--- a/tests/MoverGroupper.test.tsx
+++ b/tests/MoverGroupper.test.tsx
@@ -8,7 +8,7 @@ import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
 describe("MoverGroupper", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true, groupper: true });
     });
 

--- a/tests/ObservedElement.test.tsx
+++ b/tests/ObservedElement.test.tsx
@@ -8,7 +8,7 @@ import { getTabsterAttribute, Types } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
 describe("Focusable", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ observed: true });
     });
 

--- a/tests/Root.test.tsx
+++ b/tests/Root.test.tsx
@@ -19,7 +19,7 @@ interface WindowWithTabsterCoreAndFocusState extends Window {
 }
 
 runIfControlled("Root", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({});
     });
 

--- a/tests/Uncontrolled.test.tsx
+++ b/tests/Uncontrolled.test.tsx
@@ -9,7 +9,7 @@ import * as BroTest from "./utils/BroTest";
 import { runIfControlled } from "./utils/test-utils";
 
 runIfControlled("Uncontrolled", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true, groupper: true });
     });
 

--- a/tests/iframeFocus.test.tsx
+++ b/tests/iframeFocus.test.tsx
@@ -8,7 +8,7 @@ import { getTabsterAttribute } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
 describe("<iframe />", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ deloser: true });
     });
 


### PR DESCRIPTION
By default Grouppers in uncontrolled mode put dummy inputs outside of the container, which is bad HTML for elements like `<li>`, `<td>` and `<th>`. So, we handle that case putting dummy inputs inside when those elements are used.