### PR TITLE
fix(CrossOrigin): Fixing the cross origin version of requestFocus() not waiting for the element to become accessible.

### DIFF
--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -770,7 +770,8 @@ class GetElementTransaction extends CrossOriginTransaction<
             } else if (data.observedName) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 element = tabster.observedElement!.getElement(
-                    data.observedName
+                    data.observedName,
+                    data.accessibility
                 );
             }
         }


### PR DESCRIPTION
observedElement.requestFocus() can wait for an element to become accessible within the specified timeout and focus it right after. The cross origin version internally wasn't passing the argument to do so — if an observed element existed on the page but wasn't accessible (like having aria-hidden, for example), requestFocus() was immediately returning with no focused element.