### PR TITLE
fix(Mover): Fixing trackState when it wasn't firing events for the elements that never were visible before.

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -363,7 +363,7 @@ export class Mover
             const el = entry.target as HTMLElement;
             const id = getElementUId(this._win, el);
 
-            let newVisibility: Types.Visibility | undefined;
+            let newVisibility: Types.Visibility;
             let fullyVisible = this._fullyVisible;
 
             if (entry.intersectionRatio >= 0.25) {
@@ -375,6 +375,8 @@ export class Mover
                 if (newVisibility === Types.Visibilities.Visible) {
                     fullyVisible = id;
                 }
+            } else {
+                newVisibility = Types.Visibilities.Invisible;
             }
 
             if (this._visible[id] !== newVisibility) {

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -1099,7 +1099,7 @@ describe("Mover with trackState", () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
     });
 
-    it.only("trigger events as we scroll", async () => {
+    it("trigger events as we scroll", async () => {
         const itemStyles = {
             height: 20,
         };

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -1160,6 +1160,7 @@ describe("Mover with trackState", () => {
                     .getElementById("container")
                     ?.setAttribute("data-tabster", moverAttribute);
             }, getTabsterAttribute({ mover: { trackState: true } }, true))
+            .wait(300)
             .eval(() =>
                 Array.prototype.map.call(
                     document.querySelectorAll(".item"),

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -1094,6 +1094,105 @@ describe("Mover with inputs inside", () => {
     });
 });
 
+describe("Mover with trackState", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({ mover: true });
+    });
+
+    it.only("trigger events as we scroll", async () => {
+        const itemStyles = {
+            height: 20,
+        };
+
+        const containerStyles = {
+            height: 50,
+            overflowY: "scroll" as const,
+        };
+
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div id="container" style={containerStyles}>
+                        <div id="one" tabIndex={0} style={itemStyles}>
+                            Item 1
+                        </div>
+                        <div id="two" tabIndex={0} style={itemStyles}>
+                            Item 2
+                        </div>
+                        <div id="three" tabIndex={0} style={itemStyles}>
+                            Item 3
+                        </div>
+                        <div id="four" tabIndex={0} style={itemStyles}>
+                            Item 4
+                        </div>
+                    </div>
+                </div>
+            )
+        )
+            .eval((moverAttribute: string) => {
+                document.addEventListener(
+                    "tabster:mover",
+                    (e: Types.MoverEvent) => {
+                        let className = "item";
+
+                        switch (e.details.visibility) {
+                            case 0:
+                                className += " invisible";
+                                break;
+                            case 1:
+                                className += " partially-visible";
+                                break;
+                            case 2:
+                                className += " visible";
+                                break;
+                        }
+
+                        if (e.details.isCurrent) {
+                            className += " active";
+                        }
+
+                        (e.target as HTMLElement).className = className;
+                    }
+                );
+
+                // Adding mover after the event subscription.
+                document
+                    .getElementById("container")
+                    ?.setAttribute("data-tabster", moverAttribute);
+            }, getTabsterAttribute({ mover: { trackState: true } }, true))
+            .eval(() =>
+                Array.prototype.map.call(
+                    document.querySelectorAll(".item"),
+                    (el: HTMLElement) => el.className
+                )
+            )
+            .check((classNames) => {
+                expect(classNames).toEqual([
+                    "item visible",
+                    "item visible",
+                    "item partially-visible",
+                    "item invisible",
+                ]);
+            })
+            .scrollTo("#container", 0, 50)
+            .wait(300)
+            .eval(() =>
+                Array.prototype.map.call(
+                    document.querySelectorAll(".item"),
+                    (el: HTMLElement) => el.className
+                )
+            )
+            .check((classNames) => {
+                expect(classNames).toEqual([
+                    "item invisible",
+                    "item partially-visible",
+                    "item visible",
+                    "item visible",
+                ]);
+            });
+    });
+});
+
 describe("Mover with visibilityAware", () => {
     beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true });
