### PR TITLE
Grid with linear direction

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -853,7 +853,8 @@ export class MoverAPI implements Types.MoverAPI {
             isBoth || direction === Types.MoverDirections.Vertical;
         const isHorizontal =
             isBoth || direction === Types.MoverDirections.Horizontal;
-        const isGrid = direction === Types.MoverDirections.Grid;
+        const isGridLinear = direction === Types.MoverDirections.GridLinear;
+        const isGrid = isGridLinear || direction === Types.MoverDirections.Grid;
         const isCyclic = moverProps.cyclic;
 
         let next: HTMLElement | null | undefined;
@@ -891,7 +892,7 @@ export class MoverAPI implements Types.MoverAPI {
                     next.getBoundingClientRect().left
                 );
 
-                if (focusedElementX2 > nextElementX1) {
+                if (!isGridLinear && focusedElementX2 > nextElementX1) {
                     next = undefined;
                 }
             } else if (!next && isCyclic) {
@@ -916,7 +917,7 @@ export class MoverAPI implements Types.MoverAPI {
                     next.getBoundingClientRect().right
                 );
 
-                if (nextElementX2 > focusedElementX1) {
+                if (!isGridLinear && nextElementX2 > focusedElementX1) {
                     next = undefined;
                 }
             } else if (!next && isCyclic) {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -559,12 +559,14 @@ export interface MoverDirections {
     Vertical: 1; // Only up/down arrows move to the next/previous.
     Horizontal: 2; // Only left/right arrows move to the next/previous.
     Grid: 3; // Two-dimentional movement depending on the visual placement.
+    GridLinear: 4; // Two-dimentional movement depending on the visual placement. Allows linear movement.
 }
 export const MoverDirections: MoverDirections = {
     Both: 0,
     Vertical: 1,
     Horizontal: 2,
     Grid: 3,
+    GridLinear: 4,
 };
 export type MoverDirection = MoverDirections[keyof MoverDirections];
 

--- a/stories/Mover/Mover.ts
+++ b/stories/Mover/Mover.ts
@@ -62,7 +62,7 @@ export const createTableMover = ({
         {
             mover: {
                 cyclic,
-                direction: TabsterTypes.MoverDirections.Grid,
+                direction,
                 memorizeCurrent,
                 tabbable,
                 trackState,

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -2030,6 +2030,89 @@ describe("Mover with grid", () => {
     });
 });
 
+describe("Mover with linear grid", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({ mover: true });
+    });
+
+    it("should properly move focus with arrow keys in linear grid as <table>", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: {
+                                direction: Types.MoverDirections.GridLinear,
+                            },
+                        })}
+                    >
+                        <table>
+                            <tr>
+                                <td tabIndex={0}>Row1-Col1</td>
+                                <td>
+                                    <button style={{ fontSize: "50%" }}>
+                                        Row1-Col2
+                                    </button>
+                                </td>
+                                <td style={{ padding: 10 }}>
+                                    <button>Row1-Col3</button>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td tabIndex={0}>Row2-Col1</td>
+                                <td align="right">
+                                    <button
+                                        style={{
+                                            fontSize: "50%",
+                                            marginLeft: 40,
+                                        }}
+                                    >
+                                        Row2-Col2
+                                    </button>
+                                </td>
+                                <td style={{ padding: 10 }}>
+                                    <button>Row2-Col3</button>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td tabIndex={0}>Row3-Col1</td>
+                                <td align="center">
+                                    <button style={{ fontSize: "50%" }}>
+                                        Row3-Col2
+                                    </button>
+                                </td>
+                                <td style={{ padding: 10 }}>
+                                    <button>Row3-Col3</button>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Row1-Col1");
+            })
+            .pressRight()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Row1-Col2");
+            })
+            .pressRight()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Row1-Col3");
+            })
+            .pressRight()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Row2-Col1");
+            })
+            .pressLeft()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Row1-Col3");
+            });
+    });
+});
+
 describe("Adjacent Movers", () => {
     beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ mover: true });


### PR DESCRIPTION
Linear direction can be used in selection components that have grid layout, like emoji picker: 
<img width="365" alt="image" src="https://github.com/microsoft/tabster/assets/13742664/c8e7b971-0934-4f05-8a51-95e496aa1f4d">

|  `A1` | `B1`  | `C1`  |
|---|---|---|
| `A2`  | `B2`  | `C2`  |

When user navigates with right arrow key, the order is `A1` -> `B1` -> `C1` -> `A2` and so on.
The user can still use down arrow to move from `A1` to `A2`.

Previously there was just `isGrid` flag handling grid navigation, with a comparison that nullifies the result when X is not as it is needed for table in keydown handler of Mover.ts. These conditions have been extended to account for linear grid.