### PR TITLE
Use getAttribute instead of accessing id directly

### DIFF
--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -296,9 +296,11 @@ function buildElementSelector(
     const escapeRegExp = /(:|\.|\[|\]|,|=|@)/g;
     const escapeReplaceValue = "\\$1";
 
-    if (element.id) {
+    const elementId = element.getAttribute("id");
+
+    if (elementId) {
         selector.push(
-            "#" + element.id.replace(escapeRegExp, escapeReplaceValue)
+            "#" + elementId.replace(escapeRegExp, escapeReplaceValue)
         );
     }
 

--- a/tests/Deloser.test.tsx
+++ b/tests/Deloser.test.tsx
@@ -174,6 +174,28 @@ describe("Deloser", () => {
                 expect(el?.textContent).toEqual("Button4");
             });
     });
+
+    it("should restore focus in <form> with named inputs", async () => {
+        await new BroTest.BroTest(
+            (
+                <form {...getTabsterAttribute({ root: {}, deloser: {} })}>
+                    <button>Button1</button>
+                    <input name="id" />
+                    <button>Button2</button>
+                </form>
+            )
+        )
+            .pressTab()
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.attributes.name).toEqual("id");
+            })
+            .removeElement()
+            .wait(300)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            });
+    });
 });
 
 describe("Deloser created lazily", () => {


### PR DESCRIPTION
If there is an input with name "id" in a form, element.id will target that input field instead of the id attribute of the form.

```html
<form id="foo">
    <input type="hidden" name="id" value="1" />
</form>
```

Means, if in the current iteration of buildElementSelector, the `element` is the `<form>`-element,

```js
element.id
```

will point to the input.

Therefore using `element.getAttribute("id")` will make sure, that the id-attribute of the current element is used.