### PR TITLE
fix(Tabster): Initializing Tabster-related everything for the DOM elements mounted before Tabster creation.

### DIFF
--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -51,11 +51,18 @@ export class FocusedElementState
         this._initTimer = undefined;
 
         const win = this._win();
+        const doc = win.document;
 
         // Add these event listeners as capture - we want Tabster to run before user event handlers
-        win.document.addEventListener(KEYBORG_FOCUSIN, this._onFocusIn, true);
-        win.document.addEventListener("focusout", this._onFocusOut, true);
+        doc.addEventListener(KEYBORG_FOCUSIN, this._onFocusIn, true);
+        doc.addEventListener("focusout", this._onFocusOut, true);
         win.addEventListener("keydown", this._onKeyDown, true);
+
+        const activeElement = doc.activeElement;
+
+        if (activeElement && activeElement !== doc.body) {
+            this._setFocusedElement(activeElement as HTMLElement);
+        }
 
         this.subscribe(this._onChanged);
     };

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -59,6 +59,7 @@ class TabsterCore implements Types.TabsterCore {
     private _forgetMemorizedTimer: number | undefined;
     private _forgetMemorizedElements: HTMLElement[] = [];
     private _wrappers: Set<Tabster> = new Set<Tabster>();
+    private _initTimer: number | undefined;
 
     _version: string = __VERSION__;
     _noop = false;
@@ -117,9 +118,12 @@ class TabsterCore implements Types.TabsterCore {
             },
         };
 
-        this.internal.resumeObserver(false);
-
         startFakeWeakRefsCleanup(getWindow);