@@ -1124,27 +1223,29 @@ describe("Mover with visibilityAware", () => {
 
         await new BroTest.BroTest(
             (
-                <div
-                    id="container"
-                    {...getTabsterAttribute({
-                        mover: {
-                            visibilityAware:
-                                Types.Visibilities.PartiallyVisible,
-                        },
-                    })}
-                    style={containerStyles}
-                >
-                    <div id="one" style={itemStyles}>
-                        Item 1
-                    </div>
-                    <div id="two" style={itemStyles}>
-                        Item 2
-                    </div>
-                    <div id="three" style={itemStyles}>
-                        Item 3
-                    </div>
-                    <div id="four" style={itemStyles}>
-                        Item 4
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        id="container"
+                        {...getTabsterAttribute({
+                            mover: {
+                                visibilityAware:
+                                    Types.Visibilities.PartiallyVisible,
+                            },
+                        })}
+                        style={containerStyles}
+                    >
+                        <div id="one" tabIndex={0} style={itemStyles}>
+                            Item 1
+                        </div>
+                        <div id="two" tabIndex={0} style={itemStyles}>
+                            Item 2
+                        </div>
+                        <div id="three" tabIndex={0} style={itemStyles}>
+                            Item 3
+                        </div>
+                        <div id="four" tabIndex={0} style={itemStyles}>
+                            Item 4
+                        </div>
                     </div>
                 </div>
             )
@@ -1186,27 +1287,29 @@ describe("Mover with visibilityAware", () => {
 
         await new BroTest.BroTest(
             (
-                <div
-                    id="container"
-                    {...getTabsterAttribute({
-                        mover: {
-                            visibilityAware:
-                                Types.Visibilities.PartiallyVisible,
-                        },
-                    })}
-                    style={containerStyles}
-                >
-                    <div id="one" style={itemStyles}>
-                        Item 1
-                    </div>
-                    <div id="two" style={itemStyles}>
-                        Item 2
-                    </div>
-                    <div id="three" style={itemStyles}>
-                        Item 3
-                    </div>
-                    <div id="four" style={itemStyles}>
-                        Item 4
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        id="container"
+                        {...getTabsterAttribute({
+                            mover: {
+                                visibilityAware:
+                                    Types.Visibilities.PartiallyVisible,
+                            },
+                        })}
+                        style={containerStyles}
+                    >
+                        <div id="one" tabIndex={0} style={itemStyles}>
+                            Item 1
+                        </div>
+                        <div id="two" tabIndex={0} style={itemStyles}>
+                            Item 2
+                        </div>
+                        <div id="three" tabIndex={0} style={itemStyles}>
+                            Item 3
+                        </div>
+                        <div id="four" tabIndex={0} style={itemStyles}>
+                            Item 4
+                        </div>
                     </div>
                 </div>
             )
@@ -1246,28 +1349,30 @@ describe("Mover with visibilityAware", () => {
 
         await new BroTest.BroTest(
             (
-                <div
-                    id="container"
-                    {...getTabsterAttribute({
-                        mover: {
-                            visibilityAware:
-                                Types.Visibilities.PartiallyVisible,
-                            visibilityTolerance: 0.1,
-                        },
-                    })}
-                    style={containerStyles}
-                >
-                    <div id="one" style={itemStyles}>
-                        Item 1
-                    </div>
-                    <div id="two" style={itemStyles}>
-                        Item 2
-                    </div>
-                    <div id="three" style={itemStyles}>
-                        Item 3
-                    </div>
-                    <div id="four" style={itemStyles}>
-                        Item 4
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        id="container"
+                        {...getTabsterAttribute({
+                            mover: {
+                                visibilityAware:
+                                    Types.Visibilities.PartiallyVisible,
+                                visibilityTolerance: 0.1,
+                            },
+                        })}
+                        style={containerStyles}
+                    >
+                        <div id="one" tabIndex={0} style={itemStyles}>
+                            Item 1
+                        </div>
+                        <div id="two" tabIndex={0} style={itemStyles}>
+                            Item 2
+                        </div>
+                        <div id="three" tabIndex={0} style={itemStyles}>
+                            Item 3
+                        </div>
+                        <div id="four" tabIndex={0} style={itemStyles}>
+                            Item 4
+                        </div>
                     </div>
                 </div>
             )


### PR DESCRIPTION
`trackState` and `visibilityAware` were buggy sometimes handling elements that were never visible.