### PR TITLE
feat(Mover): Making hasDefault true by default.

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -295,10 +295,11 @@ export class Mover
 
         const { memorizeCurrent, visibilityAware, hasDefault } = this._props;
         const moverElement = this.getElement();
+        const actualHasDefault = hasDefault || hasDefault === undefined;
 
         if (
             moverElement &&
-            (memorizeCurrent || visibilityAware || hasDefault) &&
+            (memorizeCurrent || visibilityAware || actualHasDefault) &&
             (!moverElement.contains(state.from) ||
                 (
                     state.from as HTMLElementWithDummyContainer
@@ -314,7 +315,7 @@ export class Mover
                 }
             }
 
-            if (!found && hasDefault) {
+            if (!found && actualHasDefault) {
                 found = this._tabster.focusable.findDefault({
                     container: moverElement,
                     ignoreUncontrolled: true,

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -602,7 +602,7 @@ export interface MoverProps {
     visibilityAware?: Visibility;
     /**
      * When true, Mover will try to locate a focusable with Focusable.isDefault
-     * property as a prioritized element to focus.
+     * property as a prioritized element to focus. True by default.
      */
     hasDefault?: boolean;
     /**

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -2476,4 +2476,90 @@ describe("Mover with default element", () => {
                 expect(el?.textContent).toEqual("Button3");
             });
     });
+
+    it("should treat hasDefault as true when it is not specified", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button>Button1</button>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: {},
+                        })}
+                    >
+                        <button>Button2</button>
+                        <button>Button3</button>
+                        <button
+                            {...getTabsterAttribute({
+                                focusable: { isDefault: true },
+                            })}
+                        >
+                            Button4
+                        </button>
+                        <button>Button5</button>
+                    </div>
+                    <button>Button6</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            });
+    });
+
+    it("should not look for default when hasDefault is false", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button>Button1</button>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: { hasDefault: false },
+                        })}
+                    >
+                        <button>Button2</button>
+                        <button>Button3</button>
+                        <button
+                            {...getTabsterAttribute({
+                                focusable: { isDefault: true },
+                            })}
+                        >
+                            Button4
+                        </button>
+                        <button>Button5</button>
+                    </div>
+                    <button>Button6</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            });
+    });
 });


### PR DESCRIPTION
As previously concluded, it is better to have Mover's hasDefault property set to true by default.