### PR TITLE
fix: use FakeWeakRef when WeakRef is unavailable

### DIFF
--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -18,6 +18,7 @@ import {
     FakeWeakRef,
     TabsterPart,
     TabsterWeakRef,
+    cleanupFakeWeakRefs,
     getInstanceContext,
 } from "./Utils";
 
@@ -79,6 +80,7 @@ export class RestorerAPI implements RestorerAPIType {
         const win = this._getWindow();
         this._focusedElementState.unsubscribe(this._onFocusIn);
         win.removeEventListener(EVENT_NAME, this._onRestoreFocus);
+        cleanupFakeWeakRefs(this._tabster.getWindow);
 
         if (this._restoreFocusTimeout) {
             win.clearTimeout(this._restoreFocusTimeout);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -149,11 +149,11 @@ export function createWeakMap<K extends object, V>(win: Window): WeakMap<K, V> {
     return new (ctx?.basics.WeakMap || WeakMap)();
 }
 
-interface TabsterWeakRef<T> {
+export interface TabsterWeakRef<T> {
     deref(): T | undefined;
 }
 
-class FakeWeakRef<T extends HTMLElement = HTMLElement>
+export class FakeWeakRef<T extends HTMLElement = HTMLElement>
     implements TabsterWeakRef<T>
 {
     private _target: T | undefined;


### PR DESCRIPTION
FakeWeakRef is a useful construct for clients that lack WeakRef support. In particular, there are still many Android devices that don't have WeakRef available. 

This change adds FakeWeakRef fallback to Restorer and Modalizer.