### PR TITLE
Fixing autoRoot and moving Tabster attribute helpers to a separate file.

### DIFF
--- a/src/AttributeHelpers.ts
+++ b/src/AttributeHelpers.ts
@@ -1,0 +1,99 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as Types from "./Types";
+
+export function getTabsterAttribute(
+    props: Types.TabsterAttributeProps
+): Types.TabsterDOMAttribute;
+export function getTabsterAttribute(
+    props: Types.TabsterAttributeProps,
+    plain: true
+): string;
+export function getTabsterAttribute(
+    props: Types.TabsterAttributeProps,
+    plain?: true
+): Types.TabsterDOMAttribute | string {
+    const attr = JSON.stringify(props);
+
+    if (plain === true) {
+        return attr;
+    }
+
+    return {
+        [Types.TabsterAttributeName]: attr,
+    };
+}
+
+/**
+ * Updates Tabster props object with new props.
+ * @param element an element to set data-tabster attribute on.
+ * @param props current Tabster props to update.
+ * @param newProps new Tabster props to add.
+ *  When the value of a property in newProps is undefined, the property
+ *  will be removed from the attribute.
+ */
+export function mergeTabsterProps(
+    props: Types.TabsterAttributeProps,
+    newProps: Types.TabsterAttributeProps
+): void {
+    for (const key of Object.keys(
+        newProps
+    ) as (keyof Types.TabsterAttributeProps)[]) {
+        const value = newProps[key];
+
+        if (value) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            props[key] = value as any;
+        } else {
+            delete props[key];
+        }
+    }
+}
+
+/**
+ * Sets or updates Tabster attribute of the element.
+ * @param element an element to set data-tabster attribute on.
+ * @param newProps new Tabster props to set.
+ * @param update if true, newProps will be merged with the existing props.
+ *  When true and the value of a property in newProps is undefined, the property
+ *  will be removed from the attribute.
+ */
+export function setTabsterAttribute(
+    element: HTMLElement,
+    newProps: Types.TabsterAttributeProps,
+    update?: boolean
+): void {
+    let props: Types.TabsterAttributeProps | undefined;
+
+    if (update) {
+        const attr = element.getAttribute(Types.TabsterAttributeName);
+
+        if (attr) {
+            try {
+                props = JSON.parse(attr);
+            } catch (e) {
+                /**/
+            }
+        }
+    }
+
+    if (!props) {
+        props = {};
+    }
+
+    if (update) {
+        mergeTabsterProps(props, newProps);
+    }
+
+    if (Object.keys(props).length > 0) {
+        element.setAttribute(
+            Types.TabsterAttributeName,
+            getTabsterAttribute(props, true)
+        );
+    } else {
+        element.removeAttribute(Types.TabsterAttributeName);
+    }
+}

--- a/src/AttributeHelpers.ts
+++ b/src/AttributeHelpers.ts
@@ -75,7 +75,12 @@ export function setTabsterAttribute(
             try {
                 props = JSON.parse(attr);
             } catch (e) {
-                /**/
+                if (__DEV__) {
+                    console.error(
+                        `data-tabster attribute error: ${e}`,
+                        element
+                    );
+                }
             }
         }
     }

--- a/src/AttributeHelpers.ts
+++ b/src/AttributeHelpers.ts
@@ -89,9 +89,7 @@ export function setTabsterAttribute(
         props = {};
     }
 
