### PR TITLE
feat: Mover should support `ignoreKeydown` property

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -473,15 +473,15 @@ export class GroupperAPI implements Types.GroupperAPI {
             let groupper = ctx?.groupper;
 
             if (ctx && groupper) {
+                if (ctx.ignoreKeydown(e)) {
+                    return;
+                }
+
                 let next: HTMLElement | null | undefined;
 
                 const groupperElement = groupper.getElement();
 
                 if (e.keyCode === Keys.Enter) {
-                    if (ctx.ignoreKeydown.Enter) {
-                        return;
-                    }
-
                     if (
                         element === groupperElement ||
                         (groupper.getProps().delegated &&
@@ -493,10 +493,6 @@ export class GroupperAPI implements Types.GroupperAPI {
                         });
                     }
                 } else if (e.keyCode === Keys.Esc) {
-                    if (ctx.ignoreKeydown.Escape) {
-                        return;
-                    }
-
                     if (groupperElement && groupperElement.contains(element)) {
                         if (element !== groupperElement) {
                             next = groupper.getFirst(true);

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -772,7 +772,12 @@ export class MoverAPI implements Types.MoverAPI {
             checkRtl: true,
         });
 
-        if (!ctx || !ctx.mover || ctx.isExcludedFromMover) {
+        if (
+            !ctx ||
+            !ctx.mover ||
+            ctx.isExcludedFromMover ||
+            ctx.ignoreKeydown(e)
+        ) {
             return;
         }
 

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -438,6 +438,9 @@ export class RootAPI implements Types.RootAPI {
             isGroupperFirst = true;
         }
 
+        const shouldIgnoreKeydown = (event: KeyboardEvent) =>
+            !!ignoreKeydown[event.key as "Tab"];
+
         return root
             ? {
                   root,
@@ -448,7 +451,7 @@ export class RootAPI implements Types.RootAPI {
                   isRtl: checkRtl ? !!isRtl : undefined,
                   uncontrolled,
                   isExcludedFromMover,
-                  ignoreKeydown,
+                  ignoreKeydown: shouldIgnoreKeydown,
               }
             : undefined;
     }

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -15,7 +15,6 @@ import {
     getAdjacentElement,
     shouldIgnoreFocus,
     WeakHTMLElement,
-    shouldIgnoreKeydown,
 } from "../Utils";
 import { Subscribable } from "./Subscribable";
 

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -15,6 +15,7 @@ import {
     getAdjacentElement,
     shouldIgnoreFocus,
     WeakHTMLElement,
+    shouldIgnoreKeydown,
 } from "../Utils";
 import { Subscribable } from "./Subscribable";
 
@@ -494,7 +495,7 @@ export class FocusedElementState
         if (
             !ctx ||
             (!controlTab && !ctx.groupper && !ctx.mover) ||
-            ctx.ignoreKeydown[e.key as "Tab"]
+            ctx.ignoreKeydown(e)
         ) {
             return;
         }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -338,6 +338,12 @@ export interface FocusableProps {
         Tab?: boolean;
         Escape?: boolean;
         Enter?: boolean;
+        ArrowUp?: boolean;
+        ArrowDown?: boolean;
+        PageUp?: boolean;
+        PageDown?: boolean;
+        Home?: boolean;
+        End?: boolean;
     };
 }
 
@@ -717,7 +723,7 @@ export interface TabsterContext {
      */
     uncontrolled?: HTMLElement;
     isExcludedFromMover?: boolean;
-    ignoreKeydown: NonNullable<FocusableProps["ignoreKeydown"]>;
+    ignoreKeydown: (e: KeyboardEvent) => boolean;
 }
 
 export interface RootFocusEventDetails {

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -319,6 +319,41 @@ describe("NestedMovers", () => {
             .pressTab(true)
             .activeElement((el) => expect(el?.textContent).toEqual("Target"));
     });
+
+    it.each([
+        "ArrowDown",
+        "ArrowUp",
+        "PageDown",
+        "PageUp",
+        "Home",
+        "End",
+    ] as const)("should ignore %s key", async (key) => {
+        const attr = getTabsterAttribute({
+            mover: {
+                direction: Types.MoverDirections.Vertical,
+                cyclic: true,
+            },
+            focusable: {
+                ignoreKeydown: {
+                    [key]: true,
+                },
+            },
+        });
+
+        await new BroTest.BroTest(
+            (
+                <div {...attr} id="mover">
+                    <button id="start">Mover Item</button>
+                    <button>Mover Item</button>
+                    <button>Mover Item</button>
+                    <button>Mover Item</button>
+                </div>
+            )
+        )
+            .focusElement("#start")
+            .press(key)
+            .activeElement((el) => expect(el?.attributes.id).toEqual("start"));
+    });
 });
 
 describe("Mover memorizing current", () => {


### PR DESCRIPTION
Adds a check in the `Mover` keydown handler to check for `ignoreKeydown`. Also refactors the tabster context to return a utility function for `ignoreKeydown` instead of the entire object map.