### PR TITLE
fix: Restorer should add target to history on creation if focused

### DIFF
--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -103,6 +103,10 @@ export class RestorerAPI implements RestorerAPIType {
             return;
         }
 
+        this._addToHistory(element);
+    };
+
+    private _addToHistory(element: HTMLElement) {
         // Don't duplicate the top of history
         if (this._history[this._history.length - 1]?.deref() === element) {
             return;
@@ -113,7 +117,7 @@ export class RestorerAPI implements RestorerAPIType {
         }
 
         this._history.push(new WeakRef<HTMLElement>(element));
-    };
+    }
 
     private _restoreFocus = (source: HTMLElement) => {
         // don't restore focus if focus isn't lost to body
@@ -143,6 +147,15 @@ export class RestorerAPI implements RestorerAPIType {
     };
 
     public createRestorer(element: HTMLElement, props: RestorerProps) {
-        return new Restorer(this._tabster, element, props);
+        const restorer = new Restorer(this._tabster, element, props);
+        // Focus might already be on a restorer target when it gets created so the focusin will not do anything
+        if (
+            props.type === RestorerTypes.Target &&
+            element.ownerDocument.activeElement === element
+        ) {
+            this._addToHistory(element);
+        }
+
+        return restorer;
     }
 }

--- a/tests/Restorer.test.tsx
+++ b/tests/Restorer.test.tsx
@@ -294,4 +294,45 @@ describe("Restorer", () => {
                 document.getElementById("source")?.remove();
             });
     }, 10000);
+
+    it.only("should register already focused target", async () => {
+        const rootAttr = getTabsterAttribute({ root: {} });
+        const targetAttr = getTabsterAttribute({
+            restorer: { type: Types.RestorerTypes.Target },
+        });
+        const sourceAttr = getTabsterAttribute({
+            restorer: { type: Types.RestorerTypes.Source },
+        });
+        await new BroTest.BroTest(
+            (
+                <div {...rootAttr}>
+                    <div id="target-container" {...targetAttr}></div>
+
+                    <button id="source" {...sourceAttr}>
+                        source
+                    </button>
+                </div>
+            )
+        )
+            .eval(
+                (tabsterAttrName, targetAttr) => {
+                    const target = document.createElement("button");
+                    target.textContent = "target";
+                    target.setAttribute(tabsterAttrName, targetAttr);
+                    document
+                        .getElementById("target-container")
+                        ?.appendChild(target);
+                    target.focus();
+                },
+                Types.TabsterAttributeName,
+                targetAttr[Types.TabsterAttributeName] as string
+            )
+            .activeElement((el) => expect(el?.textContent).toEqual("target"))
+            .click("#source")
+            .activeElement((el) => expect(el?.textContent).toEqual("source"))
+            .eval(() => {
+                document.getElementById("source")?.remove();
+            })
+            .activeElement((el) => expect(el?.textContent).toEqual("target"));
+    });
 });


### PR DESCRIPTION
In the cases where the actual restorer is not created yet and the target is focused - it will not be in history. This is because tabster does not exist on the element yet.

Handle this case specifically on creation and add a new target element to history if it is already the active element