### PR TITLE
fix(Mover, Groupper): Properly prioritizing grouppers and movers in the context when they are on the same element.

### DIFF
--- a/src/Root.ts
+++ b/src/Root.ts
@@ -486,9 +486,14 @@ export class RootAPI implements Types.RootAPI {
                 }
             }
 
-            if (!mover && curMover && (!modalizer || curModalizer)) {
+            if (
+                !mover &&
+                curMover &&
+                (!modalizer || curModalizer) &&
+                (!curGroupper || curElement !== element)
+            ) {
                 mover = curMover;
-                isGroupperFirst = !!groupper;
+                isGroupperFirst = !!groupper && groupper !== curGroupper;
             }
 
             if (tabsterOnElement.root) {

--- a/tests/MoverGroupper.test.tsx
+++ b/tests/MoverGroupper.test.tsx
@@ -1382,4 +1382,75 @@ describe("MoverGroupper", () => {
                 expect(el?.textContent).toEqual("Button1Button2Button3Button4");
             });
     });
+
+    it("should properly handle groupper and mover on the same element", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: {},
+                        })}
+                    >
+                        <button>Button1</button>
+                        <div
+                            tabIndex={0}
+                            {...getTabsterAttribute({
+                                groupper: {
+                                    tabbability:
+                                        Types.GroupperTabbabilities
+                                            .LimitedTrapFocus,
+                                },
+                                mover: {},
+                            })}
+                        >
+                            <button>Button2</button>
+                            <button>Button3</button>
+                        </div>
+                        <button>Button4</button>
+                    </div>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2Button3");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .pressUp()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2Button3");
+            })
+            .pressEnter()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressUp()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressUp()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressEsc()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2Button3");
+            });
+    });
 });


### PR DESCRIPTION
When Mover and Groupper are set on the same element, they should be prioritized properly:

If the context element equals to the element which has both Mover and Groupper, Mover should be ignored. Otherwise Mover shouldn't be ignored and `isGroupperFirst` should be false (if there is no deeper Groupper in the context).