### PR TITLE
fix(Groupper,Modalizer): Fixing async Esc handling when Groupper is combibed with Modalizer.

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -600,7 +600,7 @@ export class GroupperAPI implements Types.GroupperAPI {
     handleKeyPress(
         element: HTMLElement,
         event: KeyboardEvent,
-        noGoUp?: boolean
+        fromModalizer?: boolean
     ): void {
         const tabster = this._tabster;
         const ctx = RootAPI.getTabsterContext(tabster, element);
@@ -667,7 +667,10 @@ export class GroupperAPI implements Types.GroupperAPI {
 
                     if (
                         focusedElement !==
-                        tabster.focusedElement.getFocusedElement()
+                            tabster.focusedElement.getFocusedElement() &&
+                        // A part of Modalizer that has called this handler to escape the active groupper
+                        // might have been removed from DOM, if the focus is on body, we still want to handle Esc.
+                        ((fromModalizer && !focusedElement) || !fromModalizer)
                     ) {
                         // Something else in the application has moved focus, we will not handle Esc.
                         return;
@@ -678,7 +681,7 @@ export class GroupperAPI implements Types.GroupperAPI {
                         groupperElement &&
                         groupperElement.contains(element)
                     ) {
-                        if (element !== groupperElement || noGoUp) {
+                        if (element !== groupperElement || fromModalizer) {
                             next = groupper.getFirst(true);
                         } else {
                             const parentElement = groupperElement.parentElement;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -793,7 +793,7 @@ export interface GroupperAPIInternal {
     handleKeyPress(
         element: HTMLElement,
         event: KeyboardEvent,
-        noGoUp?: boolean
+        fromModalizer?: boolean
     ): void;
 }
 

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -1681,6 +1681,91 @@ describe("Modalizer with multiple containers", () => {
             .pressTab(true)
             .activeElement((el) => expect(el?.textContent).toEqual("Button2"));
     });
+
+    it("should not lose focus when escape is pressed on the modalizer combined with groupper and a part of modalizer goes away", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: {
+                                direction: Types.MoverDirections.Vertical,
+                            },
+                        })}
+                    >
+                        <button>Button1</button>
+                        <div
+                            tabIndex={0}
+                            {...getTabsterAttribute({
+                                modalizer: {
+                                    id: "modal",
+                                    isAlwaysAccessible: true,
+                                    isOthersAccessible: true,
+                                    isTrapped: true,
+                                },
+                                groupper: {
+                                    tabbability:
+                                        Types.GroupperTabbabilities
+                                            .LimitedTrapFocus,
+                                },
+                            })}
+                        >
+                            <button>ModalButton1</button>
+                            <button>ModalButton2</button>
+                        </div>
+                        <button>Button2</button>
+                    </div>
+                    <div
+                        tabIndex={0}
+                        id="remove-me-on-esc"
+                        {...getTabsterAttribute({
+                            modalizer: {
+                                id: "modal",
+                                isAlwaysAccessible: false,
+                                isOthersAccessible: false,
+                                isTrapped: true,
+                            },
+                        })}
+                    >
+                        <button>ModalButton3</button>
+                        <button>ModalButton4</button>
+                    </div>
+                </div>
+            )
+        )
+            .eval(() => {
+                document
+                    .getElementById("remove-me-on-esc")
+                    ?.addEventListener("keydown", (e) => {
+                        if (e.keyCode === 27) {
+                            document
+                                .getElementById("remove-me-on-esc")
+                                ?.remove();
+                        }
+                    });
+            })
+            .pressTab()
+            .pressDown()
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("ModalButton1ModalButton2")
+            )
+            .pressEnter()
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("ModalButton1")
+            )
+            .pressTab()
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("ModalButton2")
+            )
+            .pressTab()
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("ModalButton3")
+            )
+            .pressEsc()
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("ModalButton1ModalButton2")
+            );
+    });
 });
 
 describe("Modalizer events", () => {


### PR DESCRIPTION
When a Modalizer is combined with Groupper and Esc is pressed, we do standard Groupper behaviour of deactivating the Groupper and going to its container. This PR fixes lost focus when the Modalizer is multipart and one part of it is removed on Esc.