### PR TITLE
feat(DummyInput): Using only main mutation observer to update dummy inputs in DOM and bulk-updating transform offsets

### DIFF
--- a/src/MutationEvent.ts
+++ b/src/MutationEvent.ts
@@ -45,14 +45,12 @@ export function observeMutations(
                 }
             } else {
                 for (let i = 0; i < removed.length; i++) {
-                    const el = removed[i];
-                    updateTabsterElements(el, true);
+                    updateTabsterElements(removed[i], true);
                     tabster._dummyObserver.domChanged?.(target as HTMLElement);
                 }
 
                 for (let i = 0; i < added.length; i++) {
-                    const el = added[i];
-                    updateTabsterElements(el);
+                    updateTabsterElements(added[i]);
                     tabster._dummyObserver.domChanged?.(target as HTMLElement);
                 }
             }

--- a/src/MutationEvent.ts
+++ b/src/MutationEvent.ts
@@ -46,14 +46,16 @@ export function observeMutations(
             } else {
                 for (let i = 0; i < removed.length; i++) {
                     const el = removed[i];
+                    const parent = el.parentElement;
                     updateTabsterElements(el, true);
-                    tabster._dummyObserver.domChanged?.(el.parentElement);
+                    parent && tabster._dummyObserver.domChanged?.(parent);
                 }
 
                 for (let i = 0; i < added.length; i++) {
                     const el = added[i];
+                    const parent = el.parentElement;
                     updateTabsterElements(el);
-                    tabster._dummyObserver.domChanged?.(el.parentElement);
+                    parent && tabster._dummyObserver.domChanged?.(parent);
                 }
             }
         }

--- a/src/MutationEvent.ts
+++ b/src/MutationEvent.ts
@@ -46,16 +46,14 @@ export function observeMutations(
             } else {
                 for (let i = 0; i < removed.length; i++) {
                     const el = removed[i];
-                    const parent = el.parentElement;
                     updateTabsterElements(el, true);
-                    parent && tabster._dummyObserver.domChanged?.(parent);
+                    tabster._dummyObserver.domChanged?.(target as HTMLElement);
                 }
 
                 for (let i = 0; i < added.length; i++) {
                     const el = added[i];
-                    const parent = el.parentElement;
                     updateTabsterElements(el);
-                    parent && tabster._dummyObserver.domChanged?.(parent);
+                    tabster._dummyObserver.domChanged?.(target as HTMLElement);
                 }
             }
         }

--- a/src/MutationEvent.ts
+++ b/src/MutationEvent.ts
@@ -45,11 +45,15 @@ export function observeMutations(
                 }
             } else {
                 for (let i = 0; i < removed.length; i++) {
-                    updateTabsterElements(removed[i], true);
+                    const el = removed[i];
+                    updateTabsterElements(el, true);
+                    tabster._dummyObserver.domChanged?.(el.parentElement);
                 }
 
                 for (let i = 0; i < added.length; i++) {
-                    updateTabsterElements(added[i]);
+                    const el = added[i];
+                    updateTabsterElements(el);
+                    tabster._dummyObserver.domChanged?.(el.parentElement);
                 }
             }
         }

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -26,6 +26,7 @@ import {
     disposeInstanceContext,
     startFakeWeakRefsCleanup,
     stopFakeWeakRefsCleanupAndClearStorage,
+    DummyInputObserver,
 } from "./Utils";
 
 export { Types };
