### PR TITLE
feat: getParent prop for createTabster

### DIFF
--- a/src/Root.ts
+++ b/src/Root.ts
@@ -399,12 +399,15 @@ export class RootAPI implements Types.RootAPI {
             return undefined;
         }
 
+        const { checkRtl, referenceElement } = options;
+
+        const getParent = tabster.getParent;
+
         // Normally, the initialization starts on the next tick after the tabster
         // instance creation. However, if the application starts using it before
         // the next tick, we need to make sure the initialization is done.
         tabster.drainInitQueue();
 
-        const checkRtl = options.checkRtl;
         let root: Types.Root | undefined;
         let modalizer: Types.Modalizer | undefined;
         let groupper: Types.Groupper | undefined;
@@ -414,7 +417,7 @@ export class RootAPI implements Types.RootAPI {
         let modalizerInGroupper: Types.Groupper | undefined;
         let isRtl: boolean | undefined;
         let uncontrolled: HTMLElement | undefined;
-        let curElement: Node | null = options.referenceElement || element;
+        let curElement: Node | null = referenceElement || element;
         const ignoreKeydown: Types.FocusableProps["ignoreKeydown"] = {};
 
         while (curElement && (!root || checkRtl)) {
@@ -432,7 +435,7 @@ export class RootAPI implements Types.RootAPI {
             }
 
             if (!tabsterOnElement) {
-                curElement = curElement.parentElement;
+                curElement = getParent(curElement);
                 continue;
             }
 
@@ -501,7 +504,7 @@ export class RootAPI implements Types.RootAPI {
                 );
             }
 
-            curElement = curElement.parentElement;
+            curElement = getParent(curElement);
         }
 
         // No root element could be found, try to get an auto root

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -142,7 +142,7 @@ class TabsterCore implements Types.TabsterCore {
      * props can/should be mergeable, so let's add more as we move on.
      * @param props Tabster props
      */
-    mergeProps(props?: Types.TabsterCoreProps) {
+    private _mergeProps(props?: Types.TabsterCoreProps) {
         if (!props) {
             return;
         }
@@ -160,7 +160,7 @@ class TabsterCore implements Types.TabsterCore {
             this._wrappers.add(wrapper);
         }
 
-        this.mergeProps(props);
+        this._mergeProps(props);
 
         return wrapper;
     }

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -87,6 +87,7 @@ class TabsterCore implements Types.TabsterCore {
     observedElement?: Types.ObservedElementAPI;
     crossOrigin?: Types.CrossOriginAPI;
     restorer?: Types.RestorerAPI;
+    getParent: (el: Node) => Node | null;
 
     constructor(win: Window, props?: Types.TabsterCoreProps) {
         this._storage = createWeakMap(win);
@@ -103,6 +104,8 @@ class TabsterCore implements Types.TabsterCore {
         this.rootDummyInputs = !!props?.rootDummyInputs;
 
         this._dummyObserver = new DummyInputObserver(getWindow);
+
+        this.getParent = props?.getParent ?? ((el) => el.parentElement);
 
         this.internal = {
             stopObserver: (): void => {

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -137,12 +137,30 @@ class TabsterCore implements Types.TabsterCore {
         });
     }
 
-    createTabster(noRefCount?: boolean): Types.Tabster {
+    /**
+     * Merges external props with the current props. Not all
+     * props can/should be mergeable, so let's add more as we move on.
+     * @param props Tabster props
+     */
+    mergeProps(props?: Types.TabsterCoreProps) {
+        if (!props) {
+            return;
+        }
+
+        this.getParent = props.getParent ?? this.getParent;
+    }
+
+    createTabster(
+        noRefCount?: boolean,
+        props?: Types.TabsterCoreProps
+    ): Types.Tabster {
         const wrapper = new Tabster(this);
 
         if (!noRefCount) {
             this._wrappers.add(wrapper);
         }
+
+        this.mergeProps(props);
 
         return wrapper;
     }
@@ -303,7 +321,7 @@ export function createTabster(
     let tabster = getCurrentTabster(win as WindowWithTabsterInstance);
 
     if (tabster) {
-        return tabster.createTabster();
+        return tabster.createTabster(false, props);
     }
 
     tabster = new TabsterCore(win, props);

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -36,6 +36,12 @@ export interface TabsterCoreProps {
      * This option allows to enable dummy inputs on Root.
      */
     rootDummyInputs?: boolean;
+
+    /**
+     * Custom getter for parent elements. Defaults to the default .parentElement call
+     * Currently only used to detect tabster contexts
+     */
+    getParent?(el: Node): Node | null;
 }
 
 export type GetTabster = () => TabsterCore;
@@ -1159,6 +1165,8 @@ interface TabsterCoreInternal {
     queueInit(callback: () => void): void;
     /** @internal */
     drainInitQueue(): void;
+    /** @internal */
+    getParent: (el: Node) => Node | null;
 }
 
 export interface Tabster {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1155,7 +1155,7 @@ interface TabsterCoreInternal {
     getWindow: GetWindow;
 
     /** @internal */
-    createTabster(noRefCount?: boolean): Tabster;
+    createTabster(noRefCount?: boolean, props?: TabsterCoreProps): Tabster;
     /** @internal */
     disposeTabster(wrapper: Tabster, allInstances?: boolean): void;
     /** @internal */

--- a/tests/Tabster.test.tsx
+++ b/tests/Tabster.test.tsx
@@ -17,6 +17,69 @@ describe("Tabster dispose", () => {
         await BroTest.bootstrapTabsterPage({});
     });
 
+    it("should set getParent prop on first creation", async () => {
+        const parentId = "parent";
+        await new BroTest.BroTest(<div />)
+            .eval((id) => {
+                // dispose default tabster on the test page
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                window.__tabsterInstance.dispose();
+                const parent = document.createElement("div");
+                parent.id = id;
+                getTabsterTestVariables().createTabster?.(window, {
+                    getParent: () => parent,
+                });
+                // dispose default tabster on the test page
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                return window.__tabsterInstance.getParent().id;
+            }, parentId)
+            .check((id) => {
+                expect(id).toEqual(parentId);
+            });
+    });
+
+    it("should set getParent prop on latest creation", async () => {
+        const first = "first";
+        const second = "second";
+        await new BroTest.BroTest(<div />)
+            .eval((id) => {
+                // dispose default tabster on the test page
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                window.__tabsterInstance.dispose();
+
+                const parent = document.createElement("div");
+                parent.id = id;
+                getTabsterTestVariables().createTabster?.(window, {
+                    getParent: () => parent,
+                });
+                // dispose default tabster on the test page
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                return window.__tabsterInstance.getParent().id;
+            }, first)
+            .check((id) => {
+                expect(id).toEqual(first);
+            })
+            .eval((id) => {
+                const parent = document.createElement("div");
+                parent.id = id;
+                getTabsterTestVariables().createTabster?.(window, {
+                    getParent: () => parent,
+                });
+
+                // dispose default tabster on the test page
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                return window.__tabsterInstance.getParent().id;
+            }, second)
+            .check((id) => {
+                expect(id).toEqual(second);
+            });
+    });
+
     it("should not dispose global tabster core if there are still tabster instances", async () => {
         await new BroTest.BroTest(<div />)
             .eval(() => {

--- a/tests/Tabster.test.tsx
+++ b/tests/Tabster.test.tsx
@@ -37,11 +37,12 @@ describe("Tabster dispose", () => {
                     getParent: () => parent,
                 });
 
-                const tabsterInstance  = (
-                    window as unknown as WindowWithTabster
-                ).__tabsterInstance as unknown as Types.TabsterCore
+                const tabsterInstance = (window as unknown as WindowWithTabster)
+                    .__tabsterInstance as unknown as Types.TabsterCore;
 
-                const parentResult = tabsterInstance.getParent(document.createElement('div')) as HTMLElement | null;
+                const parentResult = tabsterInstance.getParent(
+                    document.createElement("div")
+                ) as HTMLElement | null;
                 return parentResult?.id;
             }, parentId)
             .check((id) => {
@@ -79,11 +80,12 @@ describe("Tabster dispose", () => {
                     getParent: () => parent,
                 });
 
-                const tabsterInstance  = (
-                    window as unknown as WindowWithTabster
-                ).__tabsterInstance as unknown as Types.TabsterCore
+                const tabsterInstance = (window as unknown as WindowWithTabster)
+                    .__tabsterInstance as unknown as Types.TabsterCore;
 
-                const parentResult = tabsterInstance.getParent(document.createElement('div')) as HTMLElement | null;
+                const parentResult = tabsterInstance.getParent(
+                    document.createElement("div")
+                ) as HTMLElement | null;
                 return parentResult?.id;
             }, second)
             .check((id) => {

--- a/tests/Tabster.test.tsx
+++ b/tests/Tabster.test.tsx
@@ -9,7 +9,13 @@ import { WindowWithTabsterInstance } from "../src/Root";
 import * as BroTest from "./utils/BroTest";
 
 interface WindowWithTabster extends Window {
-    __tabsterInstance: unknown;
+    __tabsterInstance?: Types.TabsterCore;
+}
+
+interface NodeWithVirtualParent extends Node {
+    _virtual: {
+        parent?: Node;
+    };
 }
 
 describe("Tabster dispose", () => {
@@ -30,10 +36,13 @@ describe("Tabster dispose", () => {
                 getTabsterTestVariables().createTabster?.(window, {
                     getParent: () => parent,
                 });
-                // dispose default tabster on the test page
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                return window.__tabsterInstance.getParent().id;
+
+                const tabsterInstance  = (
+                    window as unknown as WindowWithTabster
+                ).__tabsterInstance as unknown as Types.TabsterCore
+
+                const parentResult = tabsterInstance.getParent(document.createElement('div')) as HTMLElement | null;
+                return parentResult?.id;
             }, parentId)
             .check((id) => {
                 expect(id).toEqual(parentId);
@@ -70,13 +79,87 @@ describe("Tabster dispose", () => {
                     getParent: () => parent,
                 });
 
-                // dispose default tabster on the test page
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                return window.__tabsterInstance.getParent().id;
+                const tabsterInstance  = (
+                    window as unknown as WindowWithTabster
+                ).__tabsterInstance as unknown as Types.TabsterCore
+
+                const parentResult = tabsterInstance.getParent(document.createElement('div')) as HTMLElement | null;
+                return parentResult?.id;
             }, second)
             .check((id) => {
                 expect(id).toEqual(second);
+            });
+    });
+
+    it("should support virtual parents with getParent", async () => {
+        const parentId = "parent";
+        await new BroTest.BroTest(<div />)
+            .eval((id) => {
+                function isVirtualElement(
+                    element: Node
+                ): element is NodeWithVirtualParent {
+                    // eslint-disable-next-line no-prototype-builtins
+                    return element && element.hasOwnProperty("_virtual");
+                }
+
+                function getVirtualParent(child: Node): Node | null {
+                    return isVirtualElement(child)
+                        ? child._virtual.parent || null
+                        : null;
+                }
+                function setVirtualParent(child: Node, parent?: Node): void {
+                    const virtualChild = child;
+
+                    if (
+                        !(virtualChild as unknown as NodeWithVirtualParent)
+                            ._virtual
+                    ) {
+                        (
+                            virtualChild as unknown as NodeWithVirtualParent
+                        )._virtual = {};
+                    }
+
+                    (
+                        virtualChild as unknown as NodeWithVirtualParent
+                    )._virtual.parent = parent;
+                }
+
+                function getParent(child: Node | null): Node | null {
+                    if (!child) {
+                        return null;
+                    }
+
+                    const virtualParent = getVirtualParent(child);
+
+                    if (virtualParent) {
+                        return virtualParent;
+                    }
+
+                    return null;
+                }
+
+                // dispose default tabster on the test page
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                window.__tabsterInstance.dispose();
+                const child = document.createElement("div");
+                const parent = document.createElement("div");
+                parent.id = id;
+
+                setVirtualParent(child, parent);
+                getTabsterTestVariables().createTabster?.(window, {
+                    getParent,
+                });
+
+                const tabsterInstance = (window as unknown as WindowWithTabster)
+                    .__tabsterInstance as unknown as Types.TabsterCore;
+                const parentResult = tabsterInstance.getParent(
+                    child
+                ) as HTMLElement | null;
+                return parentResult?.id;
+            }, parentId)
+            .check((id) => {
+                expect(id).toEqual(parentId);
             });
     });
 


### PR DESCRIPTION
Adds a new `getParent` prop for `createTabster. This lets users override how to get a parent of a HTMLElement, which is useful for libraries like Fluent UI where the parentElement does not need to follow the DOM order.