### PR TITLE
feat(Uncontrolled): completely prop to indicate that uncontrolled area fully controls Tab.

### DIFF
--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -19,7 +19,7 @@ import {
 import { getTabsterOnElement } from "../Instance";
 import { Subscribable } from "./Subscribable";
 
-function getUncontrolledFocusTrapContainer(
+function getUncontrolledCompletelyContainer(
     tabster: Types.TabsterCore,
     element: HTMLElement
 ): HTMLElement | undefined {
@@ -31,10 +31,13 @@ function getUncontrolledFocusTrapContainer(
             tabster,
             el
         )?.uncontrolled;
+
         if (
             uncontrolledOnElement &&
-            (uncontrolledOnElement.completely ||
-                tabster.uncontrolled.isUncontrolledCompletely(el))
+            tabster.uncontrolled.isUncontrolledCompletely(
+                el,
+                !!uncontrolledOnElement.completely
+            )
         ) {
             return el;
         }
@@ -513,8 +516,8 @@ export class FocusedElementState
         );
 
         const nextElement = next?.element;
-        const uncontrolledFocusTrapContainer =
-            getUncontrolledFocusTrapContainer(tabster, currentElement);
+        const uncontrolledCompletelyContainer =
+            getUncontrolledCompletelyContainer(tabster, currentElement);
 
         if (nextElement) {
             const nextUncontrolled = next.uncontrolled;
@@ -526,8 +529,8 @@ export class FocusedElementState
                 if (
                     (!next.outOfDOMOrder &&
                         nextUncontrolled === ctx.uncontrolled) ||
-                    (uncontrolledFocusTrapContainer &&
-                        !uncontrolledFocusTrapContainer.contains(nextElement))
+                    (uncontrolledCompletelyContainer &&
+                        !uncontrolledCompletelyContainer.contains(nextElement))
                 ) {
                     // Nothing to do, everything will be done by the browser or something
                     // that controls the uncontrolled area.
@@ -572,7 +575,7 @@ export class FocusedElementState
                 // Just allow the default action.
             }
         } else {
-            if (!uncontrolledFocusTrapContainer) {
+            if (!uncontrolledCompletelyContainer) {
                 ctx.root.moveOutWithDefaultAction(isBackward);
             }
         }

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -33,8 +33,8 @@ function getUncontrolledFocusTrapContainer(
         )?.uncontrolled;
         if (
             uncontrolledOnElement &&
-            (uncontrolledOnElement.trapsFocus ||
-                tabster.uncontrolled.isTrappingFocus(el))
+            (uncontrolledOnElement.completely ||
+                tabster.uncontrolled.isUncontrolledCompletely(el))
         ) {
             return el;
         }

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -27,9 +27,14 @@ function getUncontrolledFocusTrapContainer(
     let el: HTMLElement | null = element;
 
     do {
+        const uncontrolledOnElement = getTabsterOnElement(
+            tabster,
+            el
+        )?.uncontrolled;
         if (
-            getTabsterOnElement(tabster, el)?.uncontrolled &&
-            tabster.uncontrolled.isTrappingFocus(el)
+            uncontrolledOnElement &&
+            (uncontrolledOnElement.trapsFocus ||
+                tabster.uncontrolled.isTrappingFocus(el))
         ) {
             return el;
         }

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -100,7 +100,9 @@ class TabsterCore implements Types.TabsterCore {
         this.focusable = new FocusableAPI(this);
         this.root = new RootAPI(this, props?.autoRoot);
         this.uncontrolled = new UncontrolledAPI(
-            props?.checkUncontrolledTrappingFocus
+            // TODO: Remove checkUncontrolledTrappingFocus in the next major version.
+            props?.checkUncontrolledCompletely ||
+                props?.checkUncontrolledTrappingFocus
         );
         this.controlTab = props?.controlTab ?? true;
         this.rootDummyInputs = !!props?.rootDummyInputs;

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -100,7 +100,7 @@ class TabsterCore implements Types.TabsterCore {
         this.focusable = new FocusableAPI(this);
         this.root = new RootAPI(this, props?.autoRoot);
         this.uncontrolled = new UncontrolledAPI(
-            props?.checkUncontrolledTrappingFocus
+            props?.checkUncontrolledCompletely
         );
         this.controlTab = props?.controlTab ?? true;
         this.rootDummyInputs = !!props?.rootDummyInputs;

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -100,7 +100,7 @@ class TabsterCore implements Types.TabsterCore {
         this.focusable = new FocusableAPI(this);
         this.root = new RootAPI(this, props?.autoRoot);
         this.uncontrolled = new UncontrolledAPI(
-            props?.checkUncontrolledCompletely
+            props?.checkUncontrolledTrappingFocus
         );
         this.controlTab = props?.controlTab ?? true;
         this.rootDummyInputs = !!props?.rootDummyInputs;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -55,10 +55,14 @@ export interface TabsterCoreProps {
      * non-undefined value, the callback's value will dominate the element's
      * uncontrolled.completely value.
      */
-    checkUncontrolledTrappingFocus?: (
+    checkUncontrolledCompletely?: (
         element: HTMLElement,
         completely: boolean // A uncontrolled.completely value from the element.
     ) => boolean | undefined;
+    /**
+     * @deprecated use checkUncontrolledCompletely.
+     */
+    checkUncontrolledTrappingFocus?: (element: HTMLElement) => boolean;
     /**
      * Custom getter for parent elements. Defaults to the default .parentElement call
      * Currently only used to detect tabster contexts

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -50,8 +50,15 @@ export interface TabsterCoreProps {
      * A callback that will be called for the uncontrolled areas when Tabster wants
      * to know is the uncontrolled element wants complete control (for example it
      * is trapping focus) and Tabster should not interfere with handling Tab.
+     * If the callback returns undefined, then the default behaviour is to return
+     * the uncontrolled.completely value from the element. If the callback returns
+     * non-undefined value, the callback's value will dominate the element's
+     * uncontrolled.completely value.
      */
-    checkUncontrolledCompletely?: (element: HTMLElement) => boolean;
+    checkUncontrolledCompletely?: (
+        element: HTMLElement,
+        completely: boolean // A uncontrolled.completely value from the element.
+    ) => boolean | undefined;
     /**
      * Custom getter for parent elements. Defaults to the default .parentElement call
      * Currently only used to detect tabster contexts
@@ -932,7 +939,10 @@ export interface RootAPI extends Disposable, RootAPIInternal {
 }
 
 export interface UncontrolledAPI {
-    isUncontrolledCompletely(element: HTMLElement): boolean;
+    isUncontrolledCompletely(
+        element: HTMLElement,
+        completely: boolean
+    ): boolean;
 }
 
 interface ModalizerAPIInternal extends TabsterPartWithAcceptElement {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -55,7 +55,7 @@ export interface TabsterCoreProps {
      * non-undefined value, the callback's value will dominate the element's
      * uncontrolled.completely value.
      */
-    checkUncontrolledCompletely?: (
+    checkUncontrolledTrappingFocus?: (
         element: HTMLElement,
         completely: boolean // A uncontrolled.completely value from the element.
     ) => boolean | undefined;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1000,6 +1000,15 @@ export type ModalizerElementAccessibleCheck = (
     activeModalizerElements?: HTMLElement[]
 ) => boolean;
 
+export interface UncontrolledProps {
+    // Indicated that uncontrolled area traps focus, that makes Tabster
+    // to give it full control over the Tab handling. If not set, Tabster
+    // might still handle Tab in the uncontrolled area, when, for example,
+    // there is an inactive Modalizer (that needs to be skipped) after the
+    // last focusable element of the uncontrolled area.
+    trapsFocus?: boolean;
+}
+
 export interface DeloserOnElement {
     deloser: Deloser;
 }
@@ -1029,7 +1038,7 @@ export interface GroupperOnElement {
 }
 
 export interface UncontrolledOnElement {
-    uncontrolled: Record<string, never>;
+    uncontrolled: UncontrolledProps;
 }
 
 export interface ObservedOnElement {
@@ -1051,7 +1060,7 @@ export interface RestorerProps {
 export type TabsterAttributeProps = Partial<{
     deloser: DeloserProps;
     root: RootProps;
-    uncontrolled: UncontrolledOnElement["uncontrolled"];
+    uncontrolled: UncontrolledProps;
     modalizer: ModalizerProps;
     focusable: FocusableProps;
     groupper: GroupperProps;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -47,11 +47,11 @@ export interface TabsterCoreProps {
      */
     rootDummyInputs?: boolean;
     /**
-     * A callback that will be called for the uncontrolled areas with `trapsFocus`
-     * when Tabster wants to know is the element is currently trapping focus and
-     * Tabster should not interfere with handling Tab.
+     * A callback that will be called for the uncontrolled areas when Tabster wants
+     * to know is the uncontrolled element wants complete control (for example it
+     * is trapping focus) and Tabster should not interfere with handling Tab.
      */
-    checkUncontrolledTrappingFocus?: (element: HTMLElement) => boolean;
+    checkUncontrolledCompletely?: (element: HTMLElement) => boolean;
     /**
      * Custom getter for parent elements. Defaults to the default .parentElement call
      * Currently only used to detect tabster contexts
@@ -932,7 +932,7 @@ export interface RootAPI extends Disposable, RootAPIInternal {
 }
 
 export interface UncontrolledAPI {
-    isTrappingFocus(element: HTMLElement): boolean;
+    isUncontrolledCompletely(element: HTMLElement): boolean;
 }
 
 interface ModalizerAPIInternal extends TabsterPartWithAcceptElement {
@@ -1001,12 +1001,22 @@ export type ModalizerElementAccessibleCheck = (
 ) => boolean;
 
 export interface UncontrolledProps {
-    // Indicated that uncontrolled area traps focus, that makes Tabster
-    // to give it full control over the Tab handling. If not set, Tabster
-    // might still handle Tab in the uncontrolled area, when, for example,
-    // there is an inactive Modalizer (that needs to be skipped) after the
-    // last focusable element of the uncontrolled area.
-    trapsFocus?: boolean;
+    // Normally, even uncontrolled areas should not be completely uncontrolled
+    // to be able to interact with the rest of the application properly.
+    // For example, if an uncontrolled area implements something like
+    // roving tabindex, it should be uncontrolled inside the area, but it
+    // still should be able to be an organic part of the application.
+    // However, in some cases, third party component might want to be able
+    // to gain full control of the area, for example, if it implements
+    // some custom trap focus logic.
+    // `completely` indicates that uncontrolled area must gain full control over
+    // Tab handling. If not set, Tabster might still handle Tab in the
+    // uncontrolled area, when, for example, there is an inactive Modalizer
+    // (that needs to be skipped) after the last focusable element of the
+    // uncontrolled area.
+    // WARNING: Use with caution, as it might break the normal keyboard navigation
+    // between the uncontrolled area and the rest of the application.
+    completely?: boolean;
 }
 
 export interface DeloserOnElement {

--- a/src/Uncontrolled.ts
+++ b/src/Uncontrolled.ts
@@ -10,13 +10,32 @@ import * as Types from "./Types";
  * i.e. Tabster will not control focus events within an uncontrolled area
  */
 export class UncontrolledAPI implements Types.UncontrolledAPI {
-    private _isUncontrolledCompletely?: (element: HTMLElement) => boolean;
+    private _isUncontrolledCompletely?: (
+        element: HTMLElement,
+        completely: boolean
+    ) => boolean | undefined;
 
-    constructor(isUncontrolledCompletely?: (element: HTMLElement) => boolean) {
+    constructor(
+        isUncontrolledCompletely?: (
+            element: HTMLElement,
+            completely: boolean
+        ) => boolean | undefined
+    ) {
         this._isUncontrolledCompletely = isUncontrolledCompletely;
     }
 
-    isUncontrolledCompletely(element: HTMLElement): boolean {
-        return !!this._isUncontrolledCompletely?.(element);
+    isUncontrolledCompletely(
+        element: HTMLElement,
+        completely: boolean
+    ): boolean {
+        const isUncontrolledCompletely = this._isUncontrolledCompletely?.(
+            element,
+            completely
+        );
+        // If isUncontrolledCompletely callback is not defined or returns undefined, then the default
+        // behaviour is to return the uncontrolled.completely value from the element.
+        return isUncontrolledCompletely === undefined
+            ? completely
+            : isUncontrolledCompletely;
     }
 }

--- a/src/Uncontrolled.ts
+++ b/src/Uncontrolled.ts
@@ -10,13 +10,13 @@ import * as Types from "./Types";
  * i.e. Tabster will not control focus events within an uncontrolled area
  */
 export class UncontrolledAPI implements Types.UncontrolledAPI {
-    private _isTrappingFocus?: (element: HTMLElement) => boolean;
+    private _isUncontrolledCompletely?: (element: HTMLElement) => boolean;
 
-    constructor(isTrappingFocus?: (element: HTMLElement) => boolean) {
-        this._isTrappingFocus = isTrappingFocus;
+    constructor(isUncontrolledCompletely?: (element: HTMLElement) => boolean) {
+        this._isUncontrolledCompletely = isUncontrolledCompletely;
     }
 
-    isTrappingFocus(element: HTMLElement): boolean {
-        return !!this._isTrappingFocus?.(element);
+    isUncontrolledCompletely(element: HTMLElement): boolean {
+        return !!this._isUncontrolledCompletely?.(element);
     }
 }

--- a/tests/Uncontrolled.test.tsx
+++ b/tests/Uncontrolled.test.tsx
@@ -1091,4 +1091,194 @@ describe("Uncontrolled with 3rd party focus trap", () => {
                 expect(el?.textContent).toEqual("Button6");
             });
     });
+
+    it("should coexist with custom focus trap implementation, using checkUncontrolledCompletely() callback and completely property defaulting to the property when the callback returns undefined", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button id="button-1">Button1</button>
+                    <div
+                        id="trap1"
+                        {...getTabsterAttribute({ uncontrolled: {} })}
+                    >
+                        <button>Button2</button>
+                        <button>Button3</button>
+                    </div>
+                    <button id="button-4">Button4</button>
+                    <div
+                        id="trap2"
+                        {...getTabsterAttribute({
+                            uncontrolled: { completely: true },
+                        })}
+                    >
+                        <button>Button5</button>
+                        <button>Button6</button>
+                    </div>
+                    <button id="button-7">Button7</button>
+                    <div
+                        id="trap3"
+                        {...getTabsterAttribute({
+                            uncontrolled: { completely: false },
+                        })}
+                    >
+                        <button>Button8</button>
+                        <button>Button9</button>
+                    </div>
+                    <button id="button-10">Button10</button>
+                    <div
+                        id="no-trap4"
+                        {...getTabsterAttribute({
+                            uncontrolled: { completely: true },
+                        })}
+                    >
+                        <button>Button11</button>
+                        <button>Button12</button>
+                    </div>
+                    <button id="button-13">Button13</button>
+                </div>
+            )
+        )
+            .eval(() => {
+                getTabsterTestVariables().createTabster?.(window, {
+                    checkUncontrolledCompletely: (e) => {
+                        switch (true) {
+                            case e.id === "trap1":
+                                return true;
+                            case e.id === "trap2":
+                                return undefined;
+                            case e.id === "trap3":
+                                return true;
+                            case e.id === "no-trap4":
+                                return false;
+                            default:
+                                return undefined;
+                        }
+                    },
+                });
+
+                const trapFocus = (parentId: string) => {
+                    const parent = document.getElementById(parentId);
+
+                    if (parent) {
+                        parent.addEventListener("keydown", (e) => {
+                            if (e.key === "Tab") {
+                                const buttons = parent.querySelectorAll(
+                                    "button, *[tabindex]"
+                                ) as NodeListOf<HTMLElement>;
+                                const index = Array.prototype.indexOf.call(
+                                    buttons,
+                                    document.activeElement
+                                );
+
+                                if (index >= 0) {
+                                    if (index === 0 && e.shiftKey) {
+                                        e.preventDefault();
+                                        buttons[buttons.length - 1].focus();
+                                    } else if (
+                                        index === buttons.length - 1 &&
+                                        !e.shiftKey
+                                    ) {
+                                        e.preventDefault();
+                                        buttons[0].focus();
+                                    }
+                                }
+                            }
+                        });
+                    }
+                };
+
+                trapFocus("trap1");
+                trapFocus("trap2");
+                trapFocus("trap3");
+                trapFocus("no-trap4");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .focusElement("#button-4")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .focusElement("#button-7")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button7");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button8");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button9");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button8");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button9");
+            })
+            .focusElement("#button-10")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button10");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button11");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button12");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button13");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button12");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button11");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button10");
+            });
+    });
 });

--- a/tests/Uncontrolled.test.tsx
+++ b/tests/Uncontrolled.test.tsx
@@ -881,7 +881,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
         await BroTest.bootstrapTabsterPage();
     });
 
-    it("should coexist with custom focus trap implementation, using checkUncontrolledTrappingFocus() callback", async () => {
+    it("should coexist with custom focus trap implementation, using checkUncontrolledCompletely() callback", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -906,7 +906,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
         )
             .eval(() => {
                 getTabsterTestVariables().createTabster?.(window, {
-                    checkUncontrolledTrappingFocus: (e) =>
+                    checkUncontrolledCompletely: (e) =>
                         e.id === "trap1" || e.id === "trap2",
                 });
 
@@ -986,7 +986,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
             });
     });
 
-    it("should coexist with custom focus trap implementation, using trapsFocus property", async () => {
+    it("should coexist with custom focus trap implementation, using completely property", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -994,7 +994,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
                     <div
                         id="trap1"
                         {...getTabsterAttribute({
-                            uncontrolled: { trapsFocus: true },
+                            uncontrolled: { completely: true },
                         })}
                     >
                         <button>Button2</button>
@@ -1004,7 +1004,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
                     <div
                         id="trap2"
                         {...getTabsterAttribute({
-                            uncontrolled: { trapsFocus: true },
+                            uncontrolled: { completely: true },
                         })}
                     >
                         <button>Button5</button>

--- a/tests/Uncontrolled.test.tsx
+++ b/tests/Uncontrolled.test.tsx
@@ -881,7 +881,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
         await BroTest.bootstrapTabsterPage();
     });
 
-    it("should coexist with custom focus trap implementation, using checkUncontrolledTrappingFocus() callback", async () => {
+    it("should coexist with custom focus trap implementation, using checkUncontrolledCompletely() callback", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -906,7 +906,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
         )
             .eval(() => {
                 getTabsterTestVariables().createTabster?.(window, {
-                    checkUncontrolledTrappingFocus: (e) =>
+                    checkUncontrolledCompletely: (e) =>
                         e.id === "trap1" || e.id === "trap2",
                 });
 
@@ -1092,7 +1092,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
             });
     });
 
-    it("should coexist with custom focus trap implementation, using checkUncontrolledTrappingFocus() callback and completely property defaulting to the property when the callback returns undefined", async () => {
+    it("should coexist with custom focus trap implementation, using checkUncontrolledCompletely() callback and completely property defaulting to the property when the callback returns undefined", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -1140,7 +1140,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
         )
             .eval(() => {
                 getTabsterTestVariables().createTabster?.(window, {
-                    checkUncontrolledTrappingFocus: (e) => {
+                    checkUncontrolledCompletely: (e) => {
                         switch (true) {
                             case e.id === "trap1":
                                 return true;

--- a/tests/Uncontrolled.test.tsx
+++ b/tests/Uncontrolled.test.tsx
@@ -881,7 +881,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
         await BroTest.bootstrapTabsterPage();
     });
 
-    it("should coexist with custom focus trap implementation, using checkUncontrolledCompletely() callback", async () => {
+    it("should coexist with custom focus trap implementation, using checkUncontrolledTrappingFocus() callback", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -906,7 +906,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
         )
             .eval(() => {
                 getTabsterTestVariables().createTabster?.(window, {
-                    checkUncontrolledCompletely: (e) =>
+                    checkUncontrolledTrappingFocus: (e) =>
                         e.id === "trap1" || e.id === "trap2",
                 });
 
@@ -1092,7 +1092,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
             });
     });
 
-    it("should coexist with custom focus trap implementation, using checkUncontrolledCompletely() callback and completely property defaulting to the property when the callback returns undefined", async () => {
+    it("should coexist with custom focus trap implementation, using checkUncontrolledTrappingFocus() callback and completely property defaulting to the property when the callback returns undefined", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -1140,7 +1140,7 @@ describe("Uncontrolled with 3rd party focus trap", () => {
         )
             .eval(() => {
                 getTabsterTestVariables().createTabster?.(window, {
-                    checkUncontrolledCompletely: (e) => {
+                    checkUncontrolledTrappingFocus: (e) => {
                         switch (true) {
                             case e.id === "trap1":
                                 return true;


### PR DESCRIPTION
Currently we have `checkUncontrolledTrappingFocus` callback in `createTabster()` to provide the flag that an uncontrolled area is trapping focus. Adding `completely` property to uncontrolled props on DOM element to be able to set this indicator right on the particular DOM elements. Also deprecating `checkUncontrolledTrappingFocus` and adding `checkUncontrolledCompletely` for the sake of consistency and better coexistence.