### PR TITLE
Add CredScan filter to address false positives

### DIFF
--- a/CredScanSuppressions.json
+++ b/CredScanSuppressions.json
@@ -1,0 +1,13 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "file": ".git/config",
+            "_justification": "Standard token for CI pipeline"
+        },
+        {
+            "file": "node_modules/proxy-agent/test/ssl-cert-snakeoil.key",
+            "_justification": "External dependency proxy-agent, not shipping these files"
+        }
+    ]
+}


### PR DESCRIPTION
As part of the 1ESPT compliance work, the new pipeline compliance steps are discovering that there are secrets. Validated that these are false positives of external dependencies.