### PR TITLE
fix: Restorer works in Firefox and Safari when initial focus is set

### DIFF
--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -33,6 +33,9 @@ class Restorer extends TabsterPart<RestorerProps> implements RestorerInterface {
             const element = this._element?.get();
             element?.addEventListener("focusout", this._onFocusOut);
             element?.addEventListener("focusin", this._onFocusIn);
+
+            // set hasFocus when the instance is created, in case focus has already moved within it
+            this._hasFocus = !!element?.contains(element.ownerDocument.activeElement);
         }
     }
 

--- a/stories/Restorer/Restorer.stories.ts
+++ b/stories/Restorer/Restorer.stories.ts
@@ -30,11 +30,11 @@ export const RestorerBasicExample: Story = () => {
     source.setAttribute(TabsterTypes.TabsterAttributeName, sourceAttr);
     source.classList.add("source");
     source.innerHTML = `
-        <button>Foo</button>
-        <button>Foo</button>
-        <button>Foo</button>
-        <button>Foo</button>
         <button id="unmount">unmount</button>
+        <button>Foo</button>
+        <button>Foo</button>
+        <button>Foo</button>
+        <button>Foo</button>
     `;
 
     const target = document.createElement("button");
@@ -42,6 +42,8 @@ export const RestorerBasicExample: Story = () => {
     target.setAttribute(TabsterTypes.TabsterAttributeName, targetAttr);
     target.addEventListener("click", () => {
         example.append(source);
+        const initialFocus = source.querySelector("#unmount") as HTMLButtonElement;
+        initialFocus?.focus();
         document.getElementById("unmount")?.addEventListener("click", () => {
             source.remove();
         });
@@ -72,11 +74,11 @@ export const UseTargetHistory: Story = () => {
     source.setAttribute(TabsterTypes.TabsterAttributeName, sourceAttr);
     source.classList.add("source");
     source.innerHTML = `
-        <button>Foo</button>
-        <button>Foo</button>
-        <button>Foo</button>
-        <button>Foo</button>
         <button id="unmount">unmount</button>
+        <button>Foo</button>
+        <button>Foo</button>
+        <button>Foo</button>
+        <button>Foo</button>
     `;
 
     const target = document.createElement("button");
@@ -84,6 +86,8 @@ export const UseTargetHistory: Story = () => {
     target.setAttribute(TabsterTypes.TabsterAttributeName, targetAttr);
     target.addEventListener("click", () => {
         example.append(source);
+        const initialFocus = source.querySelector("#unmount") as HTMLButtonElement;
+        initialFocus?.focus();
         document.getElementById("unmount")?.addEventListener("click", () => {
             source.remove();
         });


### PR DESCRIPTION
Related to #306
Fixes [ADO bug](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18420)

The initial solution works when the `focusin` event is fired within the target container element, but fails when it is removed after being opened but without moving focus (e.g. open a dialog, then immediately close it).

This fixes that bug by setting `this._hasFocus` when the restorer instance is created.

I also updated the restorer stories so that focus moves to the created restorer container to more accurately simulate a popup.