### PR TITLE
fix: Mover should ignore CTRL key

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -760,6 +760,10 @@ export class MoverAPI implements Types.MoverAPI {
         this._ignoredInputResolve?.(false);
 
         let keyCode = e.keyCode;
+        // Mover does not use ctrl key currently
+        if (e.ctrlKey) {
+            return;
+        }
 
         switch (keyCode) {
             case Keys.Down:

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -364,6 +364,47 @@ describe("NestedMovers", () => {
             .press(key)
             .activeElement((el) => expect(el?.attributes.id).toEqual("start"));
     });
+
+    it.each([
+        "ArrowDown",
+        "ArrowUp",
+        "PageDown",
+        "PageUp",
+        "Home",
+        "End",
+    ] as const)("should ignore CTRL key with %s", async (key) => {
+        const attr = getTabsterAttribute({
+            mover: {
+                direction: Types.MoverDirections.Vertical,
+                cyclic: true,
+            },
+            focusable: {
+                ignoreKeydown: {
+                    [key]: true,
+                },
+            },
+        });
+
+        await new BroTest.BroTest(
+            (
+                <div
+                    {...getTabsterAttribute({
+                        root: {},
+                    })}
+                >
+                    <div {...attr} id="mover">
+                        <button id="start">Mover Item</button>
+                        <button>Mover Item</button>
+                        <button>Mover Item</button>
+                        <button>Mover Item</button>
+                    </div>
+                </div>
+            )
+        )
+            .focusElement("#start")
+            .press(key, { ctrl: true })
+            .activeElement((el) => expect(el?.attributes.id).toEqual("start"));
+    });
 });
 
 describe("Mover memorizing current", () => {

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -465,7 +465,12 @@ export class BroTest implements PromiseLike<undefined> {
     press(
         key: KeyInput,
         options?:
-            | { text?: string | undefined; delay?: number | undefined; ctrl?: boolean; shift?: boolean }
+            | {
+                  text?: string | undefined;
+                  delay?: number | undefined;
+                  ctrl?: boolean;
+                  shift?: boolean;
+              }
             | undefined
     ) {
         this._chain.push(

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -465,12 +465,29 @@ export class BroTest implements PromiseLike<undefined> {
     press(
         key: KeyInput,
         options?:
-            | { text?: string | undefined; delay?: number | undefined }
+            | { text?: string | undefined; delay?: number | undefined; ctrl?: boolean; shift?: boolean }
             | undefined
     ) {
         this._chain.push(
             new BroTestItemCallback(this._frameStack, async () => {
+                const { shift, ctrl } = options ?? {};
+                if (shift) {
+                    await page.keyboard.down("Shift");
+                }
+
+                if (ctrl) {
+                    await page.keyboard.down("Control");
+                }
+
                 await page.keyboard.press(key, options);
+
+                if (shift) {
+                    await page.keyboard.up("Shift");
+                }
+
+                if (ctrl) {
+                    await page.keyboard.up("Control");
+                }
             })
         );
 


### PR DESCRIPTION
Any action perfomed with the CTRL key should be ignored. There is currently no tabster feature that needs to support the CTRL key. Currently key combos like CTRL+HOME are simply doing the same thing as HOME with the addition of the event being swallowed (stopImmediatePropagation) by tabster.

Also updates the testing util so that `pressKey` supports shift and ctrl