### PR TITLE
fix: Making sure getComputedStyle() is called for a Node.ELEMENT_NODE only.

### DIFF
--- a/src/Focusable.ts
+++ b/src/Focusable.ts
@@ -60,7 +60,7 @@ export class FocusableAPI implements Types.FocusableAPI {
     }
 
     isVisible(el: HTMLElement): boolean {
-        if (!el.ownerDocument) {
+        if (!el.ownerDocument || el.nodeType !== Node.ELEMENT_NODE) {
             return false;
         }
 

--- a/src/Outline.ts
+++ b/src/Outline.ts
@@ -377,7 +377,7 @@ export class OutlineAPI implements Types.OutlineAPI {
 
         for (
             let parent = this._outlinedElement.parentElement;
-            parent;
+            parent && parent.nodeType === Node.ELEMENT_NODE;
             parent = parent.parentElement
         ) {
             // The element might be partially visible within its scrollable parent,

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1527,7 +1527,7 @@ class DummyInputManagerCore {
 
         for (
             let element: HTMLElement | undefined | null = from;
-            element;
+            element && element.nodeType === Node.ELEMENT_NODE;
             element = element.parentElement
         ) {
             let scrollTopLeft = scrollTopLeftCache.get(element);


### PR DESCRIPTION
Working around that document.body.parentElement.parentElement is not null in Firefox in some environments because of some yet unknown reason.