### PR TITLE
feat: implement `visibilityTolerance` prop to Mover

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -107,6 +107,7 @@ export class Mover
     private _updateQueue: MoverUpdateQueueItem[] | undefined;
     private _updateTimer: number | undefined;
 
+    visibilityTolerance: number;
     dummyManager: MoverDummyManager | undefined;
 
     constructor(
@@ -118,6 +119,7 @@ export class Mover
         super(tabster, element, props);
 
         this._win = tabster.getWindow;
+        this.visibilityTolerance = props.visibilityTolerance ?? 0.8;
 
         if (this._props.trackState || this._props.visibilityAware) {
             this._intersectionObserver = new IntersectionObserver(
@@ -976,7 +978,13 @@ export class MoverAPI implements Types.MoverAPI {
                         return false;
                     }
 
-                    if (isElementVerticallyVisibleInContainer(this._win, el)) {
+                    if (
+                        isElementVerticallyVisibleInContainer(
+                            this._win,
+                            el,
+                            mover.visibilityTolerance
+                        )
+                    ) {
                         next = el;
                         return false;
                     }
@@ -1027,7 +1035,13 @@ export class MoverAPI implements Types.MoverAPI {
                         return false;
                     }
 
-                    if (isElementVerticallyVisibleInContainer(this._win, el)) {
+                    if (
+                        isElementVerticallyVisibleInContainer(
+                            this._win,
+                            el,
+                            mover.visibilityTolerance
+                        )
+                    ) {
                         next = el;
                         return false;
                     }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -602,6 +602,17 @@ export interface MoverProps {
      * property as a prioritized element to focus.
      */
     hasDefault?: boolean;
+    /**
+     * A value between 0 and 1 that specifies the tolerance allowed
+     * when testing for visibility.
+     *
+     * @example
+     * an element of height 100px has 10px that are above the viewport
+     * hidden by scroll. This element is a valid visible element to focus.
+     *
+     * @default 0.8
+     */
+    visibilityTolerance?: number;
 }
 
 export type MoverEvent = TabsterEventWithDetails<MoverElementState>;
@@ -612,6 +623,9 @@ export interface Mover
         TabsterPartWithAcceptElement {
     readonly id: string;
     readonly dummyManager: DummyInputManager | undefined;
+    readonly visibilityTolerance: NonNullable<
+        MoverProps["visibilityTolerance"]
+    >;
     dispose(): void;
     setCurrent(element: HTMLElement | undefined): void;
     getCurrent(): HTMLElement | null;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -359,7 +359,8 @@ export function getBoundingRect(
 
 export function isElementVerticallyVisibleInContainer(
     getWindow: GetWindow,
-    element: HTMLElement
+    element: HTMLElement,
+    tolerance: number
 ): boolean {
     const container = getScrollableContainer(element);
     if (!container) {
@@ -368,7 +369,7 @@ export function isElementVerticallyVisibleInContainer(
 
     const containerRect = getBoundingRect(getWindow, container);
     const elementRect = element.getBoundingClientRect();
-    const intersectionThreshold = elementRect.height * 0.1;
+    const intersectionThreshold = elementRect.height * (1 - tolerance);
     const topIntersection = Math.max(0, containerRect.top - elementRect.top);
     const bottomIntersection = Math.max(
         0,

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -378,7 +378,8 @@ export function isElementVerticallyVisibleInContainer(
         const totalIntersection = topIntersection + bottomIntersection;
 
         return (
-            totalIntersection === 0 || totalIntersection <= intersectionThreshold
+            totalIntersection === 0 ||
+            totalIntersection <= intersectionThreshold
         );
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -369,7 +369,7 @@ export function isElementVerticallyVisibleInContainer(
 
     const containerRect = getBoundingRect(getWindow, container);
     const elementRect = element.getBoundingClientRect();
-    const intersectionThreshold = elementRect.height * (1 - tolerance);
+    const intersectionTolerance = elementRect.height * (1 - tolerance);
     const topIntersection = Math.max(0, containerRect.top - elementRect.top);
     const bottomIntersection = Math.max(
         0,
@@ -378,7 +378,7 @@ export function isElementVerticallyVisibleInContainer(
     const totalIntersection = topIntersection + bottomIntersection;
 
     return (
-        totalIntersection === 0 || totalIntersection <= intersectionThreshold
+        totalIntersection === 0 || totalIntersection <= intersectionTolerance
     );
 }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -362,28 +362,23 @@ export function isElementVerticallyVisibleInContainer(
     element: HTMLElement
 ): boolean {
     const container = getScrollableContainer(element);
-
-    if (container) {
-        const containerRect = getBoundingRect(getWindow, container);
-        const elementRect = element.getBoundingClientRect();
-        const intersectionThreshold = elementRect.height * 0.1;
-        const topIntersection = Math.max(
-            0,
-            containerRect.top - elementRect.top
-        );
-        const bottomIntersection = Math.max(
-            0,
-            elementRect.bottom - containerRect.bottom
-        );
-        const totalIntersection = topIntersection + bottomIntersection;
-
-        return (
-            totalIntersection === 0 ||
-            totalIntersection <= intersectionThreshold
-        );
+    if (!container) {
+        return false;
     }
 
-    return false;
+    const containerRect = getBoundingRect(getWindow, container);
+    const elementRect = element.getBoundingClientRect();
+    const intersectionThreshold = elementRect.height * 0.1;
+    const topIntersection = Math.max(0, containerRect.top - elementRect.top);
+    const bottomIntersection = Math.max(
+        0,
+        elementRect.bottom - containerRect.bottom
+    );
+    const totalIntersection = topIntersection + bottomIntersection;
+
+    return (
+        totalIntersection === 0 || totalIntersection <= intersectionThreshold
+    );
 }
 
 export function isElementVisibleInContainer(

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -366,10 +366,19 @@ export function isElementVerticallyVisibleInContainer(
     if (container) {
         const containerRect = getBoundingRect(getWindow, container);
         const elementRect = element.getBoundingClientRect();
+        const intersectionThreshold = elementRect.height * 0.1;
+        const topIntersection = Math.max(
+            0,
+            containerRect.top - elementRect.top
+        );
+        const bottomIntersection = Math.max(
+            0,
+            elementRect.bottom - containerRect.bottom
+        );
+        const totalIntersection = topIntersection + bottomIntersection;
 
         return (
-            Math.ceil(elementRect.top) >= Math.ceil(containerRect.top) &&
-            Math.floor(elementRect.bottom) <= Math.floor(containerRect.bottom)
+            totalIntersection === 0 || totalIntersection <= intersectionThreshold
         );
     }
 

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -1095,6 +1095,186 @@ describe("Mover with visibilityAware", () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
+    it("should scroll to first visible element with PageUp", async () => {
+        const itemStyles = {
+            height: 100,
+            width: 100,
+            display: "flex",
+            flexShrink: 0,
+            alignItems: "center",
+            justifyContent: "center",
+            border: "1px dashed blue",
+            boxSizing: "border-box" as const,
+        };
+
+        const containerStyles = {
+            height: 200,
+            width: 200,
+            display: "flex",
+            flexDirection: "column" as const,
+            alignItems: "center",
+            border: "1px dashed red",
+            boxSizing: "border-box" as const,
+            overflowY: "scroll" as const,
+        };
+
+        await new BroTest.BroTest(
+            (
+                <div
+                    id="container"
+                    {...getTabsterAttribute({
+                        mover: {
+                            visibilityAware:
+                                Types.Visibilities.PartiallyVisible,
+                        },
+                    })}
+                    style={containerStyles}
+                >
+                    <div id="one" style={itemStyles}>
+                        Item 1
+                    </div>
+                    <div id="two" style={itemStyles}>
+                        Item 2
+                    </div>
+                    <div id="three" style={itemStyles}>
+                        Item 3
+                    </div>
+                    <div id="four" style={itemStyles}>
+                        Item 4
+                    </div>
+                </div>
+            )
+        )
+            .focusElement("#two")
+            .activeElement((el) => el?.attributes.id === "two")
+            .scrollTo("#container", 0, 20)
+            .press("PageUp")
+            .activeElement((el) => el?.attributes.id === "one")
+            .focusElement("#two")
+            .activeElement((el) => el?.attributes.id === "two")
+            .scrollTo("#container", 0, 10)
+            .press("PageUp")
+            .activeElement((el) => el?.attributes.id === "two");
+    });
+
+    it("should scroll to last visible element with PageDown", async () => {
+        const itemStyles = {
+            height: 100,
+            width: 100,
+            display: "flex",
+            flexShrink: 0,
+            alignItems: "center",
+            justifyContent: "center",
+            border: "1px dashed blue",
+            boxSizing: "border-box" as const,
+        };
+
+        const containerStyles = {
+            height: 200,
+            width: 200,
+            display: "flex",
+            flexDirection: "column" as const,
+            alignItems: "center",
+            border: "1px dashed red",
+            boxSizing: "border-box" as const,
+            overflowY: "scroll" as const,
+        };
+
+        await new BroTest.BroTest(
+            (
+                <div
+                    id="container"
+                    {...getTabsterAttribute({
+                        mover: {
+                            visibilityAware:
+                                Types.Visibilities.PartiallyVisible,
+                        },
+                    })}
+                    style={containerStyles}
+                >
+                    <div id="one" style={itemStyles}>
+                        Item 1
+                    </div>
+                    <div id="two" style={itemStyles}>
+                        Item 2
+                    </div>
+                    <div id="three" style={itemStyles}>
+                        Item 3
+                    </div>
+                    <div id="four" style={itemStyles}>
+                        Item 4
+                    </div>
+                </div>
+            )
+        )
+            .focusElement("#two")
+            .activeElement((el) => el?.attributes.id === "two")
+            .scrollTo("#container", 0, 80)
+            .press("PageDown")
+            .activeElement((el) => el?.attributes.id === "three")
+            .scrollTo("#container", 0, 85)
+            .press("PageDown")
+            .activeElement((el) => el?.attributes.id === "two");
+    });
+
+    it("should be able to configure visibility tolerance", async () => {
+        const itemStyles = {
+            height: 100,
+            width: 100,
+            display: "flex",
+            flexShrink: 0,
+            alignItems: "center",
+            justifyContent: "center",
+            border: "1px dashed blue",
+            boxSizing: "border-box" as const,
+        };
+
+        const containerStyles = {
+            height: 200,
+            width: 200,
+            display: "flex",
+            flexDirection: "column" as const,
+            alignItems: "center",
+            border: "1px dashed red",
+            boxSizing: "border-box" as const,
+            overflowY: "scroll" as const,
+        };
+
+        await new BroTest.BroTest(
+            (
+                <div
+                    id="container"
+                    {...getTabsterAttribute({
+                        mover: {
+                            visibilityAware:
+                                Types.Visibilities.PartiallyVisible,
+                            visibilityTolerance: 0.1,
+                        },
+                    })}
+                    style={containerStyles}
+                >
+                    <div id="one" style={itemStyles}>
+                        Item 1
+                    </div>
+                    <div id="two" style={itemStyles}>
+                        Item 2
+                    </div>
+                    <div id="three" style={itemStyles}>
+                        Item 3
+                    </div>
+                    <div id="four" style={itemStyles}>
+                        Item 4
+                    </div>
+                </div>
+            )
+        )
+            .focusElement("#two")
+            .activeElement((el) => el?.attributes.id === "two")
+            .scrollTo("#container", 0, 80)
+            .press("PageUp")
+            .activeElement((el) => el?.attributes.id === "one");
+    });
+
     it("should tab to first/last visible element when tabbing from outside of the Mover", async () => {
         await new BroTest.BroTest(
             (

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -567,6 +567,21 @@ export class BroTest implements PromiseLike<undefined> {
         return this._pressKey("ArrowRight", shift);
     }
 
+    scrollTo(selector: string, x: number, y: number) {
+        this._chain.push(
+            new BroTestItemCallback(this._frameStack, async () => {
+                await page.waitForSelector(selector);
+                await page.evaluate((selector: string, x: number, y: number) => {
+                    const scrollContainer: HTMLElement | null =
+                        document.querySelector(selector);
+                    scrollContainer?.scroll(x, y);
+                }, selector, x, y);
+            })
+        );
+
+        return this;
+    }
+
     activeElement(callback: (activeElement: BrowserElement | null) => void) {
         this._chain.push(
             new BroTestItemCallback(this._frameStack, async () => {

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -571,11 +571,16 @@ export class BroTest implements PromiseLike<undefined> {
         this._chain.push(
             new BroTestItemCallback(this._frameStack, async () => {
                 await page.waitForSelector(selector);
-                await page.evaluate((selector: string, x: number, y: number) => {
-                    const scrollContainer: HTMLElement | null =
-                        document.querySelector(selector);
-                    scrollContainer?.scroll(x, y);
-                }, selector, x, y);
+                await page.evaluate(
+                    (selector: string, x: number, y: number) => {
+                        const scrollContainer: HTMLElement | null =
+                            document.querySelector(selector);
+                        scrollContainer?.scroll(x, y);
+                    },
+                    selector,
+                    x,
+                    y
+                );
             })
         );
 


### PR DESCRIPTION
Adds a tolerance of 80% to the check `isElementVerticallyVisible`. This means that when an element is cut off by the viewport, as long as the part cut off is 80% visible, the check will return true.

The Mover now supports a `visibilityTolerance` prop so that this tolerance is configurable for each mover. Adds tests to make sure that this tolerance is correctly enforced in scroll containers where elements are partially visible.

This is needed since browser scrolling is not precise enough to have 100% of an element visible all the time. Previously the tolerance was essentially 1px, which is too small.