### PR TITLE
fix(Mover): Fixing how Mover handles elements with aria-expanded.

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -1211,7 +1211,12 @@ export class MoverAPI implements Types.MoverAPI {
         element: HTMLElement,
         keyCode: number
     ): Promise<boolean> {
-        if (element.getAttribute("aria-expanded") === "true") {
+        if (
+            element.getAttribute("aria-expanded") === "true" &&
+            element.hasAttribute("aria-activedescendant")
+        ) {
+            // It is likely a combobox with expanded options and arrow keys are
+            // controlled by it.
             return true;
         }
 

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -1051,7 +1051,7 @@ describe("Mover with inputs inside", () => {
             });
     });
 
-    it("should not move focus when aria-expanded is true", async () => {
+    it("should not move focus when aria-expanded is true and aria-activedescendant is present", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -1065,6 +1065,7 @@ describe("Mover with inputs inside", () => {
                             type="text"
                             defaultValue="Input"
                             aria-expanded="true"
+                            aria-activedescendant="ololo"
                         />
                         <button>Button2</button>
                     </div>
@@ -1102,6 +1103,56 @@ describe("Mover with inputs inside", () => {
             .pressUp()
             .activeElement((el) => {
                 expect(el?.attributes.value).toEqual("Input");
+            });
+    });
+
+    it("should move focus when aria-expanded is true, but aria-activedescendant is not set", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: {},
+                        })}
+                    >
+                        <button>Button1</button>
+                        <input
+                            type="text"
+                            defaultValue="Input"
+                            aria-expanded="true"
+                        />
+                        <button>Button2</button>
+                    </div>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.attributes.value).toEqual("Input");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.attributes.value).toEqual("Input");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressUp()
+            .activeElement((el) => {
+                expect(el?.attributes.value).toEqual("Input");
+            })
+            .pressUp()
+            .activeElement((el) => {
+                expect(el?.attributes.value).toEqual("Input");
+            })
+            .pressUp()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
             });
     });
 });


### PR DESCRIPTION
We have a case for Mover to ignore handling keypresses when a focused element has `aria-expanded=true` to work around comoboxes inside Mover. This PR narrows the check to not just `aria-expanded` but also `aria-activedescendant`, as just `aria-expanded` could also be used in different scenarios.