### PR TITLE
feat(Mover, Groupper): Ignore handling arrows in Mover and Enter/Esc in Groupper when Ctrl, Alt, Shift or Meta keys are pressed.

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -579,6 +579,11 @@ export class GroupperAPI implements Types.GroupperAPI {
             return;
         }
 
+        // Give a chance to other listeners to handle the event.
+        if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) {
+            return;
+        }
+
         const element = this._tabster.focusedElement.getFocusedElement();
 
         if (element) {

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -759,7 +759,7 @@ export class MoverAPI implements Types.MoverAPI {
         }
     };
 
-    private _onKeyDown = async (e: KeyboardEvent): Promise<void> => {
+    private _onKeyDown = async (event: KeyboardEvent): Promise<void> => {
         if (this._ignoredInputTimer) {
             this._win().clearTimeout(this._ignoredInputTimer);
             delete this._ignoredInputTimer;
@@ -767,11 +767,11 @@ export class MoverAPI implements Types.MoverAPI {
 
         this._ignoredInputResolve?.(false);
 
-        let keyCode = e.keyCode;
+        let keyCode = event.keyCode;
 
         // Give a chance to other listeners to handle the event (for example,
         // to scroll instead of moving focus).
-        if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
+        if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) {
             return;
         }
 
@@ -804,7 +804,7 @@ export class MoverAPI implements Types.MoverAPI {
             !ctx ||
             !ctx.mover ||
             ctx.isExcludedFromMover ||
-            ctx.ignoreKeydown(e)
+            ctx.ignoreKeydown(event)
         ) {
             return;
         }
@@ -1190,8 +1190,8 @@ export class MoverAPI implements Types.MoverAPI {
         }
 
         if (next) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
+            event.preventDefault();
+            event.stopImmediatePropagation();
 
             nativeFocus(next);
         }

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -768,8 +768,10 @@ export class MoverAPI implements Types.MoverAPI {
         this._ignoredInputResolve?.(false);
 
         let keyCode = e.keyCode;
-        // Mover does not use ctrl key currently
-        if (e.ctrlKey) {
+
+        // Give a chance to other listeners to handle the event (for example,
+        // to scroll instead of moving focus).
+        if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
             return;
         }
 

--- a/tests/Groupper.test.tsx
+++ b/tests/Groupper.test.tsx
@@ -326,6 +326,52 @@ describe("Groupper - limited focus trap", () => {
                 .activeElement((el) => expect(el?.textContent).toBe("Bar3"));
         }
     );
+
+    it.each(["ctrl", "alt", "shift", "meta"] as const)(
+        "should ignore Enter and Esc keys with %s",
+        async (key) => {
+            await new BroTest.BroTest(
+                (
+                    <div
+                        {...getTabsterAttribute({
+                            root: {},
+                        })}
+                    >
+                        <div
+                            tabIndex={0}
+                            {...getTabsterAttribute({
+                                groupper: {
+                                    tabbability:
+                                        Types.GroupperTabbabilities
+                                            .LimitedTrapFocus,
+                                },
+                            })}
+                        >
+                            <button>Button1</button>
+                            <button>Button2</button>
+                        </div>
+                    </div>
+                )
+            )
+                .pressTab()
+                .press("Enter", { [key]: true })
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Button1Button2")
+                )
+                .pressEnter()
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Button1")
+                )
+                .press("Escape", { [key]: true })
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Button1")
+                )
+                .pressEsc()
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Button1Button2")
+                );
+        }
+    );
 });
 
 describe("Groupper tabbing forward and backwards", () => {

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -376,39 +376,51 @@ describe("NestedMovers", () => {
         "PageUp",
         "Home",
         "End",
-    ] as const)("should ignore CTRL key with %s", async (key) => {
-        const attr = getTabsterAttribute({
-            mover: {
-                direction: Types.MoverDirections.Vertical,
-                cyclic: true,
-            },
-            focusable: {
-                ignoreKeydown: {
-                    [key]: true,
+    ] as const)(
+        "should ignore Ctrl, Alt, Shift and Meta keys with %s",
+        async (key) => {
+            const attr = getTabsterAttribute({
+                mover: {
+                    direction: Types.MoverDirections.Both,
+                    cyclic: true,
                 },
-            },
-        });
+            });
 
-        await new BroTest.BroTest(
-            (
-                <div
-                    {...getTabsterAttribute({
-                        root: {},
-                    })}
-                >
-                    <div {...attr} id="mover">
-                        <button id="start">Mover Item</button>
-                        <button>Mover Item</button>
-                        <button>Mover Item</button>
-                        <button>Mover Item</button>
+            await new BroTest.BroTest(
+                (
+                    <div
+                        {...getTabsterAttribute({
+                            root: {},
+                        })}
+                    >
+                        <div {...attr} id="mover">
+                            <button id="start">Mover Item 1</button>
+                            <button>Mover Item 2</button>
+                            <button>Mover Item 3</button>
+                            <button>Mover Item 4</button>
+                        </div>
                     </div>
-                </div>
+                )
             )
-        )
-            .focusElement("#start")
-            .press(key, { ctrl: true })
-            .activeElement((el) => expect(el?.attributes.id).toEqual("start"));
-    });
+                .focusElement("#start")
+                .press(key, { ctrl: true })
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Mover Item 1")
+                )
+                .press(key, { alt: true })
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Mover Item 1")
+                )
+                .press(key, { shift: true })
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Mover Item 1")
+                )
+                .press(key, { meta: true })
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Mover Item 1")
+                );
+        }
+    );
 });
 
 describe("Mover memorizing current", () => {

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -486,18 +486,29 @@ export class BroTest implements PromiseLike<undefined> {
                   delay?: number | undefined;
                   ctrl?: boolean;
                   shift?: boolean;
+                  alt?: boolean;
+                  meta?: boolean;
               }
             | undefined
     ) {
         this._chain.push(
             new BroTestItemCallback(this._frameStack, async () => {
-                const { shift, ctrl } = options ?? {};
+                const { shift, ctrl, alt, meta } = options ?? {};
+
                 if (shift) {
                     await page.keyboard.down("Shift");
                 }
 
                 if (ctrl) {
                     await page.keyboard.down("Control");
+                }
+
+                if (alt) {
+                    await page.keyboard.down("Alt");
+                }
+
+                if (meta) {
+                    await page.keyboard.down("Meta");
                 }
 
                 await page.keyboard.press(key, options);
@@ -509,6 +520,14 @@ export class BroTest implements PromiseLike<undefined> {
                 if (ctrl) {
                     await page.keyboard.up("Control");
                 }
+
+                if (alt) {
+                    await page.keyboard.up("Alt");
+                }
+
+                if (meta) {
+                    await page.keyboard.up("Meta");
+                }
             })
         );
 
@@ -517,7 +536,13 @@ export class BroTest implements PromiseLike<undefined> {
         return this;
     }
 
-    private _pressKey(key: KeyInput, shift?: boolean, ctrl?: boolean) {
+    private _pressKey(
+        key: KeyInput,
+        shift?: boolean,
+        ctrl?: boolean,
+        alt?: boolean,
+        meta?: boolean
+    ) {
         this._chain.push(
             new BroTestItemCallback(this._frameStack, async () => {
                 if (shift) {
@@ -528,6 +553,14 @@ export class BroTest implements PromiseLike<undefined> {
                     await page.keyboard.down("Control");
                 }
 
+                if (alt) {
+                    await page.keyboard.down("Alt");
+                }
+
+                if (meta) {
+                    await page.keyboard.down("Meta");
+                }
+
                 await page.keyboard.press(key);
 
                 if (shift) {
@@ -536,6 +569,14 @@ export class BroTest implements PromiseLike<undefined> {
 
                 if (ctrl) {
                     await page.keyboard.up("Control");
+                }
+
+                if (alt) {
+                    await page.keyboard.up("Alt");
+                }
+
+                if (meta) {
+                    await page.keyboard.up("Meta");
                 }
             })
         );
@@ -561,26 +602,61 @@ export class BroTest implements PromiseLike<undefined> {
         return this;
     }
 
-    pressTab(shift?: boolean, ctrlKey?: boolean) {
-        return this._pressKey("Tab", shift, ctrlKey);
+    pressTab(
+        shiftKey?: boolean,
+        ctrlKey?: boolean,
+        altKey?: boolean,
+        metaKey?: boolean
+    ) {
+        return this._pressKey("Tab", shiftKey, ctrlKey, altKey, metaKey);
     }
-    pressEsc(shift?: boolean) {
-        return this._pressKey("Escape", shift);
+    pressEsc(
+        shiftKey?: boolean,
+        ctrlKey?: boolean,
+        altKey?: boolean,
+        metaKey?: boolean
+    ) {
+        return this._pressKey("Escape", shiftKey, ctrlKey, altKey, metaKey);
     }
-    pressEnter(shift?: boolean) {
-        return this._pressKey("Enter", shift);
+    pressEnter(
+        shiftKey?: boolean,
+        ctrlKey?: boolean,
+        altKey?: boolean,
+        metaKey?: boolean
+    ) {
+        return this._pressKey("Enter", shiftKey, ctrlKey, altKey, metaKey);
     }
-    pressUp(shift?: boolean) {
-        return this._pressKey("ArrowUp", shift);
+    pressUp(
+        shiftKey?: boolean,
+        ctrlKey?: boolean,
+        altKey?: boolean,
+        metaKey?: boolean
+    ) {
+        return this._pressKey("ArrowUp", shiftKey, ctrlKey, altKey, metaKey);
     }
-    pressDown(shift?: boolean) {
-        return this._pressKey("ArrowDown", shift);
+    pressDown(
+        shiftKey?: boolean,
+        ctrlKey?: boolean,
+        altKey?: boolean,
+        metaKey?: boolean
+    ) {
+        return this._pressKey("ArrowDown", shiftKey, ctrlKey, altKey, metaKey);
     }
-    pressLeft(shift?: boolean) {
-        return this._pressKey("ArrowLeft", shift);
+    pressLeft(
+        shiftKey?: boolean,
+        ctrlKey?: boolean,
+        altKey?: boolean,
+        metaKey?: boolean
+    ) {
+        return this._pressKey("ArrowLeft", shiftKey, ctrlKey, altKey, metaKey);
     }
-    pressRight(shift?: boolean) {
-        return this._pressKey("ArrowRight", shift);
+    pressRight(
+        shiftKey?: boolean,
+        ctrlKey?: boolean,
+        altKey?: boolean,
+        metaKey?: boolean
+    ) {
+        return this._pressKey("ArrowRight", shiftKey, ctrlKey, altKey, metaKey);
     }
 
     scrollTo(selector: string, x: number, y: number) {


### PR DESCRIPTION
This is to give people extra options to fall back to default behaviour (like scrolling the page) or give the application options for handling the key presses.