### PR TITLE
feat: Adding tabster:movefocus DOM event which is triggered every time Tabster wants to move focus.

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -18,6 +18,7 @@ import {
     TabsterPart,
     WeakHTMLElement,
     getAdjacentElement,
+    triggerMoveFocusEvent,
 } from "./Utils";
 
 class GroupperDummyManager extends DummyInputManager {
@@ -646,7 +647,16 @@ export class GroupperAPI implements Types.GroupperAPI {
                 }
             }
 
-            if (next) {
+            if (
+                next &&
+                groupperElement &&
+                triggerMoveFocusEvent({
+                    by: "groupper",
+                    owner: groupperElement,
+                    next,
+                    relatedEvent: event,
+                })
+            ) {
                 event.preventDefault();
                 event.stopImmediatePropagation();
 

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -22,6 +22,7 @@ import {
     scrollIntoView,
     TabsterPart,
     triggerEvent,
+    triggerMoveFocusEvent,
     WeakHTMLElement,
 } from "./Utils";
 
@@ -873,6 +874,7 @@ export class MoverAPI implements Types.MoverAPI {
         const isCyclic = moverProps.cyclic;
 
         let next: HTMLElement | null | undefined;
+        let scrollIntoViewArg: boolean | undefined;
 
         let focusedElementRect: DOMRect;
         let focusedElementX1 = 0;
@@ -1060,9 +1062,7 @@ export class MoverAPI implements Types.MoverAPI {
                 });
             }
 
-            if (next) {
-                scrollIntoView(this._win, next, false);
-            }
+            scrollIntoViewArg = false;
         } else if (keyCode === Keys.PageDown) {
             focusable.findElement({
                 currentElement: focused,
@@ -1118,9 +1118,7 @@ export class MoverAPI implements Types.MoverAPI {
                 });
             }
 
-            if (next) {
-                scrollIntoView(this._win, next, true);
-            }
+            scrollIntoViewArg = true;
         } else if (isGrid) {
             const isBackward = keyCode === Keys.Up;
             const ax1 = focusedElementX1;
@@ -1203,7 +1201,19 @@ export class MoverAPI implements Types.MoverAPI {
             next = targetElement;
         }
 
-        if (next) {
+        if (
+            next &&
+            triggerMoveFocusEvent({
+                by: "mover",
+                owner: container,
+                next,
+                relatedEvent: event,
+            })
+        ) {
+            if (scrollIntoViewArg !== undefined) {
+                scrollIntoView(this._win, next, scrollIntoViewArg);
+            }
+
             event.preventDefault();
             event.stopImmediatePropagation();
 

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -166,11 +166,11 @@ export class Root
         this._remove();
     }
 
-    moveOutWithDefaultAction(isBackward: boolean) {
+    moveOutWithDefaultAction(isBackward: boolean, relatedEvent: KeyboardEvent) {
         const dummyManager = this._dummyManager;
 
         if (dummyManager) {
-            dummyManager.moveOutWithDefaultAction(isBackward);
+            dummyManager.moveOutWithDefaultAction(isBackward, relatedEvent);
         } else {
             const el = this.getElement();
 
@@ -179,7 +179,8 @@ export class Root
                     this._tabster,
                     el,
                     true,
-                    isBackward
+                    isBackward,
+                    relatedEvent
                 );
             }
         }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -16,6 +16,11 @@ export const MoverEventName = "tabster:mover";
 export const FocusInEventName = "tabster:focusin";
 export const FocusOutEventName = "tabster:focusout";
 
+// Event to be triggered when Tabster wants to move focus as the result of
+// keyboard event. This allows to preventDefault() if you want to have
+// some custom logic.
+export const MoveFocusEventName = "tabster:movefocus";
+
 export const FocusableSelector = [
     "a[href]",
     "button:not([disabled])",
@@ -29,6 +34,16 @@ export const FocusableSelector = [
 export interface TabsterEventWithDetails<D> extends Event {
     details: D;
 }
+
+export interface TabsterMoveFocusEventDetails {
+    by: "mover" | "groupper" | "modalizer" | "root";
+    owner: HTMLElement; // Mover, Groupper, Modalizer or Root, the initiator.
+    next: HTMLElement | null; // Next element to focus or null if Tabster wants to go outside of Root (i.e. to the address bar of the browser).
+    relatedEvent: KeyboardEvent; // The original keyboard event that triggered the move.
+}
+
+export type TabsterMoveFocusEvent =
+    TabsterEventWithDetails<TabsterMoveFocusEventDetails>;
 
 export interface TabsterDOMAttribute {
     [TabsterAttributeName]: string | undefined;
@@ -594,7 +609,10 @@ export interface FocusableAPI extends Disposable {
 
 export interface DummyInputManager {
     moveOut: (backwards: boolean) => void;
-    moveOutWithDefaultAction: (backwards: boolean) => void;
+    moveOutWithDefaultAction: (
+        backwards: boolean,
+        relatedEvent: KeyboardEvent
+    ) => void;
 }
 
 export interface Visibilities {
@@ -846,7 +864,10 @@ export interface Root extends TabsterPart<RootProps> {
 
     readonly uid: string;
     dispose(): void;
-    moveOutWithDefaultAction(backwards: boolean): void;
+    moveOutWithDefaultAction(
+        backwards: boolean,
+        relatedEvent: KeyboardEvent
+    ): void;
 }
 
 export type RootConstructor = (

--- a/tests/DummyInputManager.test.tsx
+++ b/tests/DummyInputManager.test.tsx
@@ -668,31 +668,22 @@ describeIfUncontrolled("DummyInputManager", () => {
 
                 const tabster = getTabsterTestVariables().core?.core;
 
-                if (tabster && rootElement) {
-                    // Calling an internal API to force the dummy inputs update.
-                    const root = (
-                        tabster.root.constructor as unknown as {
-                            getRoot: (
-                                tabster: Types.TabsterCore,
-                                element: HTMLElement
-                            ) => Types.Root | undefined;
+                return new Promise((resolve) => {
+                    // Waiting for the dummy inputs to update.
+                    setTimeout(() => {
+                        if (tabster && rootElement) {
+                            isDummyLast.push(
+                                rootElement?.lastElementChild
+                                    ? rootElement.lastElementChild.hasAttribute(
+                                          dummyAttribute
+                                      )
+                                    : null
+                            );
                         }
-                    ).getRoot(tabster, rootElement);
 
-                    root?.moveOutWithDefaultAction(false);
-
-                    // After the internal API call above, the dummy input should be
-                    // forced to become the last element again.
-                    isDummyLast.push(
-                        rootElement?.lastElementChild
-                            ? rootElement.lastElementChild.hasAttribute(
-                                  dummyAttribute
-                              )
-                            : null
-                    );
-                }
-
-                return isDummyLast;
+                        resolve(isDummyLast);
+                    }, 200);
+                });
             }, Types.TabsterDummyInputAttributeName)
             .check((isDummyLast: (boolean | null)[]) => {
                 expect(isDummyLast).toEqual([false, true]);

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -2709,3 +2709,59 @@ describe("Mover with default element", () => {
             });
     });
 });
+
+describe("Mover with tabster:movefocus event handling", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({ mover: true });
+    });
+
+    it("should allow to custom handle the focus movement", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button id="button-1">Button1</button>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: {},
+                        })}
+                    >
+                        <button>Button2</button>
+                        <button>Button3</button>
+                        <button>Button4</button>
+                        <button>Button5</button>
+                    </div>
+                    <button id="button-6">Button6</button>
+                </div>
+            )
+        )
+            .eval(() => {
+                document.addEventListener(
+                    "tabster:movefocus",
+                    (e: Types.TabsterMoveFocusEvent) => {
+                        if (document.activeElement?.textContent === "Button3") {
+                            e.preventDefault();
+                            e.details.relatedEvent.preventDefault();
+                            document.getElementById("button-6")?.focus();
+                        }
+
+                        if (document.activeElement?.textContent === "Button4") {
+                            e.preventDefault();
+                            e.details.relatedEvent.preventDefault();
+                            document.getElementById("button-1")?.focus();
+                        }
+                    }
+                );
+            })
+            .pressTab()
+            .pressTab()
+            .pressDown()
+            .activeElement((el) => expect(el?.textContent).toEqual("Button3"))
+            .pressDown()
+            .activeElement((el) => expect(el?.textContent).toEqual("Button6"))
+            .pressTab(true)
+            .pressUp()
+            .activeElement((el) => expect(el?.textContent).toEqual("Button4"))
+            .press("PageDown")
+            .activeElement((el) => expect(el?.textContent).toEqual("Button1"));
+    });
+});


### PR DESCRIPTION
Adding `tabster:movefocus`. Whenever Tabster wants to move focus as the result of a keydown, this event will be triggered. The application can do `event.preventDefault()` to prevent Tabster from what it is going to perform.