### PR TITLE
chore: creates EventTarget ponyfill

### DIFF
--- a/src/EventTarget.ts
+++ b/src/EventTarget.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { GetWindow } from "./Types";
+
+export function createEventTarget(getWindow: GetWindow): EventTarget {
+    const global = getWindow() as unknown as typeof globalThis;
+    if ("EventTarget" in global) {
+        return new global.EventTarget();
+    }
+    return global.document.createElement("div");
+}

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { createEventTarget } from "./EventTarget";
 import { getTabsterOnElement } from "./Instance";
 import { KeyboardNavigationState } from "./State/KeyboardNavigation";
 import * as Types from "./Types";
@@ -269,7 +270,7 @@ export class RootAPI implements Types.RootAPI {
         this._win = tabster.getWindow;
         this._initTimer = this._win().setTimeout(this._init, 0);
         this._autoRoot = autoRoot;
-        this.eventTarget = new EventTarget();
+        this.eventTarget = createEventTarget(this._win);
     }
 
     private _init = (): void => {


### PR DESCRIPTION
As a follow up on https://github.com/microsoft/fluentui/issues/24721, to ensure support browser matrix, we'll have to stop using `EventTarget`.

This PR adds a ponyfill method `createEventTarget`, that will create a `div` element and use it as an `EventTarget` in the cases where `EventTarget` class is not available in the `window`.


Fixes https://github.com/microsoft/fluentui/issues/24721