### PR TITLE
chore: adds devcontainer to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dts/
 /.rollup.cache
 
 .npmrc
+
+# vs code devcontainer
+.devcontainer


### PR DESCRIPTION
Adds `.devcontainer` to `.gitignore` to ensure that if we're not providing our own dev container configuration we should opt out of having it in our repo.