-    if (update) {
-        mergeTabsterProps(props, newProps);
-    }
+    mergeTabsterProps(props, newProps);
 
     if (Object.keys(props).length > 0) {
         element.setAttribute(

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -299,10 +299,8 @@ export class RootAPI implements Types.RootAPI {
     };
 
     private _autoRootUnwait(doc: Document): void {
-        if (this._autoRootWaiting) {
-            doc.removeEventListener("readystatechange", this._autoRootCreate);
-            this._autoRootWaiting = false;
-        }
+        doc.removeEventListener("readystatechange", this._autoRootCreate);
+        this._autoRootWaiting = false;
     }
 
     dispose(): void {

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -4,7 +4,7 @@
  */
 
 import { createEventTarget } from "./EventTarget";
-import { getTabsterOnElement } from "./Instance";
+import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance";
 import * as Types from "./Types";
 import {
     DummyInput,
@@ -266,18 +266,23 @@ export class RootAPI implements Types.RootAPI {
         this._tabster = tabster;
         this._win = tabster.getWindow;
         this._initTimer = this._win().setTimeout(this._init, 0);
-        if (autoRoot) {
-            this._autoRoot = autoRoot;
-            this._autoRootCreate();
-        }
+        this._autoRoot = autoRoot;
         this.eventTarget = createEventTarget(this._win);
     }
 
     private _init = (): void => {
         this._initTimer = undefined;
+
+        if (this._autoRoot) {
+            this._autoRootCreate();
+        }
     };
 
     private _autoRootCreate = (): Types.Root | undefined => {
+        if (this._initTimer) {
+            return;
+        }
+
         const doc = this._win().document;
         const body = doc.body;
 
@@ -288,6 +293,7 @@ export class RootAPI implements Types.RootAPI {
 
             if (props) {
                 setTabsterAttribute(body, { root: props }, true);
+                updateTabsterByAttribute(this._tabster, body);
                 return getTabsterOnElement(this._tabster, body)?.root;
             }
         } else if (!this._autoRootWaiting) {

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -315,10 +315,8 @@ export class RootAPI implements Types.RootAPI {
         this._autoRootUnwait(win.document);
         delete this._autoRoot;
 
-        if (this._initTimer) {
-            win.clearTimeout(this._initTimer);
-            this._initTimer = undefined;
-        }
+        win.clearTimeout(this._initTimer);
+        this._initTimer = undefined;
 
         Object.keys(this._roots).forEach((rootId) => {
             if (this._roots[rootId]) {

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -15,6 +15,7 @@ import {
     triggerEvent,
     WeakHTMLElement,
 } from "./Utils";
+import { setTabsterAttribute } from "./AttributeHelpers";
 
 export interface WindowWithTabsterInstance extends Window {
     __tabsterInstance?: Types.TabsterCore;
@@ -256,7 +257,7 @@ export class RootAPI implements Types.RootAPI {
     private _win: Types.GetWindow;
     private _initTimer: number | undefined;
     private _autoRoot: Types.RootProps | undefined;
-    private _autoRootInstance: Root | undefined;
+    private _autoRootWaiting = false;
     private _roots: Record<string, Types.Root> = {};
     rootById: { [id: string]: Types.Root } = {};
     eventTarget: EventTarget;
@@ -265,7 +266,10 @@ export class RootAPI implements Types.RootAPI {
         this._tabster = tabster;
         this._win = tabster.getWindow;
         this._initTimer = this._win().setTimeout(this._init, 0);
-        this._autoRoot = autoRoot;
+        if (autoRoot) {
+            this._autoRoot = autoRoot;
+            this._autoRootCreate();
+        }
         this.eventTarget = createEventTarget(this._win);
     }
 
@@ -273,14 +277,39 @@ export class RootAPI implements Types.RootAPI {
         this._initTimer = undefined;
     };
 
+    private _autoRootCreate = (): Types.Root | undefined => {
+        const doc = this._win().document;
+        const body = doc.body;
+
+        if (body) {
+            this._autoRootUnwait(doc);
+
+            const props = this._autoRoot;
+
+            if (props) {
+                setTabsterAttribute(body, { root: props }, true);
+                return getTabsterOnElement(this._tabster, body)?.root;
+            }
+        } else if (!this._autoRootWaiting) {
+            this._autoRootWaiting = true;
+            doc.addEventListener("readystatechange", this._autoRootCreate);
+        }
+
+        return undefined;
+    };
+
+    private _autoRootUnwait(doc: Document): void {
+        if (this._autoRootWaiting) {
+            doc.removeEventListener("readystatechange", this._autoRootCreate);
+            this._autoRootWaiting = false;
+        }
+    }
+
     dispose(): void {
         const win = this._win();
 
-        if (this._autoRootInstance) {
-            this._autoRootInstance.dispose();
-            delete this._autoRootInstance;
-            delete this._autoRoot;
-        }
+        this._autoRootUnwait(win.document);
+        delete this._autoRoot;
 
         if (this._initTimer) {
             win.clearTimeout(this._initTimer);
@@ -418,20 +447,11 @@ export class RootAPI implements Types.RootAPI {
             const rootAPI = tabster.root as RootAPI;
             const autoRoot = rootAPI._autoRoot;
 
-            if (autoRoot && !rootAPI._autoRootInstance) {
-                const body = element.ownerDocument?.body;
-
-                if (body) {
-                    rootAPI._autoRootInstance = new Root(
-                        rootAPI._tabster,
-                        body,
-                        rootAPI._onRootDispose,
-                        autoRoot
-                    );
+            if (autoRoot) {
+                if (element.ownerDocument?.body) {
+                    root = rootAPI._autoRootCreate();
                 }
             }
-
-            root = rootAPI._autoRootInstance;
         }
 
         if (groupper && !mover) {

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -29,6 +29,7 @@ import {
 } from "./Utils";
 
 export { Types };
+export * from "./AttributeHelpers";
 
 class Tabster implements Types.Tabster {
     keyboardNavigation: Types.KeyboardNavigationState;
@@ -375,82 +376,6 @@ export function disposeTabster(
     allInstances?: boolean
 ): void {
     tabster.core.disposeTabster(tabster, allInstances);
-}
-
-export function getTabsterAttribute(
-    props: Types.TabsterAttributeProps
-): Types.TabsterDOMAttribute;
-export function getTabsterAttribute(
-    props: Types.TabsterAttributeProps,
-    plain: true
-): string;
-export function getTabsterAttribute(
-    props: Types.TabsterAttributeProps,
-    plain?: true
-): Types.TabsterDOMAttribute | string {
-    const attr = JSON.stringify(props);
-
-    if (plain === true) {
-        return attr;
-    }
-
-    return {
-        [Types.TabsterAttributeName]: attr,
-    };
-}
-
-/**
- * Sets or updates Tabster attribute of the element.
- * @param element an element to set data-tabster attribute on.
- * @param newProps new Tabster props to set.
- * @param update if true, newProps will be merged with the existing props.
- *  When true and the value of a property in newProps is undefined, the property
- *  will be removed from the attribute.
- */
-export function setTabsterAttribute(
-    element: HTMLElement,
-    newProps: Types.TabsterAttributeProps,
-    update?: boolean
-): void {
-    let props: Types.TabsterAttributeProps | undefined;
-
-    if (update) {
-        const attr = element.getAttribute(Types.TabsterAttributeName);
-
-        if (attr) {
-            try {
-                props = JSON.parse(attr);
-            } catch (e) {
-                /**/
-            }
-        }
-    }
-
-    if (!update || !props) {
-        props = {};
-    }
-
-    for (const key of Object.keys(
-        newProps
-    ) as (keyof Types.TabsterAttributeProps)[]) {
-        const value = newProps[key];
-
-        if (value) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            props[key] = value as any;
-        } else {
-            delete props[key];
-        }
-    }
-
-    if (Object.keys(props).length > 0) {
-        element.setAttribute(
-            Types.TabsterAttributeName,
-            getTabsterAttribute(props, true)
-        );
-    } else {
-        element.removeAttribute(Types.TabsterAttributeName);
-    }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
     getTabster,
     disposeTabster,
     forceCleanup,
+    mergeTabsterProps,
     getTabsterAttribute,
     setTabsterAttribute,
     getGroupper,

--- a/tests/AttributeHelpers.test.tsx
+++ b/tests/AttributeHelpers.test.tsx
@@ -1,0 +1,153 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as React from "react";
+import { Types, getTabsterAttribute, mergeTabsterProps } from "tabster";
+import * as BroTest from "./utils/BroTest";
+
+describe("getTabsterAttribute()", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({
+            mover: true,
+            groupper: true,
+            modalizer: true,
+        });
+    });
+
+    it("should return Tabster attribute", () => {
+        expect(
+            getTabsterAttribute({
+                root: {},
+                deloser: {},
+                modalizer: { id: "test" },
+            })
+        ).toEqual({
+            "data-tabster": JSON.stringify({
+                root: {},
+                deloser: {},
+                modalizer: { id: "test" },
+            }),
+        });
+
+        expect(
+            getTabsterAttribute(
+                {
+                    root: {},
+                    deloser: {},
+                    modalizer: { id: "test" },
+                },
+                true
+            )
+        ).toEqual(
+            JSON.stringify({
+                root: {},
+                deloser: {},
+                modalizer: { id: "test" },
+            })
+        );
+    });
+
+    it("should set Tabster attribute", async () => {
+        await new BroTest.BroTest(
+            (
+                <div>
+                    <div id="div1"></div>
+                    <div
+                        id="div2"
+                        {...getTabsterAttribute({
+                            mover: {},
+                            modalizer: { id: "test" },
+                        })}
+                    ></div>
+                </div>
+            )
+        )
+            .eval(() => {
+                const div1 = document.getElementById("div1");
+                const div2 = document.getElementById("div2");
+
+                if (div1) {
+                    getTabsterTestVariables().setTabsterAttribute?.(div1, {
+                        groupper: {},
+                        modalizer: { id: "ololo" },
+                    });
+                }
+
+                if (div2) {
+                    getTabsterTestVariables().setTabsterAttribute?.(
+                        div2,
+                        {
+                            groupper: {},
+                            modalizer: undefined,
+                        },
+                        true
+                    );
+                }
+
+                return {
+                    div1: div1?.getAttribute("data-tabster"),
+                    div2: div2?.getAttribute("data-tabster"),
+                };
+            })
+            .check((attrs: { div1?: string; div2?: string }) => {
+                expect(attrs.div1).toEqual(
+                    JSON.stringify({
+                        groupper: {},
+                        modalizer: { id: "ololo" },
+                    })
+                );
+                expect(attrs.div2).toEqual(
+                    JSON.stringify({ mover: {}, groupper: {} })
+                );
+            })
+            .eval(() => {
+                const div1 = document.getElementById("div1");
+                const div2 = document.getElementById("div2");
+
+                if (div1) {
+                    getTabsterTestVariables().setTabsterAttribute?.(
+                        div1,
+                        {
+                            groupper: undefined,
+                            modalizer: undefined,
+                        },
+                        true
+                    );
+                }
+
+                if (div2) {
+                    getTabsterTestVariables().setTabsterAttribute?.(div2, {
+                        groupper: undefined,
+                        mover: undefined,
+                    });
+                }
+
+                return [
+                    div1?.getAttribute("data-tabster") === null,
+                    div2?.getAttribute("data-tabster") === null,
+                ];
+            })
+            .check((isNull?: boolean[]) => {
+                expect(isNull).toEqual([true, true]);
+            });
+    });
+
+    it("should merge Tabster props", () => {
+        const props1: Types.TabsterAttributeProps = {
+            deloser: {},
+            modalizer: { id: "test" },
+        };
+
+        const props2: Types.TabsterAttributeProps = {
+            deloser: undefined,
+            groupper: {},
+            modalizer: { id: "test2" },
+        };
+
+        mergeTabsterProps(props1, props2);
+
+        expect(props1).toEqual({ groupper: {}, modalizer: { id: "test2" } });
+    });
+});

--- a/tests/DummyInputManager.test.tsx
+++ b/tests/DummyInputManager.test.tsx
@@ -72,7 +72,7 @@ describeIfUncontrolled("DummyInputManager", () => {
             const moverId = "mover";
 
             const testHtml = (
-                <div>
+                <div {...getTabsterAttribute({ root: {} })}>
                     <div {...attr} id={moverId}>
                         <button>Button1</button>
                         <button>Button2</button>
@@ -120,7 +120,7 @@ describeIfUncontrolled("DummyInputManager", () => {
             const moverId = "mover";
 
             const testHtml = (
-                <div>
+                <div {...getTabsterAttribute({ root: {} })}>
                     <button>Button1</button>
                     <div
                         id={scrollId}
@@ -210,7 +210,7 @@ describeIfUncontrolled("DummyInputManager", () => {
             const groupperId = "groupper";
 
             const testHtml = (
-                <div>
+                <div {...getTabsterAttribute({ root: {} })}>
                     <div {...attr} id={groupperId}>
                         <button>Button1</button>
                         <button>Button2</button>
@@ -253,7 +253,7 @@ describeIfUncontrolled("DummyInputManager", () => {
             const modalizerAPIId = "modalizerAPI";
 
             const testHtml = (
-                <div>
+                <div {...getTabsterAttribute({ root: {} })}>
                     <div {...attr} aria-label="modalizer">
                         <button>Button1</button>
                         <button>Button2</button>
@@ -301,7 +301,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 const containerId = "outside";
                 const Tag = tagName;
                 const testHtml = (
-                    <div>
+                    <div {...getTabsterAttribute({ root: {} })}>
                         <Tag {...attr} id={containerId}>
                             <li>
                                 <button>Button1</button>
@@ -350,7 +350,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 const containerId = "inside";
                 const Tag = tagName;
                 const testHtml = (
-                    <div>
+                    <div {...getTabsterAttribute({ root: {} })}>
                         <table>
                             <Tag {...attr} id={containerId}>
                                 <button>Button1</button>

--- a/tests/index.html
+++ b/tests/index.html
@@ -15,6 +15,9 @@
                 getObservedElement,
                 getOutline,
                 makeNoOp,
+                mergeTabsterProps,
+                getTabsterAttribute,
+                setTabsterAttribute,
             } from "../src";
 
             const tabsterTest = {};
@@ -39,6 +42,9 @@
             tabsterTest.disposeTabster = disposeTabster;
             tabsterTest.getTabster = getTabster;
             tabsterTest.makeNoOp = makeNoOp;
+            tabsterTest.getTabsterAttribute = getTabsterAttribute;
+            tabsterTest.setTabsterAttribute = setTabsterAttribute;
+            tabsterTest.mergeTabsterProps = mergeTabsterProps;
 
             tabsterTest.core = tabster;
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -33,7 +33,6 @@
             }
 
             const tabster = createTabster(window, {
-                autoRoot: {},
                 controlTab,
                 rootDummyInputs,
             });

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -15,7 +15,10 @@ import {
     createTabster,
     disposeTabster,
     getTabster,
+    getTabsterAttribute,
     makeNoOp,
+    mergeTabsterProps,
+    setTabsterAttribute,
     Types,
 } from "tabster";
 
@@ -95,6 +98,9 @@ export interface BroTestTabsterTestVariables {
     createTabster?: typeof createTabster;
     getTabster?: typeof getTabster;
     makeNoOp?: typeof makeNoOp;
+    getTabsterAttribute?: typeof getTabsterAttribute;
+    setTabsterAttribute?: typeof setTabsterAttribute;
+    mergeTabsterProps?: typeof mergeTabsterProps;
     core?: Types.Tabster;
     modalizer?: Types.ModalizerAPI;
     deloser?: Types.DeloserAPI;


### PR DESCRIPTION
* Fixing autoRoot not functioning properly for Modalizer scenarios.
* Moving Tabster attribute helper functions to a separate file.
* Adding mergeTabsterProps().