+
+        this._initTimer = win.setTimeout(() => {
+            delete this._initTimer;
+            this.internal.resumeObserver(true);
+        }, 0);
     }
 
     createTabster(noRefCount?: boolean): Types.Tabster {
@@ -148,6 +152,9 @@ class TabsterCore implements Types.TabsterCore {
         this.internal.stopObserver();
 
         const win = this._win;
+
+        win?.clearTimeout(this._initTimer);
+        delete this._initTimer;
 
         this._forgetMemorizedElements = [];
 

--- a/tests/Tabster.test.tsx
+++ b/tests/Tabster.test.tsx
@@ -5,6 +5,7 @@
 
 import * as React from "react";
 import { getTabsterAttribute } from "tabster";
+import { WindowWithTabsterInstance } from "../src/Root";
 import * as BroTest from "./utils/BroTest";
 
 interface WindowWithTabster extends Window {
@@ -162,6 +163,90 @@ describe("Tabster dispose", () => {
             })
             .check((exists) => {
                 expect(exists).toEqual(true);
+            });
+    });
+});
+
+describe("Tabster create", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it("should initialize Modalizer when the DOM is mounted before Tabster is created", async () => {
+        await new BroTest.BroTest(
+            (
+                <div>
+                    <button>Button1</button>
+                    <div
+                        {...getTabsterAttribute({
+                            modalizer: { id: "modal", isTrapped: true },
+                        })}
+                    >
+                        <button>Button2</button>
+                    </div>
+                    <button id="button3">Button3</button>
+                </div>
+            )
+        )
+            .eval(() => {
+                return !!(window as WindowWithTabsterInstance)
+                    .__tabsterInstance;
+            })
+            .check((hasInstance: boolean) => {
+                expect(hasInstance).toBe(false);
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .eval(() => {
+                const vars = getTabsterTestVariables();
+
+                const tabster = vars.createTabster?.(window, { autoRoot: {} });
+
+                if (tabster) {
+                    vars.getModalizer?.(tabster);
+                }
+
+                return !!(window as WindowWithTabsterInstance)
+                    .__tabsterInstance;
+            })
+            .check((hasInstance: boolean) => {
+                expect(hasInstance).toBe(true);
+            })
+            .eval(() => {
+                return document.body.getAttribute("data-tabster");
+            })
+            .check((bodyTabster: string | null) => {
+                expect(bodyTabster).toEqual('{"root":{}}');
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .focusElement("#button3")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
             });
     });
 });

--- a/tests/index.html
+++ b/tests/index.html
@@ -25,69 +25,82 @@
             const params = new URL(location.href).searchParams;
             const controlTab = params.get("controlTab") !== "false";
             const rootDummyInputs = params.get("rootDummyInputs") !== "false";
-            const parts = (params.get("parts") || "").split(",");
+            const partsValue = params.get("parts");
+            const parts =
+                typeof partsValue === "string"
+                    ? partsValue.split(",")
+                    : undefined;
             const partsToEnable = {};
-
-            for (let part of parts) {
-                partsToEnable[part] = true;
-            }
-
-            const tabster = createTabster(window, {
-                controlTab,
-                rootDummyInputs,
-            });
 
             tabsterTest.createTabster = createTabster;
             tabsterTest.disposeTabster = disposeTabster;
             tabsterTest.getTabster = getTabster;
+            tabsterTest.getCrossOrigin = getCrossOrigin;
+            tabsterTest.getDeloser = getDeloser;
+            tabsterTest.getGroupper = getGroupper;
+            tabsterTest.getModalizer = getModalizer;
+            tabsterTest.getMover = getMover;
+            tabsterTest.getObservedElement = getObservedElement;
+            tabsterTest.getOutline = getOutline;
             tabsterTest.makeNoOp = makeNoOp;
             tabsterTest.getTabsterAttribute = getTabsterAttribute;
             tabsterTest.setTabsterAttribute = setTabsterAttribute;
             tabsterTest.mergeTabsterProps = mergeTabsterProps;
 
-            tabsterTest.core = tabster;
+            if (parts !== undefined) {
+                for (let part of parts) {
+                    partsToEnable[part] = true;
+                }
 
-            console.log(
-                "created tabster",
-                `as ${
-                    controlTab ? "controlled" : "uncontrolled"
-                }, root dummy inputs ${rootDummyInputs}`
-            );
+                const tabster = createTabster(window, {
+                    controlTab,
+                    rootDummyInputs,
+                });
 
-            if ("modalizer" in partsToEnable) {
-                tabsterTest.modalizer = getModalizer(tabster);
-                console.log("created modalizer");
-            }
+                tabsterTest.core = tabster;
 
-            if ("deloser" in partsToEnable) {
-                tabsterTest.deloser = getDeloser(tabster);
-                console.log("created deloser");
-            }
+                console.log(
+                    "created tabster",
+                    `as ${
+                        controlTab ? "controlled" : "uncontrolled"
+                    }, root dummy inputs ${rootDummyInputs}`
+                );
 
-            if ("outline" in partsToEnable) {
-                tabsterTest.outline = getOutline(tabster);
-                console.log("created outline");
-            }
+                if ("modalizer" in partsToEnable) {
+                    tabsterTest.modalizer = getModalizer(tabster);
+                    console.log("created modalizer");
+                }
 
-            if ("mover" in partsToEnable) {
-                tabsterTest.mover = getMover(tabster);
-                console.log("created mover");
-            }
+                if ("deloser" in partsToEnable) {
+                    tabsterTest.deloser = getDeloser(tabster);
+                    console.log("created deloser");
+                }
 
-            if ("groupper" in partsToEnable) {
-                tabsterTest.groupper = getGroupper(tabster);
-                console.log("created groupper");
-            }
+                if ("outline" in partsToEnable) {
+                    tabsterTest.outline = getOutline(tabster);
+                    console.log("created outline");
+                }
 
-            if ("observed" in partsToEnable) {
-                tabsterTest.observedElement = getObservedElement(tabster);
-                console.log("created observed");
-            }
+                if ("mover" in partsToEnable) {
+                    tabsterTest.mover = getMover(tabster);
+                    console.log("created mover");
+                }
 
-            if ("crossOrigin" in partsToEnable) {
-                tabsterTest.crossOrigin = getCrossOrigin(tabster);
-                tabsterTest.crossOrigin.setup();
-                console.log("created cross origin");
+                if ("groupper" in partsToEnable) {
+                    tabsterTest.groupper = getGroupper(tabster);
+                    console.log("created groupper");
+                }
+
+                if ("observed" in partsToEnable) {
+                    tabsterTest.observedElement = getObservedElement(tabster);
+                    console.log("created observed");
+                }
+
+                if ("crossOrigin" in partsToEnable) {
+                    tabsterTest.crossOrigin = getCrossOrigin(tabster);
+                    tabsterTest.crossOrigin.setup();
+                    console.log("created cross origin");
+                }
             }
 
             window.getTabsterTestVariables = () => tabsterTest;

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -15,6 +15,13 @@ import {
     createTabster,
     disposeTabster,
     getTabster,
+    getCrossOrigin,
+    getDeloser,
+    getGroupper,
+    getModalizer,
+    getMover,
+    getObservedElement,
+    getOutline,
     getTabsterAttribute,
     makeNoOp,
     mergeTabsterProps,
@@ -97,6 +104,13 @@ export interface BroTestTabsterTestVariables {
     disposeTabster?: typeof disposeTabster;
     createTabster?: typeof createTabster;
     getTabster?: typeof getTabster;
+    getCrossOrigin?: typeof getCrossOrigin;
+    getDeloser?: typeof getDeloser;
+    getGroupper?: typeof getGroupper;
+    getModalizer?: typeof getModalizer;
+    getMover?: typeof getMover;
+    getObservedElement?: typeof getObservedElement;
+    getOutline?: typeof getOutline;
     makeNoOp?: typeof makeNoOp;
     getTabsterAttribute?: typeof getTabsterAttribute;
     setTabsterAttribute?: typeof setTabsterAttribute;
@@ -111,18 +125,20 @@ export interface BroTestTabsterTestVariables {
     crossOrigin?: Types.CrossOriginAPI;
 }
 
-export function getTestPageURL(parts: TabsterParts): string {
+export function getTestPageURL(parts?: TabsterParts): string {
     const port = parseInt(process.env.PORT || "0", 10) || 8080;
     const controlTab = !process.env.STORYBOOK_UNCONTROLLED;
     const rootDummyInputs = !!process.env.STORYBOOK_ROOT_DUMMY_INPUTS;
-    return `http://localhost:${port}/?controlTab=${controlTab}&rootDummyInputs=${rootDummyInputs}&parts=${Object.keys(
+    return `http://localhost:${port}/?controlTab=${controlTab}&rootDummyInputs=${rootDummyInputs}${
         parts
-    )
-        .filter((part: keyof TabsterParts) => parts[part])
-        .join(",")}&rnd=${++_lastRnd}`;
+            ? `&parts=${Object.keys(parts)
+                  .filter((part: keyof TabsterParts) => parts[part])
+                  .join(",")}`
+            : ""
+    }&rnd=${++_lastRnd}`;
 }
 
-export async function bootstrapTabsterPage(parts: TabsterParts) {
+export async function bootstrapTabsterPage(parts?: TabsterParts) {
     await goToPageWithRetry(getTestPageURL(parts), 4);
     await expect(page.title()).resolves.toMatch("Tabster Test");
     await waitPageReadyAndDecorateConsoleError(page);


### PR DESCRIPTION
Making sure that if the DOM with `data-tabster` attributes is created before Tabster, everything will be initialized properly.