### PR TITLE
fix: Remove Modalizer warning for aria labels

### DIFF
--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -122,7 +122,6 @@ export class Modalizer
         this.userId = props.id;
         this._onDispose = onDispose;
         this._activeElements = activeElements;
-        this._setAccessibilityProps();
 
         if (!tabster.controlTab) {
             this.dummyManager = new ModalizerDummyManager(
@@ -199,8 +198,6 @@ export class Modalizer
         }
 
         this._props = { ...props };
-
-        this._setAccessibilityProps();
     }
 
     dispose(): void {
@@ -307,21 +304,6 @@ export class Modalizer
     private _remove(): void {
         if (__DEV__) {
             _setInformativeStyle(this._element, true);
-        }
-    }
-
-    private _setAccessibilityProps(): void {
-        if (__DEV__) {
-            const element = this._element.get();
-            if (
-                element &&
-                !element.getAttribute("aria-label") &&
-                !element.getAttribute("aria-labelledby")
-            ) {
-                console.warn(
-                    `Modalizer ${this.id} must have either aria-label or aria-labelledby`
-                );
-            }
         }
     }
 }


### PR DESCRIPTION
This error is removed because it does not provide any actionaly information for users to do anything meaningful. The need for a an aria-label will depend a lot on the end user scenario. Tabster should not be responsible for this.