### PR TITLE
fix(Mover): Fixing a corner case in Mover/Groupper/Groupper scenario.

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -812,12 +812,33 @@ export class MoverAPI implements Types.MoverAPI {
             return;
         }
 
-        if (ctx.isGroupperFirst && ctx.groupper?.isActive(true)) {
-            return;
-        }
-
         const mover = ctx.mover;
         const container = mover.getElement();
+
+        if (ctx.isGroupperFirst) {
+            const groupper = ctx.groupper;
+
+            if (groupper && !groupper.isActive(true)) {
+                // For the cases when we have Mover/Active Groupper/Inactive Groupper, we need to check
+                // the grouppers between the current element and the current mover.
+                for (
+                    let el: HTMLElement | null | undefined =
+                        groupper.getElement()?.parentElement;
+                    el && el !== container;
+                    el = el.parentElement
+                ) {
+                    if (
+                        getTabsterOnElement(tabster, el)?.groupper?.isActive(
+                            true
+                        )
+                    ) {
+                        return;
+                    }
+                }
+            } else {
+                return;
+            }
+        }
 
         if (!container) {
             return;

--- a/tests/MoverGroupper.test.tsx
+++ b/tests/MoverGroupper.test.tsx
@@ -1200,7 +1200,15 @@ describe("MoverGroupper", () => {
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button3Button4");
             })
+            .pressUp()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3Button4");
+            })
             .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1Button2");
+            })
+            .pressDown()
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button1Button2");
             })
@@ -1213,6 +1221,10 @@ describe("MoverGroupper", () => {
                 expect(el?.textContent).toEqual("Button2");
             })
             .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressDown()
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button1");
             });


### PR DESCRIPTION
Fixing a case when Mover's arrow keys handler was moving focus inside Groupper in Mover/Active Groupper/Inactive Groupper scenario.