@@ -73,6 +74,7 @@ class TabsterCore implements Types.TabsterCore {
     root: Types.RootAPI;
     uncontrolled: Types.UncontrolledAPI;
     internal: Types.InternalAPI;
+    _dummyObserver: Types.DummyInputObserver;
 
     // Extended APIs
     groupper?: Types.GroupperAPI;
@@ -96,6 +98,8 @@ class TabsterCore implements Types.TabsterCore {
         this.uncontrolled = new UncontrolledAPI();
         this.controlTab = props?.controlTab ?? true;
         this.rootDummyInputs = !!props?.rootDummyInputs;
+
+        this._dummyObserver = new DummyInputObserver(getWindow);
 
         this.internal = {
             stopObserver: (): void => {
@@ -177,6 +181,8 @@ class TabsterCore implements Types.TabsterCore {
         this.focusable.dispose();
         this.focusedElement.dispose();
         this.root.dispose();
+
+        this._dummyObserver.dispose();
 
         stopFakeWeakRefsCleanupAndClearStorage(this.getWindow);
         clearElementCache(this.getWindow);

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1014,10 +1014,10 @@ export interface InternalAPI {
 }
 
 export interface DummyInputObserver {
-    add(dummy: HTMLElement | undefined, callback: () => void): void;
-    remove(dummy: HTMLElement | undefined): void;
+    add(dummy: HTMLElement, callback: () => void): void;
+    remove(dummy: HTMLElement): void;
     dispose(): void;
-    domChanged?(parent: HTMLElement | null): void;
+    domChanged?(parent: HTMLElement): void;
     updateOffsets(callback: () => void): void;
 }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1013,6 +1013,14 @@ export interface InternalAPI {
     resumeObserver(syncState: boolean): void;
 }
 
+export interface DummyInputObserver {
+    add(dummy: HTMLElement | undefined, callback: () => void): void;
+    remove(dummy: HTMLElement | undefined): void;
+    dispose(): void;
+    domChanged?(parent: HTMLElement | null): void;
+    updateOffsets(callback: () => void): void;
+}
+
 interface TabsterCoreInternal {
     /** @internal */
     groupper?: GroupperAPI;
@@ -1030,6 +1038,9 @@ interface TabsterCoreInternal {
     crossOrigin?: CrossOriginAPI;
     /** @internal */
     internal: InternalAPI;
+
+    /** @internal */
+    _dummyObserver: DummyInputObserver;
 
     // The version of the tabster package this instance is on
     /** @internal */

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1006,14 +1006,10 @@ export class DummyInputObserver implements Types.DummyInputObserver {
 
     remove(dummy: HTMLElement): void {
         const dummyInputElements = this._dummies;
-        const cb = dummyInputElements.get(dummy);
+        dummyInputElements.delete(dummy);
 
-        if (cb) {
-            dummyInputElements.delete(dummy);
-
-            if (dummyInputElements.size === 0) {
-                delete this.domChanged;
-            }
+        if (dummyInputElements.size === 0) {
+            delete this.domChanged;
         }
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1078,7 +1078,10 @@ export class DummyInputObserver implements Types.DummyInputObserver {
                 const dummy = dummyRef.deref();
                 const dummyParent = dummy?.parentElement;
 
-                if (dummyParent && this._domChangedMap.has(dummyParent)) {
+                if (
+                    dummy &&
+                    (!dummyParent || this._domChangedMap.has(dummyParent))
+                ) {
                     this._dummyMap.get(dummy)?.();
                 }
             }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1093,14 +1093,16 @@ export class DummyInputObserver implements Types.DummyInputObserver {
     updateOffsets(callback: () => void): void {
         this._offsetsQueue.push(callback);
 
-        if (!this._offsetsTimer) {
-            this._offsetsTimer = this._win?.().setTimeout(() => {
-                delete this._offsetsTimer;
-
-                this._offsetsQueue.forEach((callback) => callback());
-                this._offsetsQueue = [];
-            }, 100);
+        if (this._offsetsTimer) {
+            return;
         }
+
+        this._offsetsTimer = this._win?.().setTimeout(() => {
+            delete this._offsetsTimer;
+
+            this._offsetsQueue.forEach((callback) => callback());
+            this._offsetsQueue = [];
+        }, 100);
     }
 }
 

--- a/tests/DummyInputManager.test.tsx
+++ b/tests/DummyInputManager.test.tsx
@@ -411,7 +411,7 @@ describeIfUncontrolled("DummyInputManager", () => {
             }
         );
 
-        it.only("should reinsert the dummy input if it's removed for some reason", async () => {
+        it("should reinsert the dummy input if it's removed for some reason", async () => {
             const attr = getTabsterAttribute({
                 groupper: {},
             });

--- a/tests/DummyInputManager.test.tsx
+++ b/tests/DummyInputManager.test.tsx
@@ -107,7 +107,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyInside)
                 .eval(appendElement, moverId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -115,7 +115,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyInside)
                 .eval(prependElement, moverId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -295,7 +295,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyInside)
                 .eval(appendElement, modalizerOuterId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -303,7 +303,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyInside)
                 .eval(prependElement, modalizerOuterId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -389,7 +389,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                     )
                     .check(checkDummyInside)
                     .eval(appendElement, containerId)
-                    .wait(1)
+                    .wait(300)
                     .eval(
                         evaluateDummy,
                         Types.TabsterDummyInputAttributeName,
@@ -397,7 +397,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                     )
                     .check(checkDummyInside)
                     .eval(prependElement, containerId)
-                    .wait(1)
+                    .wait(300)
                     .eval(
                         evaluateDummy,
                         Types.TabsterDummyInputAttributeName,
@@ -441,7 +441,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyOutside)
                 .eval(insertElementBefore, moverId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -449,7 +449,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyOutside)
                 .eval(insertElementAfter, moverId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -489,7 +489,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyInside)
                 .eval(appendElement, groupperId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -497,7 +497,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyInside)
                 .eval(prependElement, groupperId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -537,7 +537,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyOutside)
                 .eval(insertElementBefore, modalizerId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -545,7 +545,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyOutside)
                 .eval(insertElementAfter, modalizerId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,

--- a/tests/DummyInputManager.test.tsx
+++ b/tests/DummyInputManager.test.tsx
@@ -231,11 +231,13 @@ describeIfUncontrolled("DummyInputManager", () => {
 
             const testHtml = (
                 <div {...getTabsterAttribute({ root: {} })}>
-                    <div {...attr} id={groupperId}>
-                        <button>Button1</button>
-                        <button>Button2</button>
-                        <button>Button3</button>
-                        <button>Button4</button>
+                    <div>
+                        <div {...attr} id={groupperId}>
+                            <button>Button1</button>
+                            <button>Button2</button>
+                            <button>Button3</button>
+                            <button>Button4</button>
+                        </div>
                     </div>
                 </div>
             );
@@ -248,7 +250,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyOutside)
                 .eval(appendElement, groupperId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -256,7 +258,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                 )
                 .check(checkDummyOutside)
                 .eval(prependElement, groupperId)
-                .wait(1)
+                .wait(300)
                 .eval(
                     evaluateDummy,
                     Types.TabsterDummyInputAttributeName,
@@ -322,14 +324,16 @@ describeIfUncontrolled("DummyInputManager", () => {
                 const Tag = tagName;
                 const testHtml = (
                     <div {...getTabsterAttribute({ root: {} })}>
-                        <Tag {...attr} id={containerId}>
-                            <li>
-                                <button>Button1</button>
-                            </li>
-                            <li>
-                                <button>Button2</button>
-                            </li>
-                        </Tag>
+                        <div>
+                            <Tag {...attr} id={containerId}>
+                                <li>
+                                    <button>Button1</button>
+                                </li>
+                                <li>
+                                    <button>Button2</button>
+                                </li>
+                            </Tag>
+                        </div>
                     </div>
                 );
                 await new BroTest.BroTest(testHtml)
@@ -340,7 +344,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                     )
                     .check(checkDummyOutside)
                     .eval(appendElement, containerId)
-                    .wait(1)
+                    .wait(300)
                     .eval(
                         evaluateDummy,
                         Types.TabsterDummyInputAttributeName,
@@ -348,7 +352,7 @@ describeIfUncontrolled("DummyInputManager", () => {
                     )
                     .check(checkDummyOutside)
                     .eval(prependElement, containerId)
-                    .wait(1)
+                    .wait(300)
                     .eval(
                         evaluateDummy,
                         Types.TabsterDummyInputAttributeName,
@@ -406,6 +410,85 @@ describeIfUncontrolled("DummyInputManager", () => {
                     .check(checkDummyInside);
             }
         );
+
+        it.only("should reinsert the dummy input if it's removed for some reason", async () => {
+            const attr = getTabsterAttribute({
+                groupper: {},
+            });
+            const groupperId = "groupper";
+
+            const testHtml = (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div>
+                        <div {...attr} id={groupperId}>
+                            <button>Button1</button>
+                            <button>Button2</button>
+                        </div>
+                    </div>
+                </div>
+            );
+
+            await new BroTest.BroTest(testHtml)
+                .eval(
+                    evaluateDummy,
+                    Types.TabsterDummyInputAttributeName,
+                    groupperId
+                )
+                .check(checkDummyOutside)
+                .eval((elementId) => {
+                    const current = document.getElementById(
+                        elementId
+                    ) as HTMLElement;
+                    const parent = current.parentElement as HTMLElement;
+                    const firstDummy =
+                        current.previousElementSibling as HTMLElement;
+                    parent.removeChild(firstDummy);
+                }, groupperId)
+                .eval(
+                    evaluateDummy,
+                    Types.TabsterDummyInputAttributeName,
+                    groupperId
+                )
+                .check((res: ReturnType<typeof evaluateDummy>) => {
+                    expect(res.first).toBe(false);
+                    expect(res.last).toBe(false);
+                    expect(res.prev).toBe(false);
+                    expect(res.next).toBe(true);
+                })
+                .wait(300)
+                .eval(
+                    evaluateDummy,
+                    Types.TabsterDummyInputAttributeName,
+                    groupperId
+                )
+                .check(checkDummyOutside)
+                .eval((elementId) => {
+                    const current = document.getElementById(
+                        elementId
+                    ) as HTMLElement;
+                    const parent = current.parentElement as HTMLElement;
+                    const lastDummy = current.nextElementSibling as HTMLElement;
+                    parent.removeChild(lastDummy);
+                }, groupperId)
+                .eval(
+                    evaluateDummy,
+                    Types.TabsterDummyInputAttributeName,
+                    groupperId
+                )
+                .check((res: ReturnType<typeof evaluateDummy>) => {
+                    expect(res.first).toBe(false);
+                    expect(res.last).toBe(false);
+                    expect(res.prev).toBe(true);
+                    expect(res.next).toBe(false);
+                })
+                .wait(300)
+                .eval(
+                    evaluateDummy,
+                    Types.TabsterDummyInputAttributeName,
+                    groupperId
+                )
+                .check(checkDummyOutside);
+        });
 
         it("should use enforced dummy input position in Mover", async () => {
             const moverId = "mover";


### PR DESCRIPTION
Two optimizations regarding dummy inputs:

1. There is no mutation observed in `DummyInputManagerCore` anymore. We're utilizing the main mutation observer to keep the dummy inputs DOM placement consistent. And the DOM placement update is throttled to reduce the amount of reflows.

2. Every `DummyInputManagerCore` doesn't update the dummy input visual position on scroll independently, it is being queued to do the bulk-update in order to reduce the amount of reflows.