### PR TITLE
fix: Mover should not ignore non-text inputs

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -25,7 +25,11 @@ import {
     WeakHTMLElement,
 } from "./Utils";
 
-const _inputSelector = ["input", "textarea", "*[contenteditable]"].join(", ");
+const _inputSelector = [
+    "input[type='text']",
+    "textarea",
+    "*[contenteditable]",
+].join(", ");
 
 class MoverDummyManager extends DummyInputManager {
     private _tabster: Types.TabsterCore;

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -25,11 +25,15 @@ import {
     WeakHTMLElement,
 } from "./Utils";
 
-const _inputSelector = [
+const _textInputSelector = [
     "input[type='text']",
     "textarea",
     "*[contenteditable]",
 ].join(", ");
+
+const _inputExclusions = ["input[type='radio']", "input[type='checkbox']"].join(
+    ", "
+);
 
 class MoverDummyManager extends DummyInputManager {
     private _tabster: Types.TabsterCore;
@@ -1015,7 +1019,10 @@ export class MoverAPI implements Types.MoverAPI {
             return true;
         }
 
-        if (matchesSelector(element, _inputSelector)) {
+        if (
+            matchesSelector(element, _textInputSelector) &&
+            !matchesSelector(element, _inputExclusions)
+        ) {
             let selectionStart = 0;
             let selectionEnd = 0;
             let textLength = 0;

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -31,9 +31,10 @@ const _textInputSelector = [
     "*[contenteditable]",
 ].join(", ");
 
-const _inputExclusions = ["input[type='radio']", "input[type='checkbox']"].join(
-    ", "
-);
+const _nonTextInputSelector = [
+    "input[type='radio']",
+    "input[type='checkbox']",
+].join(", ");
 
 class MoverDummyManager extends DummyInputManager {
     private _tabster: Types.TabsterCore;
@@ -1021,7 +1022,7 @@ export class MoverAPI implements Types.MoverAPI {
 
         if (
             matchesSelector(element, _textInputSelector) &&
-            !matchesSelector(element, _inputExclusions)
+            !matchesSelector(element, _nonTextInputSelector)
         ) {
             let selectionStart = 0;
             let selectionEnd = 0;

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -25,11 +25,9 @@ import {
     WeakHTMLElement,
 } from "./Utils";
 
-const _textInputSelector = [
-    "input[type='text']",
-    "textarea",
-    "*[contenteditable]",
-].join(", ");
+const _textInputSelector = ["input", "textarea", "*[contenteditable]"].join(
+    ", "
+);
 
 const _nonTextInputSelector = [
     "input[type='radio']",

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -591,6 +591,30 @@ describe("Mover with inputs inside", () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
+    it("should move for checkbox inputs", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ mover: {} })}>
+                    <input type="checkbox" id="first" />
+                    <input type="checkbox" id="second" />
+                    <input type="checkbox" id="third" />
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) =>
+                expect(el?.attributes["id"]).toEqual("first")
+            )
+            .pressDown()
+            .activeElement((el) =>
+                expect(el?.attributes["id"]).toEqual("second")
+            )
+            .pressDown()
+            .activeElement((el) =>
+                expect(el?.attributes["id"]).toEqual("third")
+            );
+    });
+
     it("should move or not move focus depending on caret position", async () => {
         await new BroTest.BroTest(
             (


### PR DESCRIPTION
The `Mover`current ignores all inputs by using the selector `input` https://github.com/microsoft/tabster/blob/90ca3718a81fe53730a23d6cddae87cbbf54ff2f/src/Mover.ts#L28

- updates the current `_inputSelector` to be `_textInputSelector` to be more specific and adds a specific list of exclusions under `_nonTextInputSelector`


Fixes #211