### PR TITLE
feat(Modalizer): A createTabster() option to provide alwaysAccessibleSelector selector for the elements to not set aria-hidden on.

### DIFF
--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -329,18 +329,20 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     private _augMap: WeakMap<HTMLElement, true>;
     private _aug: WeakRef<HTMLElement>[];
     private _hiddenUpdateTimer: number | undefined;
+    private _alwaysAccessibleSelector: string | undefined;
 
     activeId: string | undefined;
     currentIsOthersAccessible: boolean | undefined;
     activeElements: WeakRef<HTMLElement>[];
 
-    constructor(tabster: Types.TabsterCore) {
+    constructor(tabster: Types.TabsterCore, alwaysAccessibleSelector?: string) {
         this._tabster = tabster;
         this._win = tabster.getWindow;
         this._modalizers = {};
         this._parts = {};
         this._augMap = new WeakMap();
         this._aug = [];
+        this._alwaysAccessibleSelector = alwaysAccessibleSelector;
         this.activeElements = [];
 
         if (!tabster.controlTab) {
@@ -654,15 +656,13 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         const parts = this._parts;
         const visibleElements: HTMLElement[] = [];
         const hiddenElements: HTMLElement[] = [];
-        const alwaysAccessibleElementsSelector =
-            tabster.modalizerAlwaysAccessible;
-        const alwaysAccessibleElements: HTMLElement[] =
-            alwaysAccessibleElementsSelector
-                ? Array.prototype.slice.call(
-                      body.querySelectorAll(alwaysAccessibleElementsSelector),
-                      0
-                  )
-                : [];
+        const alwaysAccessibleSelector = this._alwaysAccessibleSelector;
+        const alwaysAccessibleElements: HTMLElement[] = alwaysAccessibleSelector
+            ? Array.prototype.slice.call(
+                  body.querySelectorAll(alwaysAccessibleSelector),
+                  0
+              )
+            : [];
 
         for (const userId of Object.keys(parts)) {
             const mParts = parts[userId];

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -654,7 +654,15 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         const parts = this._parts;
         const visibleElements: HTMLElement[] = [];
         const hiddenElements: HTMLElement[] = [];
-        const alwaysAccessibleElements: HTMLElement[] = [];
+        const alwaysAccessibleElementsSelector =
+            tabster.modalizerAlwaysAccessible;
+        const alwaysAccessibleElements: HTMLElement[] =
+            alwaysAccessibleElementsSelector
+                ? Array.prototype.slice.call(
+                      body.querySelectorAll(alwaysAccessibleElementsSelector),
+                      0
+                  )
+                : [];
 
         for (const userId of Object.keys(parts)) {
             const mParts = parts[userId];

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -658,10 +658,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         const hiddenElements: HTMLElement[] = [];
         const alwaysAccessibleSelector = this._alwaysAccessibleSelector;
         const alwaysAccessibleElements: HTMLElement[] = alwaysAccessibleSelector
-            ? Array.prototype.slice.call(
-                  body.querySelectorAll(alwaysAccessibleSelector),
-                  0
-              )
+            ? Array.from(body.querySelectorAll(alwaysAccessibleSelector))
             : [];
 
         for (const userId of Object.keys(parts)) {

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -67,6 +67,7 @@ class TabsterCore implements Types.TabsterCore {
     _noop = false;
     controlTab: boolean;
     rootDummyInputs: boolean;
+    modalizerAlwaysAccessible?: string;
 
     // Core APIs
     keyboardNavigation: Types.KeyboardNavigationState;
@@ -99,6 +100,7 @@ class TabsterCore implements Types.TabsterCore {
         this.uncontrolled = new UncontrolledAPI();
         this.controlTab = props?.controlTab ?? true;
         this.rootDummyInputs = !!props?.rootDummyInputs;
+        this.modalizerAlwaysAccessible = props?.modalizerAlwaysAccessible;
 
         this._dummyObserver = new DummyInputObserver(getWindow);
 

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -100,7 +100,6 @@ class TabsterCore implements Types.TabsterCore {
         this.uncontrolled = new UncontrolledAPI();
         this.controlTab = props?.controlTab ?? true;
         this.rootDummyInputs = !!props?.rootDummyInputs;
-        this.modalizerAlwaysAccessible = props?.modalizerAlwaysAccessible;
 
         this._dummyObserver = new DummyInputObserver(getWindow);
 
@@ -374,11 +373,22 @@ export function getDeloser(
 /**
  * Creates a new modalizer instance or returns an existing one
  * @param tabster Tabster instance
+ * @param alwaysAccessibleSelector When Modalizer is active, we put
+ * aria-hidden to everything else to hide it from screen readers. This CSS
+ * selector allows to exclude some elements from this behaviour. For example,
+ * this could be used to exclude aria-live region with the application-wide
+ * status announcements.
  */
-export function getModalizer(tabster: Types.Tabster): Types.ModalizerAPI {
+export function getModalizer(
+    tabster: Types.Tabster,
+    alwaysAccessibleSelector?: string
+): Types.ModalizerAPI {
     const tabsterCore = tabster.core;
     if (!tabsterCore.modalizer) {
-        tabsterCore.modalizer = new ModalizerAPI(tabsterCore);
+        tabsterCore.modalizer = new ModalizerAPI(
+            tabsterCore,
+            alwaysAccessibleSelector
+        );
     }
 
     return tabsterCore.modalizer;

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -67,7 +67,6 @@ class TabsterCore implements Types.TabsterCore {
     _noop = false;
     controlTab: boolean;
     rootDummyInputs: boolean;
-    modalizerAlwaysAccessible?: string;
 
     // Core APIs
     keyboardNavigation: Types.KeyboardNavigationState;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -36,6 +36,13 @@ export interface TabsterCoreProps {
      * This option allows to enable dummy inputs on Root.
      */
     rootDummyInputs?: boolean;
+    /**
+     * When Modalizer is active, we put aria-hidden to everything else to hide
+     * it from screen readers. This CSS selector allows to exclude some elements
+     * from this behaviour. For example, this could be used to exclude aria-live region
+     * with the application-wide status announcements.
+     */
+    modalizerAlwaysAccessible?: string;
 }
 
 export type GetTabster = () => TabsterCore;
@@ -1092,7 +1099,10 @@ export interface Tabster {
 }
 
 export interface TabsterCore
-    extends Pick<TabsterCoreProps, "controlTab" | "rootDummyInputs">,
+    extends Pick<
+            TabsterCoreProps,
+            "controlTab" | "rootDummyInputs" | "modalizerAlwaysAccessible"
+        >,
         Disposable,
         TabsterCoreInternal,
         Omit<Tabster, "core"> {}

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -36,13 +36,6 @@ export interface TabsterCoreProps {
      * This option allows to enable dummy inputs on Root.
      */
     rootDummyInputs?: boolean;
-    /**
-     * When Modalizer is active, we put aria-hidden to everything else to hide
-     * it from screen readers. This CSS selector allows to exclude some elements
-     * from this behaviour. For example, this could be used to exclude aria-live region
-     * with the application-wide status announcements.
-     */
-    modalizerAlwaysAccessible?: string;
 }
 
 export type GetTabster = () => TabsterCore;
@@ -1099,10 +1092,7 @@ export interface Tabster {
 }
 
 export interface TabsterCore
-    extends Pick<
-            TabsterCoreProps,
-            "controlTab" | "rootDummyInputs" | "modalizerAlwaysAccessible"
-        >,
+    extends Pick<TabsterCoreProps, "controlTab" | "rootDummyInputs">,
         Disposable,
         TabsterCoreInternal,
         Omit<Tabster, "core"> {}

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -1846,3 +1846,84 @@ describe("Modalizer dispose", () => {
             });
     });
 });
+
+describe("Modalizer with modalizerAlwaysAccessible selector", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it("should not set aria-hidden on elements that match the modalizerAlwaysAccessible selector", async () => {
+        await new BroTest.BroTest(
+            (
+                <div>
+                    <button id="button1">Button1</button>
+                    <div
+                        {...getTabsterAttribute({
+                            modalizer: { id: "modal", isTrapped: true },
+                        })}
+                    >
+                        <button id="button2">Button2</button>
+                    </div>
+                    <button id="button3">Button3</button>
+                    <div id="aria-live" aria-live="polite">
+                        Ololo
+                    </div>
+                </div>
+            )
+        )
+            .eval(() => {
+                const vars = getTabsterTestVariables();
+
+                const tabster = vars.createTabster?.(window, {
+                    autoRoot: {},
+                    modalizerAlwaysAccessible: "[aria-live]",
+                });
+
+                if (tabster) {
+                    vars.getModalizer?.(tabster);
+                }
+            })
+            .focusElement("#button2")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .wait(500)
+            .eval(() => [
+                document.getElementById("button1")?.hasAttribute("aria-hidden"),
+                document
+                    .getElementById("button2")
+                    ?.parentElement?.hasAttribute("aria-hidden"),
+                document.getElementById("button3")?.hasAttribute("aria-hidden"),
+                document
+                    .getElementById("aria-live")
+                    ?.hasAttribute("aria-hidden"),
+            ])
+            .check(([button1, button2, button3, ariaLive]) => {
+                expect(button1).toEqual(true);
+                expect(button2).toEqual(false);
+                expect(button3).toEqual(true);
+                expect(ariaLive).toEqual(false);
+            })
+            .focusElement("#button3")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .wait(500)
+            .eval(() => [
+                document.getElementById("button1")?.hasAttribute("aria-hidden"),
+                document
+                    .getElementById("button2")
+                    ?.parentElement?.hasAttribute("aria-hidden"),
+                document.getElementById("button3")?.hasAttribute("aria-hidden"),
+                document
+                    .getElementById("aria-live")
+                    ?.hasAttribute("aria-hidden"),
+            ])
+            .check(([button1, button2, button3, ariaLive]) => {
+                expect(button1).toEqual(false);
+                expect(button2).toEqual(true);
+                expect(button3).toEqual(false);
+                expect(ariaLive).toEqual(false);
+            });
+    });
+});

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -1876,11 +1876,10 @@ describe("Modalizer with modalizerAlwaysAccessible selector", () => {
 
                 const tabster = vars.createTabster?.(window, {
                     autoRoot: {},
-                    modalizerAlwaysAccessible: "[aria-live]",
                 });
 
                 if (tabster) {
-                    vars.getModalizer?.(tabster);
+                    vars.getModalizer?.(tabster, "[aria-live]");
                 }
             })
             .focusElement("#button2")

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -1847,12 +1847,12 @@ describe("Modalizer dispose", () => {
     });
 });
 
-describe("Modalizer with modalizerAlwaysAccessible selector", () => {
+describe("Modalizer with alwaysAccessibleSelector", () => {
     beforeEach(async () => {
         await BroTest.bootstrapTabsterPage();
     });
 
-    it("should not set aria-hidden on elements that match the modalizerAlwaysAccessible selector", async () => {
+    it("should not set aria-hidden on elements that match the alwaysAccessibleSelector", async () => {
         await new BroTest.BroTest(
             (
                 <div>


### PR DESCRIPTION
By default everything outside of the active Modalizer gets aria-hidden attribute. We are adding option to be able to exclude some particular elements (for example aria-live announcement containers) from receiving aria-hidden.