### PR TITLE
fix: Add ArrowLeft and ArrowRight to ignoreKeydown type

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -371,6 +371,8 @@ export interface FocusableProps {
         Enter?: boolean;
         ArrowUp?: boolean;
         ArrowDown?: boolean;
+        ArrowLeft?: boolean;
+        ArrowRight?: boolean;
         PageUp?: boolean;
         PageDown?: boolean;
         Home?: boolean;

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -327,6 +327,8 @@ describe("NestedMovers", () => {
     it.each([
         "ArrowDown",
         "ArrowUp",
+        "ArrowLeft",
+        "ArrowRight",
         "PageDown",
         "PageUp",
         "Home",
@@ -368,6 +370,8 @@ describe("NestedMovers", () => {
     it.each([
         "ArrowDown",
         "ArrowUp",
+        "ArrowLeft",
+        "ArrowRight",
         "PageDown",
         "PageUp",
         "Home",


### PR DESCRIPTION
The library in fact supports this configuration, but the FocusableProps.ignoreKeydown doesn't include it for some reason.

This is needed for my POC of keyboard navigation in the table and interacting with an intractable element:

https://github.com/microsoft/fluentui/pull/26873/files#diff-91a26c39f89f4f6f6ce48e2d580e0c68d2b10706c96f851e5a070a65f0871fe7R47