### PR TITLE
fix(DummyInput): Force dummy input position update when it is needed before the scheduled update.

### DIFF
--- a/tests/DummyInputManager.test.tsx
+++ b/tests/DummyInputManager.test.tsx
@@ -638,7 +638,7 @@ describeIfUncontrolled("DummyInputManager", () => {
         });
     });
 
-    it("should force dummy inputs position update when the move out functions are called before the async update on DOM changed", async () => {
+    it("should force dummy inputs position update when the move out functions are called before the async update on DOM change", async () => {
         await new BroTest.BroTest(
             (
                 <div id="root" {...getTabsterAttribute({ root: {} })}>
@@ -657,7 +657,7 @@ describeIfUncontrolled("DummyInputManager", () => {
 
                 // We've pushed the button to the end of the root element. The dummy
                 // input is supposed to be moved after this element, but that normally
-                // happens asuncronously.
+                // happens asynchronously.
                 isDummyLast.push(
                     rootElement?.lastElementChild
                         ? rootElement.lastElementChild.hasAttribute(


### PR DESCRIPTION
Dummy inputs are supposed to be first/last elements in the container. When new DOM is appended after the dummy input, Tabster will schedule a position update on the next tick. In the real world it is hardly possible to press Tab between the DOM update and the scheduled dummy input update, but in the test environment it is easily possible. Because the position affects the behaviour like `moveOutWithDefaultAction()`, we enforce its update from the move out functions.