### PR TITLE
feat(Modalizer): An accessibleCheck callback for getModalizer() to be able to avoid setting aria-hidden on specific elements.

### DIFF
--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -330,12 +330,17 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     private _aug: WeakRef<HTMLElement>[];
     private _hiddenUpdateTimer: number | undefined;
     private _alwaysAccessibleSelector: string | undefined;
+    private _accessibleCheck: Types.ModalizerElementAccessibleCheck | undefined;
 
     activeId: string | undefined;
     currentIsOthersAccessible: boolean | undefined;
     activeElements: WeakRef<HTMLElement>[];
 
-    constructor(tabster: Types.TabsterCore, alwaysAccessibleSelector?: string) {
+    constructor(
+        tabster: Types.TabsterCore,
+        alwaysAccessibleSelector?: string,
+        accessibleCheck?: Types.ModalizerElementAccessibleCheck
+    ) {
         this._tabster = tabster;
         this._win = tabster.getWindow;
         this._modalizers = {};
@@ -343,6 +348,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         this._augMap = new WeakMap();
         this._aug = [];
         this._alwaysAccessibleSelector = alwaysAccessibleSelector;
+        this._accessibleCheck = accessibleCheck;
         this.activeElements = [];
 
         if (!tabster.controlTab) {
@@ -660,18 +666,21 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         const alwaysAccessibleElements: HTMLElement[] = alwaysAccessibleSelector
             ? Array.from(body.querySelectorAll(alwaysAccessibleSelector))
             : [];
+        const activeModalizerElements: HTMLElement[] = [];
 
         for (const userId of Object.keys(parts)) {
-            const mParts = parts[userId];
+            const modalizerParts = parts[userId];
 
-            for (const id of Object.keys(mParts)) {
-                const m = mParts[id];
-                const el = m.getElement();
-                const props = m.getProps();
+            for (const id of Object.keys(modalizerParts)) {
+                const modalizer = modalizerParts[id];
+                const el = modalizer.getElement();
+                const props = modalizer.getProps();
                 const isAlwaysAccessible = props.isAlwaysAccessible;
 
                 if (el) {
                     if (userId === activeId) {
+                        activeModalizerElements.push(el);
+
                         if (!this.currentIsOthersAccessible) {
                             visibleElements.push(el);
                         }
@@ -711,6 +720,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                 }
             } else if (
                 hide &&
+                !this._accessibleCheck?.(element, activeModalizerElements) &&
                 augmentAttribute(tabster, element, _ariaHidden, "true")
             ) {
                 augmentedMap.set(element, true);

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -338,6 +338,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
 
     constructor(
         tabster: Types.TabsterCore,
+        // @deprecated use accessibleCheck.
         alwaysAccessibleSelector?: string,
         accessibleCheck?: Types.ModalizerElementAccessibleCheck
     ) {

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -385,6 +385,7 @@ export function getDeloser(
  */
 export function getModalizer(
     tabster: Types.Tabster,
+    // @deprecated use accessibleCheck.
     alwaysAccessibleSelector?: string,
     accessibleCheck?: Types.ModalizerElementAccessibleCheck
 ): Types.ModalizerAPI {

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -377,16 +377,23 @@ export function getDeloser(
  * selector allows to exclude some elements from this behaviour. For example,
  * this could be used to exclude aria-live region with the application-wide
  * status announcements.
+ * @param accessibleCheck An optional callback that will be called when
+ * active Modalizer wants to hide an element that doesn't belong to it from
+ * the screen readers by setting aria-hidden. Similar to alwaysAccessibleSelector
+ * but allows to address the elements programmatically rather than with a selector.
+ * If the callback returns true, the element will not receive aria-hidden.
  */
 export function getModalizer(
     tabster: Types.Tabster,
-    alwaysAccessibleSelector?: string
+    alwaysAccessibleSelector?: string,
+    accessibleCheck?: Types.ModalizerElementAccessibleCheck
 ): Types.ModalizerAPI {
     const tabsterCore = tabster.core;
     if (!tabsterCore.modalizer) {
         tabsterCore.modalizer = new ModalizerAPI(
             tabsterCore,
-            alwaysAccessibleSelector
+            alwaysAccessibleSelector,
+            accessibleCheck
         );
     }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -915,6 +915,20 @@ export interface ModalizerAPI extends ModalizerAPIInternal, Disposable {
     ): boolean;
 }
 
+/**
+ * A signature for the accessibleCheck callback from getModalizer().
+ * It is called when active Modalizer sets aria-hidden on elements outsidef of it.
+ *
+ * @param element The element that is about to receive aria-hidden.
+ * @param activeModalizerElements The container elements of the active modalizer.
+ * @returns true if the element should remain accessible and should not receive
+ * aria-hidden.
+ */
+export type ModalizerElementAccessibleCheck = (
+    element: HTMLElement,
+    activeModalizerElements?: HTMLElement[]
+) => boolean;
+
 export interface DeloserOnElement {
     deloser: Deloser;
 }

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -1926,3 +1926,76 @@ describe("Modalizer with alwaysAccessibleSelector", () => {
             });
     });
 });
+
+describe("Modalizer with checkAccessible callback", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it("should not set aria-hidden on elements that match the alwaysAccessibleSelector", async () => {
+        await new BroTest.BroTest(
+            (
+                <div>
+                    <button id="button1">Button1</button>
+                    <div
+                        {...getTabsterAttribute({
+                            modalizer: { id: "modal", isTrapped: true },
+                        })}
+                    >
+                        <button id="button2">Button2</button>
+                    </div>
+                    <button id="button3">Button3</button>
+                </div>
+            )
+        )
+            .eval(() => {
+                const vars = getTabsterTestVariables();
+
+                const tabster = vars.createTabster?.(window, {
+                    autoRoot: {},
+                });
+
+                if (tabster) {
+                    vars.getModalizer?.(
+                        tabster,
+                        undefined,
+                        (el) => el.id === "button3"
+                    );
+                }
+            })
+            .focusElement("#button2")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .wait(500)
+            .eval(() => [
+                document.getElementById("button1")?.hasAttribute("aria-hidden"),
+                document
+                    .getElementById("button2")
+                    ?.parentElement?.hasAttribute("aria-hidden"),
+                document.getElementById("button3")?.hasAttribute("aria-hidden"),
+            ])
+            .check(([button1, button2, button3]) => {
+                expect(button1).toEqual(true);
+                expect(button2).toEqual(false);
+                expect(button3).toEqual(false);
+            })
+            .focusElement("#button3")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .wait(500)
+            .eval(() => [
+                document.getElementById("button1")?.hasAttribute("aria-hidden"),
+                document
+                    .getElementById("button2")
+                    ?.parentElement?.hasAttribute("aria-hidden"),
+                document.getElementById("button3")?.hasAttribute("aria-hidden"),
+            ])
+            .check(([button1, button2, button3]) => {
+                expect(button1).toEqual(false);
+                expect(button2).toEqual(true);
+                expect(button3).toEqual(false);
+            });
+    });
+});


### PR DESCRIPTION
Active Modalizer sets `aria-hidden` to everything outside to hide it from screen readers. We already have `alwaysAccessibleSelector` selector to avoid setting `aria-hidden` on some elements that match a specific selector. This is another option to do the same but programmatically.