### PR TITLE
fix: Modalizer aria-label warning should be less severe

### DIFF
--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -293,9 +293,8 @@ export class Modalizer
                 !element.getAttribute("aria-label") &&
                 !element.getAttribute("aria-labelledby")
             ) {
-                console.error(
-                    "Modalizer element must have either aria-label or aria-labelledby",
-                    element
+                console.warn(
+                    `Modalizer ${this.id} must have either aria-label or aria-labelledby`
                 );
             }
         }


### PR DESCRIPTION
Removes the element logging from the warning since it can show up as false-positive memory leak

Also downgrades the message to `warn` since correct labelling should be handled at a higher level.