### PR TITLE
fix(Restorer): Use correct document for restore focus

### DIFF
--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -118,7 +118,7 @@ export class RestorerAPI implements RestorerAPIType {
     private _restoreFocus = (source: HTMLElement) => {
         // don't restore focus if focus isn't lost to body
         const doc = this._getWindow().document;
-        if (doc.activeElement !== document.body) {
+        if (doc.activeElement !== doc.body) {
             return;
         }
 


### PR DESCRIPTION
Currently the `_restoreFocus` function uses the global document, this is incorrect, it should use the document from tabster's window.