### PR TITLE
Check if EventTarget is constructable

### DIFF
--- a/src/EventTarget.ts
+++ b/src/EventTarget.ts
@@ -8,8 +8,15 @@ import type { GetWindow } from "./Types";
 export function createEventTarget(getWindow: GetWindow): EventTarget {
     const global = getWindow() as unknown as typeof globalThis;
 
-    if (global.EventTarget) {
-        return new global.EventTarget();
+    try {
+        if (global.EventTarget) {
+            return new global.EventTarget();
+        }
+    } catch (error) {
+        // thrown if EventTarget is not constructable or doesn't exit
+        if (!(error instanceof TypeError)) {
+            throw error;
+        }
     }
 
     return global.document.createElement("div");


### PR DESCRIPTION
In Safari 13 (which is supported by Loop), EventTarget exists but is not constructable. This change updates the code to fallback if the class isn't constructable.

A `typeof EventTarget === 'function'` check *might* also work here, but I didn't have a copy of Safari 13 to test with.