### PR TITLE
fix(Mover): Fixing the case when focusable mover container was causing memorization of current element on the wrong mover.

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -745,8 +745,14 @@ export class MoverAPI implements Types.MoverAPI {
     };
 
     private _onFocus = (e: HTMLElement | undefined): void => {
+        // When something in the app gets focused, we are making sure that
+        // the relevant context Mover is aware of it.
+        // Looking for the relevant context Mover from the currently
+        // focused element parent, not from the element itself, because the
+        // mover element itself cannot be its own current (but might be
+        // current for its parent Mover).
         for (
-            let el: HTMLElement | null | undefined = e;
+            let el: HTMLElement | null | undefined = e?.parentElement;
             el;
             el = el.parentElement
         ) {

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -744,23 +744,36 @@ export class MoverAPI implements Types.MoverAPI {
         delete this._movers[mover.id];
     };
 
-    private _onFocus = (e: HTMLElement | undefined): void => {
+    private _onFocus = (element: HTMLElement | undefined): void => {
         // When something in the app gets focused, we are making sure that
         // the relevant context Mover is aware of it.
         // Looking for the relevant context Mover from the currently
         // focused element parent, not from the element itself, because the
-        // mover element itself cannot be its own current (but might be
+        // Mover element itself cannot be its own current (but might be
         // current for its parent Mover).
+        let currentFocusableElement = element;
+        let deepestFocusableElement = element;
+
         for (
-            let el: HTMLElement | null | undefined = e?.parentElement;
+            let el: HTMLElement | null | undefined = element?.parentElement;
             el;
             el = el.parentElement
         ) {
+            // We go through all Movers up from the focused element and
+            // set their current element to the deepest focusable of that
+            // Mover.
             const mover = getTabsterOnElement(this._tabster, el)?.mover;
 
             if (mover) {
-                mover.setCurrent(e);
-                break;
+                mover.setCurrent(deepestFocusableElement);
+                currentFocusableElement = undefined;
+            }
+
+            if (
+                !currentFocusableElement &&
+                this._tabster.focusable.isFocusable(el)
+            ) {
+                currentFocusableElement = deepestFocusableElement = el;
             }
         }
     };

--- a/tests/MoverGroupper.test.tsx
+++ b/tests/MoverGroupper.test.tsx
@@ -1458,7 +1458,7 @@ describe("MoverGroupper", () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
-                    <button>Foo</button>
+                    <button id="foo">Foo</button>
                     <div
                         {...getTabsterAttribute({
                             mover: {
@@ -1516,7 +1516,7 @@ describe("MoverGroupper", () => {
                             })}
                         >
                             <button>Button5</button>
-                            <button>Button6</button>
+                            <button id="button6">Button6</button>
                         </div>
                     </div>
                     <button>Bar</button>
@@ -1574,6 +1574,22 @@ describe("MoverGroupper", () => {
             .pressTab(true)
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button3Button4");
+            })
+            .eval(() => {
+                document.getElementById("button6")?.focus();
+            })
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .eval(() => {
+                document.getElementById("foo")?.focus();
+            })
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Foo");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5Button6");
             });
     });
 });

--- a/tests/MoverGroupper.test.tsx
+++ b/tests/MoverGroupper.test.tsx
@@ -1453,4 +1453,127 @@ describe("MoverGroupper", () => {
                 expect(el?.textContent).toEqual("Button2Button3");
             });
     });
+
+    it("should handle nested movers when the inner mover is on focusable element", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button>Foo</button>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: {
+                                memorizeCurrent: true,
+                                direction: Types.MoverDirections.Vertical,
+                            },
+                        })}
+                    >
+                        <div
+                            tabIndex={0}
+                            {...getTabsterAttribute({
+                                mover: {
+                                    direction: Types.MoverDirections.Horizontal,
+                                    cyclic: true,
+                                },
+                                groupper: {
+                                    tabbability:
+                                        Types.GroupperTabbabilities
+                                            .LimitedTrapFocus,
+                                },
+                            })}
+                        >
+                            <button>Button1</button>
+                            <button>Button2</button>
+                        </div>
+                        <div
+                            tabIndex={0}
+                            {...getTabsterAttribute({
+                                mover: {
+                                    direction: Types.MoverDirections.Horizontal,
+                                    cyclic: true,
+                                },
+                                groupper: {
+                                    tabbability:
+                                        Types.GroupperTabbabilities
+                                            .LimitedTrapFocus,
+                                },
+                            })}
+                        >
+                            <button>Button3</button>
+                            <button>Button4</button>
+                        </div>
+                        <div
+                            tabIndex={0}
+                            {...getTabsterAttribute({
+                                mover: {
+                                    direction: Types.MoverDirections.Horizontal,
+                                    cyclic: true,
+                                },
+                                groupper: {
+                                    tabbability:
+                                        Types.GroupperTabbabilities
+                                            .LimitedTrapFocus,
+                                },
+                            })}
+                        >
+                            <button>Button5</button>
+                            <button>Button6</button>
+                        </div>
+                    </div>
+                    <button>Bar</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Foo");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1Button2");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3Button4");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Bar");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3Button4");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Foo");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3Button4");
+            })
+            .pressEnter()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressRight()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .pressRight()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressEsc()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3Button4");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Bar");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3Button4");
+            });
+    });
 });


### PR DESCRIPTION
In case of nested movers, when the inner mover's container is focusable, the current element was memorized on that inner mover, not on the parent mover. Because of that memorizeCurrent behaviour of the parent mover didn't work properly.

When the movers are nested and something in the inner mover receives focus, the parent movers were not populated with the proper current element.