### PR TITLE
fix(Core): Fixing makeNoOp().

### DIFF
--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -461,11 +461,11 @@ export function getCurrentTabster(win: Window): Types.TabsterCore | undefined {
     return (win as WindowWithTabsterInstance).__tabsterInstance;
 }
 
-export function makeNoOp(tabster: Types.TabsterCore, noop: boolean): void {
-    const self = tabster as TabsterCore;
+export function makeNoOp(tabster: Types.Tabster, noop: boolean): void {
+    const core = tabster.core;
 
-    if (self._noop !== noop) {
-        self._noop = noop;
+    if (core._noop !== noop) {
+        core._noop = noop;
 
         const processNode = (element: HTMLElement): number => {
             if (!element.getAttribute) {
@@ -473,16 +473,16 @@ export function makeNoOp(tabster: Types.TabsterCore, noop: boolean): void {
             }
 
             if (
-                getTabsterOnElement(self, element) ||
+                getTabsterOnElement(core, element) ||
                 element.hasAttribute(Types.TabsterAttributeName)
             ) {
-                updateTabsterByAttribute(self, element);
+                updateTabsterByAttribute(core, element);
             }
 
             return NodeFilter.FILTER_SKIP;
         };
 
-        const doc = self.getWindow().document;
+        const doc = core.getWindow().document;
         const body = doc.body;
 
         processNode(body);

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -461,6 +461,13 @@ export function getCurrentTabster(win: Window): Types.TabsterCore | undefined {
     return (win as WindowWithTabsterInstance).__tabsterInstance;
 }
 
+/**
+ * Allows to make Tabster non operational. Intended for performance debugging (and other
+ * kinds of debugging), you can switch Tabster off without changing the application code
+ * that consumes it.
+ * @param tabster a reference created by createTabster().
+ * @param noop true if you want to make Tabster noop, false if you want to turn it back.
+ */
 export function makeNoOp(tabster: Types.Tabster, noop: boolean): void {
     const core = tabster.core;
 

--- a/tests/Tabster.test.tsx
+++ b/tests/Tabster.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import * as React from "react";
+import { getTabsterAttribute } from "tabster";
 import * as BroTest from "./utils/BroTest";
 
 interface WindowWithTabster extends Window {
@@ -117,6 +118,50 @@ describe("Tabster dispose", () => {
             })
             .check((tabsterExists) => {
                 expect(tabsterExists).toEqual([true, true, false]);
+            });
+    });
+
+    it("should make Tabster noop", async () => {
+        await new BroTest.BroTest(
+            <div id="root" {...getTabsterAttribute({ root: {} })} />
+        )
+            .eval(() => {
+                const root = document.getElementById("root");
+                return !!(
+                    root &&
+                    getTabsterTestVariables().core?.core.storageEntry(root)
+                );
+            })
+            .check((exists) => {
+                expect(exists).toEqual(true);
+            })
+            .eval(() => {
+                const tabsterTest = getTabsterTestVariables();
+
+                if (tabsterTest.core) {
+                    tabsterTest.makeNoOp?.(tabsterTest.core, true);
+                }
+
+                const root = document.getElementById("root");
+
+                return !!(root && tabsterTest.core?.core.storageEntry(root));
+            })
+            .check((exists) => {
+                expect(exists).toEqual(false);
+            })
+            .eval(() => {
+                const tabsterTest = getTabsterTestVariables();
+
+                if (tabsterTest.core) {
+                    tabsterTest.makeNoOp?.(tabsterTest.core, false);
+                }
+
+                const root = document.getElementById("root");
+
+                return !!(root && tabsterTest.core?.core.storageEntry(root));
+            })
+            .check((exists) => {
+                expect(exists).toEqual(true);
             });
     });
 });

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,6 +14,7 @@
                 getMover,
                 getObservedElement,
                 getOutline,
+                makeNoOp,
             } from "../src";
 
             const tabsterTest = {};
@@ -37,6 +38,7 @@
             tabsterTest.createTabster = createTabster;
             tabsterTest.disposeTabster = disposeTabster;
             tabsterTest.getTabster = getTabster;
+            tabsterTest.makeNoOp = makeNoOp;
 
             tabsterTest.core = tabster;
 

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -11,7 +11,13 @@ import {
     Frame,
     KeyInput,
 } from "puppeteer";
-import { createTabster, disposeTabster, getTabster, Types } from "tabster";
+import {
+    createTabster,
+    disposeTabster,
+    getTabster,
+    makeNoOp,
+    Types,
+} from "tabster";
 
 // Importing the production version so that React doesn't complain in the test output.
 declare function require(name: string): any;
@@ -88,6 +94,7 @@ export interface BroTestTabsterTestVariables {
     disposeTabster?: typeof disposeTabster;
     createTabster?: typeof createTabster;
     getTabster?: typeof getTabster;
+    makeNoOp?: typeof makeNoOp;
     core?: Types.Tabster;
     modalizer?: Types.ModalizerAPI;
     deloser?: Types.DeloserAPI;


### PR DESCRIPTION
makeNoOp() is broken since we've added core wrappers for createTabster().