### PR TITLE
fix: Restorer should restore focus when element is removed in Safari & Firefox

### DIFF
--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -42,7 +42,7 @@ class Restorer extends TabsterPart<RestorerProps> implements RestorerInterface {
             element?.removeEventListener("focusout", this._onFocusOut);
             element?.removeEventListener("focusin", this._onFocusIn);
 
-            if (element && this._hasFocus) {
+            if (this._hasFocus) {
                 const doc = this._tabster.getWindow().document;
                 doc.body?.dispatchEvent(
                     new Event(EVENT_NAME, {

--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -62,7 +62,10 @@ class Restorer extends TabsterPart<RestorerProps> implements RestorerInterface {
                 })
             );
         }
-        if (element && !element.contains(e.relatedTarget as HTMLElement | null)) {
+        if (
+            element &&
+            !element.contains(e.relatedTarget as HTMLElement | null)
+        ) {
             this._hasFocus = false;
         }
     };


### PR DESCRIPTION
Fixes #305

Not sure if this is the best approach, but it does fix the root issue. Some of the constraints are:

- `document.activeElement` has already been set to `body` by the time the MutationObserver removedNodes mutation is detected
- Non-Chromium browsers fire literally no events when the focused element is removed from the DOM & `activeElement` is set to `body`
- This could in theory be fixed by firing `.blur()` on the `document.activeElement` _before_ it's removed, if we can figure out any way to do so

Here's a reduced demo of the basic issue in Safari & Firefox: https://jsfiddle.net/5pcf9L64/