### PR TITLE
feat(Groupper): Ability to delegate the role of focusable groupper container to first focusble element in groupper.

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -437,7 +437,13 @@ export class GroupperAPI implements Types.GroupperAPI {
 
                 if (includeTarget || !isTarget) {
                     this._current[groupper.id] = groupper;
-                    groupper.makeTabbable(element !== el);
+                    const isTabbable =
+                        groupper.isActive() ||
+                        (element !== el &&
+                            (!groupper.getProps().delegated ||
+                                groupper.getFirst(false) !== element));
+
+                    groupper.makeTabbable(isTabbable);
                 }
 
                 isTarget = false;
@@ -464,7 +470,7 @@ export class GroupperAPI implements Types.GroupperAPI {
 
         if (element) {
             const ctx = RootAPI.getTabsterContext(this._tabster, element);
-            const groupper = ctx?.groupper;
+            let groupper = ctx?.groupper;
 
             if (ctx && groupper) {
                 let next: HTMLElement | null | undefined;
@@ -476,7 +482,11 @@ export class GroupperAPI implements Types.GroupperAPI {
                         return;
                     }
 
-                    if (element === groupperElement) {
+                    if (
+                        element === groupperElement ||
+                        (groupper.getProps().delegated &&
+                            element === groupper.getFirst(false))
+                    ) {
                         next = this._tabster.focusable.findNext({
                             container: groupperElement,
                             currentElement: element,
@@ -499,11 +509,12 @@ export class GroupperAPI implements Types.GroupperAPI {
                                   )
                                 : undefined;
 
-                            next = parentCtx?.groupper?.getFirst(true);
+                            groupper = parentCtx?.groupper;
+                            next = groupper?.getFirst(true);
                         }
                     }
 
-                    if (next) {
+                    if (groupper) {
                         groupper.makeTabbable(false);
                     }
                 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -562,8 +562,7 @@ export interface MoverAPI extends MoverAPIInternal, Disposable {}
 
 export interface GroupperTabbabilities {
     Unlimited: 0;
-    Limited: 1; // The tabbability is limited to the container (or first element if container is not focusable)
-    // and explicit Enter is needed to go inside.
+    Limited: 1; // The tabbability is limited to the container and explicit Enter is needed to go inside.
     LimitedTrapFocus: 2; // The focus is limited as above, plus trapped when inside.
 }
 export const GroupperTabbabilities: GroupperTabbabilities = {
@@ -576,6 +575,12 @@ export type GroupperTabbability =
 
 export interface GroupperProps {
     tabbability?: GroupperTabbability;
+    delegated?: boolean; // This allows to tweak the groupper behaviour for the cases when
+    // the groupper container is not focusable and groupper has Limited or LimitedTrapFocus
+    // tabbability. By default, the groupper will automatically become active once the focus
+    // goes to first focusable element inside the groupper during tabbing. When true, the
+    // groupper will become active only after Enter is pressed on first focusable element
+    // inside the groupper.
 }
 
 export interface Groupper extends TabsterPart<GroupperProps> {

--- a/tests/Groupper.test.tsx
+++ b/tests/Groupper.test.tsx
@@ -11,13 +11,18 @@ import { runIfUnControlled } from "./utils/test-utils";
 const groupperItem = (
     tagName: "div" | "li",
     tabsterAttr: Types.TabsterDOMAttribute,
+    isFocusable: boolean,
     count: number
 ) => {
     const Tag = tagName;
     return (
-        <Tag tabIndex={0} {...tabsterAttr} data-count={`${count}`}>
-            <button>Foo</button>
-            <button>Bar</button>
+        <Tag
+            tabIndex={isFocusable ? 0 : undefined}
+            {...tabsterAttr}
+            data-count={`${count}`}
+        >
+            <button>Foo{count}</button>
+            <button>Bar{count}</button>
         </Tag>
     );
 };
@@ -58,10 +63,10 @@ describe("Groupper - default", () => {
 
         return (
             <div {...rootAttr}>
-                {groupperItem(tagName, groupperAttr, 1)}
-                {groupperItem(tagName, groupperAttr, 2)}
-                {groupperItem(tagName, groupperAttr, 3)}
-                {groupperItem(tagName, groupperAttr, 4)}
+                {groupperItem(tagName, groupperAttr, true, 1)}
+                {groupperItem(tagName, groupperAttr, true, 2)}
+                {groupperItem(tagName, groupperAttr, true, 3)}
+                {groupperItem(tagName, groupperAttr, true, 4)}
             </div>
         );
     };
@@ -83,7 +88,7 @@ describe("Groupper - default", () => {
             await new BroTest.BroTest(getTestHtml(tagName))
                 .pressTab()
                 .pressTab()
-                .activeElement((el) => expect(el?.textContent).toBe("Foo"));
+                .activeElement((el) => expect(el?.textContent).toBe("Foo1"));
         }
     );
 
@@ -108,7 +113,7 @@ describe("Groupper - default", () => {
                 })
                 .pressTab()
                 .pressTab()
-                .activeElement((el) => expect(el?.textContent).toEqual("Foo"))
+                .activeElement((el) => expect(el?.textContent).toEqual("Foo1"))
                 .pressEsc()
                 .activeElement((el) =>
                     expect(el?.attributes["data-count"]).toBe("1")
@@ -141,9 +146,9 @@ describe("Groupper - default", () => {
                 })
                 .pressTab()
                 .pressTab()
-                .activeElement((el) => expect(el?.textContent).toEqual("Foo"))
+                .activeElement((el) => expect(el?.textContent).toEqual("Foo1"))
                 .pressEsc()
-                .activeElement((el) => expect(el?.textContent).toEqual("Foo"))
+                .activeElement((el) => expect(el?.textContent).toEqual("Foo1"))
                 .eval(() => (window as WindowWithEscFlag).__escPressed2)
                 .check((escPressed: number) => {
                     expect(escPressed).toBe(1);
@@ -172,7 +177,7 @@ describe("Groupper - default", () => {
                 })
                 .pressTab()
                 .pressEnter()
-                .activeElement((el) => expect(el?.textContent).toEqual("Foo"))
+                .activeElement((el) => expect(el?.textContent).toEqual("Foo1"))
                 .eval(() => (window as WindowWithEnterFlag).__enterPressed1)
                 .check((escPressed: number) => {
                     expect(escPressed).toBe(0);
@@ -204,7 +209,7 @@ describe("Groupper - default", () => {
                 .pressTab()
                 .pressEnter()
                 .activeElement((el) =>
-                    expect(el?.textContent).toEqual("FooBar")
+                    expect(el?.textContent).toEqual("Foo1Bar1")
                 )
                 .eval(() => (window as WindowWithEnterFlag).__enterPressed2)
                 .check((escPressed: number) => {
@@ -219,20 +224,25 @@ describe("Groupper - limited focus trap", () => {
         await BroTest.bootstrapTabsterPage({ groupper: true });
     });
 
-    const getTestHtml = (tagName: "div" | "li") => {
+    const getTestHtml = (
+        tagName: "div" | "li",
+        isFocusable: boolean,
+        delegated: boolean
+    ) => {
         const rootAttr = getTabsterAttribute({ root: {} });
         const groupperAttr = getTabsterAttribute({
             groupper: {
                 tabbability: Types.GroupperTabbabilities.LimitedTrapFocus,
+                ...(delegated ? { delegated: true } : null),
             },
         });
 
         return (
             <div {...rootAttr}>
-                {groupperItem(tagName, groupperAttr, 1)}
-                {groupperItem(tagName, groupperAttr, 2)}
-                {groupperItem(tagName, groupperAttr, 3)}
-                {groupperItem(tagName, groupperAttr, 4)}
+                {groupperItem(tagName, groupperAttr, isFocusable, 1)}
+                {groupperItem(tagName, groupperAttr, isFocusable, 2)}
+                {groupperItem(tagName, groupperAttr, isFocusable, 3)}
+                {groupperItem(tagName, groupperAttr, isFocusable, 4)}
             </div>
         );
     };
@@ -240,17 +250,17 @@ describe("Groupper - limited focus trap", () => {
     it.each<["div" | "li"]>([["div"], ["li"]])(
         "should focus inside groupper as <%s> with Enter key",
         async (tagName) => {
-            await new BroTest.BroTest(getTestHtml(tagName))
+            await new BroTest.BroTest(getTestHtml(tagName, true, false))
                 .pressTab()
                 .pressEnter()
-                .activeElement((el) => expect(el?.textContent).toBe("Foo"));
+                .activeElement((el) => expect(el?.textContent).toBe("Foo1"));
         }
     );
 
     it.each<["div" | "li"]>([["div"], ["li"]])(
         "should escape focus inside groupper as <%s> with Escape key",
         async (tagName) => {
-            await new BroTest.BroTest(getTestHtml(tagName))
+            await new BroTest.BroTest(getTestHtml(tagName, true, false))
                 .pressTab()
                 .pressEnter()
                 .pressEsc()
@@ -263,13 +273,57 @@ describe("Groupper - limited focus trap", () => {
     it.each<["div" | "li"]>([["div"], ["li"]])(
         "should trap focus within groupper as <%s>",
         async (tagName) => {
-            await new BroTest.BroTest(getTestHtml(tagName))
+            await new BroTest.BroTest(getTestHtml(tagName, true, false))
                 .pressTab()
                 .pressEnter()
                 .pressTab()
-                .activeElement((el) => expect(el?.textContent).toBe("Bar"))
+                .activeElement((el) => expect(el?.textContent).toBe("Bar1"))
                 .pressTab()
-                .activeElement((el) => expect(el?.textContent).toBe("Foo"));
+                .activeElement((el) => expect(el?.textContent).toBe("Foo1"));
+        }
+    );
+
+    it.each<["div" | "li"]>([["div"], ["li"]])(
+        "should trap focus within groupper with not focusable container as <%s>",
+        async (tagName) => {
+            await new BroTest.BroTest(getTestHtml(tagName, false, false))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Foo1"))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Bar1"))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Foo1"))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Bar1"));
+        }
+    );
+
+    it.each<["div" | "li"]>([["div"], ["li"]])(
+        "should not trap focus within groupper with delegated prop and not focusable container as <%s>",
+        async (tagName) => {
+            await new BroTest.BroTest(getTestHtml(tagName, false, true))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Foo1"))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Foo2"))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Foo3"))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Foo4"))
+                .pressTab()
+                .activeElement((el) => {
+                    expect(el?.textContent).toBeUndefined();
+                })
+                .pressTab(true)
+                .activeElement((el) => expect(el?.textContent).toBe("Foo4"))
+                .pressTab(true)
+                .activeElement((el) => expect(el?.textContent).toBe("Foo3"))
+                .pressEnter()
+                .activeElement((el) => expect(el?.textContent).toBe("Bar3"))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Foo3"))
+                .pressTab()
+                .activeElement((el) => expect(el?.textContent).toBe("Bar3"));
         }
     );
 });

--- a/tests/MoverGroupper.test.tsx
+++ b/tests/MoverGroupper.test.tsx
@@ -969,4 +969,115 @@ describe("MoverGroupper", () => {
                 );
             });
     });
+
+    it("should handle tabbing in groupper/mover/groupper when the inner groupper container is delegated and not focusable", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button>Button1</button>
+                    <div
+                        id="outer-groupper"
+                        tabIndex={0}
+                        {...getTabsterAttribute({
+                            groupper: {
+                                tabbability:
+                                    Types.GroupperTabbabilities
+                                        .LimitedTrapFocus,
+                            },
+                        })}
+                    >
+                        <button>Button2</button>
+                        <div
+                            {...getTabsterAttribute({
+                                mover: {
+                                    visibilityAware:
+                                        Types.Visibilities.PartiallyVisible,
+                                },
+                            })}
+                        >
+                            <button>Button3</button>
+                            <div
+                                id="inner-groupper"
+                                {...getTabsterAttribute({
+                                    groupper: {
+                                        delegated: true,
+                                        tabbability:
+                                            Types.GroupperTabbabilities
+                                                .LimitedTrapFocus,
+                                    },
+                                })}
+                            >
+                                <button>Button4</button>
+                                <button>Button5</button>
+                            </div>
+                        </div>
+                        <button>Button6</button>
+                    </div>
+                    <button>Button7</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual(
+                    "Button2Button3Button4Button5Button6"
+                );
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button7");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual(
+                    "Button2Button3Button4Button5Button6"
+                );
+            })
+            .pressEnter()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .pressEnter()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            })
+            .pressEsc()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .pressEsc()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual(
+                    "Button2Button3Button4Button5Button6"
+                );
+            });
+    });
 });


### PR DESCRIPTION
Generally, when Groupper is Limited or LimitedTrapFocus, the groupper container focusable (so that Enter press on that container moves focus inside the groupper and Esc press moves focus from inside the groupper to the container). We are adding `delegated` property to Groupper which will allow first focusable inside the non-focusable groupper container to behave the same way as the focusable groupper container does.

The example `<div groupper tabindex=0>...</div>` should behave the same way as `<div groupper=delegated><div tabindex=0>...</div></div>` from the Enter/Esc/Tab pressing perspective, the role of focusable container is delegated to the first focusable inside the actual container.