### PR TITLE
Move focus APIs and custom events to move focus.

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -727,12 +727,13 @@ export class GroupperAPI implements Types.GroupperAPI {
         return null;
     }
 
-    enterGroupper(element: HTMLElement): HTMLElement | null {
-        return this._enterGroupper(element);
-    }
-
-    escapeGroupper(element: HTMLElement): HTMLElement | null {
-        return this._escapeGroupper(element);
+    moveFocus(
+        element: HTMLElement,
+        action: Types.GroupperMoveFocusAction
+    ): HTMLElement | null {
+        return action === Types.GroupperMoveFocusActions.Enter
+            ? this._enterGroupper(element)
+            : this._escapeGroupper(element);
     }
 
     handleKeyPress(

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -433,6 +433,10 @@ export class GroupperAPI implements Types.GroupperAPI {
 
         win.document.addEventListener("mousedown", this._onMouseDown, true);
         win.addEventListener("keydown", this._onKeyDown, true);
+        win.addEventListener(
+            Types.GroupperMoveFocusEventName,
+            this._onMoveFocus
+        );
     };
 
     dispose(): void {
@@ -454,6 +458,10 @@ export class GroupperAPI implements Types.GroupperAPI {
 
         win.document.removeEventListener("mousedown", this._onMouseDown, true);
         win.removeEventListener("keydown", this._onKeyDown, true);
+        win.removeEventListener(
+            Types.GroupperMoveFocusEventName,
+            this._onMoveFocus
+        );
 
         Object.keys(this._grouppers).forEach((groupperId) => {
             if (this._grouppers[groupperId]) {
@@ -594,6 +602,21 @@ export class GroupperAPI implements Types.GroupperAPI {
 
         if (element) {
             this.handleKeyPress(element, event);
+        }
+    };
+
+    private _onMoveFocus = (e: Types.GroupperMoveFocusEvent): void => {
+        const element = e.target as HTMLElement | null | undefined;
+        const enter = e.detail?.enter;
+
+        if (element && enter !== undefined && !e.defaultPrevented) {
+            if (enter) {
+                this._enterGroupper(element);
+            } else {
+                this._escapeGroupper(element);
+            }
+
+            e.stopImmediatePropagation();
         }
     };
 

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -18,7 +18,7 @@ import {
     TabsterPart,
     WeakHTMLElement,
     getAdjacentElement,
-    triggerMoveFocusEvent,
+    dispatchMoveFocusEvent,
 } from "./Utils";
 
 class GroupperDummyManager extends DummyInputManager {
@@ -607,10 +607,10 @@ export class GroupperAPI implements Types.GroupperAPI {
 
     private _onMoveFocus = (e: Types.GroupperMoveFocusEvent): void => {
         const element = e.target as HTMLElement | null | undefined;
-        const enter = e.detail?.enter;
+        const action = e.detail?.action;
 
-        if (element && enter !== undefined && !e.defaultPrevented) {
-            if (enter) {
+        if (element && action !== undefined && !e.defaultPrevented) {
+            if (action === Types.GroupperMoveFocusActions.Enter) {
                 this._enterGroupper(element);
             } else {
                 this._escapeGroupper(element);
@@ -646,7 +646,7 @@ export class GroupperAPI implements Types.GroupperAPI {
                 next &&
                 (!relatedEvent ||
                     (relatedEvent &&
-                        triggerMoveFocusEvent({
+                        dispatchMoveFocusEvent({
                             by: "groupper",
                             owner: groupperElement,
                             next,
@@ -701,7 +701,7 @@ export class GroupperAPI implements Types.GroupperAPI {
                 next &&
                 (!relatedEvent ||
                     (relatedEvent &&
-                        triggerMoveFocusEvent({
+                        dispatchMoveFocusEvent({
                             by: "groupper",
                             owner: groupperElement,
                             next,

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -22,7 +22,7 @@ import {
     scrollIntoView,
     TabsterPart,
     triggerEvent,
-    triggerMoveFocusEvent,
+    dispatchMoveFocusEvent,
     WeakHTMLElement,
 } from "./Utils";
 
@@ -1186,7 +1186,7 @@ export class MoverAPI implements Types.MoverAPI {
             next &&
             (!relatedEvent ||
                 (relatedEvent &&
-                    triggerMoveFocusEvent({
+                    dispatchMoveFocusEvent({
                         by: "mover",
                         owner: container,
                         next,

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -779,44 +779,20 @@ export class MoverAPI implements Types.MoverAPI {
         }
     };
 
-    private _onKeyDown = async (event: KeyboardEvent): Promise<void> => {
-        if (this._ignoredInputTimer) {
-            this._win().clearTimeout(this._ignoredInputTimer);
-            delete this._ignoredInputTimer;
-        }
+    moveFocus(
+        fromElement: HTMLElement,
+        key: Types.MoverKey
+    ): HTMLElement | null {
+        return this._moveFocus(fromElement, key);
+    }
 
-        this._ignoredInputResolve?.(false);
-
-        let keyCode = event.keyCode;
-
-        // Give a chance to other listeners to handle the event (for example,
-        // to scroll instead of moving focus).
-        if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) {
-            return;
-        }
-
-        switch (keyCode) {
-            case Keys.Down:
-            case Keys.Right:
-            case Keys.Up:
-            case Keys.Left:
-            case Keys.PageDown:
-            case Keys.PageUp:
-            case Keys.Home:
-            case Keys.End:
-                break;
-            default:
-                return;
-        }
-
+    private _moveFocus(
+        fromElement: HTMLElement,
+        key: Types.MoverKey,
+        relatedEvent?: KeyboardEvent
+    ): HTMLElement | null {
         const tabster = this._tabster;
-        const focused = tabster.focusedElement.getFocusedElement();
-
-        if (!focused || (await this._isIgnoredInput(focused, keyCode))) {
-            return;
-        }
-
-        const ctx = RootAPI.getTabsterContext(tabster, focused, {
+        const ctx = RootAPI.getTabsterContext(tabster, fromElement, {
             checkRtl: true,
         });
 
@@ -824,9 +800,9 @@ export class MoverAPI implements Types.MoverAPI {
             !ctx ||
             !ctx.mover ||
             ctx.excludedFromMover ||
-            ctx.ignoreKeydown(event)
+            (relatedEvent && ctx.ignoreKeydown(relatedEvent))
         ) {
-            return;
+            return null;
         }
 
         const mover = ctx.mover;
@@ -849,16 +825,16 @@ export class MoverAPI implements Types.MoverAPI {
                             true
                         )
                     ) {
-                        return;
+                        return null;
                     }
                 }
             } else {
-                return;
+                return null;
             }
         }
 
         if (!container) {
-            return;
+            return null;
         }
 
         const focusable = tabster.focusable;
@@ -881,25 +857,25 @@ export class MoverAPI implements Types.MoverAPI {
         let focusedElementX2 = 0;
 
         if (isGrid) {
-            focusedElementRect = focused.getBoundingClientRect();
+            focusedElementRect = fromElement.getBoundingClientRect();
             focusedElementX1 = Math.ceil(focusedElementRect.left);
             focusedElementX2 = Math.floor(focusedElementRect.right);
         }
 
         if (ctx.rtl) {
-            if (keyCode === Keys.Right) {
-                keyCode = Keys.Left;
-            } else if (keyCode === Keys.Left) {
-                keyCode = Keys.Right;
+            if (key === Types.MoverKeys.ArrowRight) {
+                key = Types.MoverKeys.ArrowLeft;
+            } else if (key === Types.MoverKeys.ArrowLeft) {
+                key = Types.MoverKeys.ArrowRight;
             }
         }
 
         if (
-            (keyCode === Keys.Down && isVertical) ||
-            (keyCode === Keys.Right && (isHorizontal || isGrid))
+            (key === Types.MoverKeys.ArrowDown && isVertical) ||
+            (key === Types.MoverKeys.ArrowRight && (isHorizontal || isGrid))
         ) {
             next = focusable.findNext({
-                currentElement: focused,
+                currentElement: fromElement,
                 container,
                 useActiveModalizer: true,
             });
@@ -919,11 +895,11 @@ export class MoverAPI implements Types.MoverAPI {
                 });
             }
         } else if (
-            (keyCode === Keys.Up && isVertical) ||
-            (keyCode === Keys.Left && (isHorizontal || isGrid))
+            (key === Types.MoverKeys.ArrowUp && isVertical) ||
+            (key === Types.MoverKeys.ArrowLeft && (isHorizontal || isGrid))
         ) {
             next = focusable.findPrev({
-                currentElement: focused,
+                currentElement: fromElement,
                 container,
                 useActiveModalizer: true,
             });
@@ -942,11 +918,11 @@ export class MoverAPI implements Types.MoverAPI {
                     useActiveModalizer: true,
                 });
             }
-        } else if (keyCode === Keys.Home) {
+        } else if (key === Types.MoverKeys.Home) {
             if (isGrid) {
                 focusable.findElement({
                     container,
-                    currentElement: focused,
+                    currentElement: fromElement,
                     useActiveModalizer: true,
                     isBackward: true,
                     acceptCondition: (el) => {
@@ -959,7 +935,7 @@ export class MoverAPI implements Types.MoverAPI {
                         );
 
                         if (
-                            el !== focused &&
+                            el !== fromElement &&
                             focusedElementX1 <= nextElementX1
                         ) {
                             return true;
@@ -975,11 +951,11 @@ export class MoverAPI implements Types.MoverAPI {
                     useActiveModalizer: true,
                 });
             }
-        } else if (keyCode === Keys.End) {
+        } else if (key === Types.MoverKeys.End) {
             if (isGrid) {
                 focusable.findElement({
                     container,
-                    currentElement: focused,
+                    currentElement: fromElement,
                     useActiveModalizer: true,
                     acceptCondition: (el) => {
                         if (!focusable.isFocusable(el)) {
@@ -991,7 +967,7 @@ export class MoverAPI implements Types.MoverAPI {
                         );
 
                         if (
-                            el !== focused &&
+                            el !== fromElement &&
                             focusedElementX1 >= nextElementX1
                         ) {
                             return true;
@@ -1007,9 +983,9 @@ export class MoverAPI implements Types.MoverAPI {
                     useActiveModalizer: true,
                 });
             }
-        } else if (keyCode === Keys.PageUp) {
+        } else if (key === Types.MoverKeys.PageUp) {
             focusable.findElement({
-                currentElement: focused,
+                currentElement: fromElement,
                 container,
                 useActiveModalizer: true,
                 isBackward: true,
@@ -1063,9 +1039,9 @@ export class MoverAPI implements Types.MoverAPI {
             }
 
             scrollIntoViewArg = false;
-        } else if (keyCode === Keys.PageDown) {
+        } else if (key === Types.MoverKeys.PageDown) {
             focusable.findElement({
-                currentElement: focused,
+                currentElement: fromElement,
                 container,
                 useActiveModalizer: true,
                 acceptCondition: (el) => {
@@ -1120,7 +1096,7 @@ export class MoverAPI implements Types.MoverAPI {
 
             scrollIntoViewArg = true;
         } else if (isGrid) {
-            const isBackward = keyCode === Keys.Up;
+            const isBackward = key === Types.MoverKeys.ArrowUp;
             const ax1 = focusedElementX1;
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const ay1 = Math.ceil(focusedElementRect!.top);
@@ -1133,7 +1109,7 @@ export class MoverAPI implements Types.MoverAPI {
 
             focusable.findAll({
                 container,
-                currentElement: focused,
+                currentElement: fromElement,
                 isBackward,
                 onElement: (el) => {
                     // Find element which has maximal intersection with the focused element horizontally,
@@ -1203,22 +1179,78 @@ export class MoverAPI implements Types.MoverAPI {
 
         if (
             next &&
-            triggerMoveFocusEvent({
-                by: "mover",
-                owner: container,
-                next,
-                relatedEvent: event,
-            })
+            (!relatedEvent ||
+                (relatedEvent &&
+                    triggerMoveFocusEvent({
+                        by: "mover",
+                        owner: container,
+                        next,
+                        relatedEvent,
+                    })))
         ) {
             if (scrollIntoViewArg !== undefined) {
                 scrollIntoView(this._win, next, scrollIntoViewArg);
             }
 
-            event.preventDefault();
-            event.stopImmediatePropagation();
+            if (relatedEvent) {
+                relatedEvent.preventDefault();
+                relatedEvent.stopImmediatePropagation();
+            }
 
             nativeFocus(next);
+
+            return next;
         }
+
+        return null;
+    }
+
+    private _onKeyDown = async (event: KeyboardEvent): Promise<void> => {
+        if (this._ignoredInputTimer) {
+            this._win().clearTimeout(this._ignoredInputTimer);
+            delete this._ignoredInputTimer;
+        }
+
+        this._ignoredInputResolve?.(false);
+
+        // Give a chance to other listeners to handle the event (for example,
+        // to scroll instead of moving focus).
+        if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) {
+            return;
+        }
+
+        const keyCode = event.keyCode;
+        let moverKey: Types.MoverKey | undefined;
+
+        if (keyCode === Keys.Down) {
+            moverKey = Types.MoverKeys.ArrowDown;
+        } else if (keyCode === Keys.Right) {
+            moverKey = Types.MoverKeys.ArrowRight;
+        } else if (keyCode === Keys.Up) {
+            moverKey = Types.MoverKeys.ArrowUp;
+        } else if (keyCode === Keys.Left) {
+            moverKey = Types.MoverKeys.ArrowLeft;
+        } else if (keyCode === Keys.PageDown) {
+            moverKey = Types.MoverKeys.PageDown;
+        } else if (keyCode === Keys.PageUp) {
+            moverKey = Types.MoverKeys.PageUp;
+        } else if (keyCode === Keys.Home) {
+            moverKey = Types.MoverKeys.Home;
+        } else if (keyCode === Keys.End) {
+            moverKey = Types.MoverKeys.End;
+        }
+
+        if (!moverKey) {
+            return;
+        }
+
+        const focused = this._tabster.focusedElement.getFocusedElement();
+
+        if (!focused || (await this._isIgnoredInput(focused, keyCode))) {
+            return;
+        }
+
+        this._moveFocus(focused, moverKey, event);
     };
 
     private async _isIgnoredInput(

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -695,6 +695,7 @@ export class MoverAPI implements Types.MoverAPI {
         const win = this._win();
 
         win.addEventListener("keydown", this._onKeyDown, true);
+        win.addEventListener(Types.MoverMoveFocusEventName, this._onMoveFocus);
 
         this._tabster.focusedElement.subscribe(this._onFocus);
     };
@@ -712,6 +713,10 @@ export class MoverAPI implements Types.MoverAPI {
         }
 
         win.removeEventListener("keydown", this._onKeyDown, true);
+        win.removeEventListener(
+            Types.MoverMoveFocusEventName,
+            this._onMoveFocus
+        );
 
         Object.keys(this._movers).forEach((moverId) => {
             if (this._movers[moverId]) {
@@ -1251,6 +1256,16 @@ export class MoverAPI implements Types.MoverAPI {
         }
 
         this._moveFocus(focused, moverKey, event);
+    };
+
+    private _onMoveFocus = (e: Types.MoverMoveFocusEvent): void => {
+        const element = e.target as HTMLElement | null | undefined;
+        const key = e.detail?.key;
+
+        if (element && key !== undefined && !e.defaultPrevented) {
+            this._moveFocus(element, key);
+            e.stopImmediatePropagation();
+        }
     };
 
     private async _isIgnoredInput(

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -15,7 +15,7 @@ import {
     shouldIgnoreFocus,
     WeakHTMLElement,
     triggerEvent,
-    triggerMoveFocusEvent,
+    dispatchMoveFocusEvent,
 } from "../Utils";
 import { getTabsterOnElement } from "../Instance";
 import { Subscribable } from "./Subscribable";
@@ -563,7 +563,7 @@ export class FocusedElementState
                 // For iframes and uncontrolled areas we always want to use default action to
                 // move focus into.
                 if (
-                    triggerMoveFocusEvent({
+                    dispatchMoveFocusEvent({
                         by: "root",
                         owner: rootElement,
                         next: nextElement,
@@ -584,7 +584,7 @@ export class FocusedElementState
 
             if (controlTab || next?.outOfDOMOrder) {
                 if (
-                    triggerMoveFocusEvent({
+                    dispatchMoveFocusEvent({
                         by: "root",
                         owner: rootElement,
                         next: nextElement,
@@ -603,7 +603,7 @@ export class FocusedElementState
         } else {
             if (
                 !uncontrolledCompletelyContainer &&
-                triggerMoveFocusEvent({
+                dispatchMoveFocusEvent({
                     by: "root",
                     owner: rootElement,
                     next: null,

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -26,12 +26,16 @@ import {
     disposeInstanceContext,
     startFakeWeakRefsCleanup,
     stopFakeWeakRefsCleanupAndClearStorage,
+    triggerGroupperMoveFocusEvent,
+    triggerMoverMoveFocusEvent,
     DummyInputObserver,
 } from "./Utils";
 import { RestorerAPI } from "./Restorer";
 
 export { Types };
 export * from "./AttributeHelpers";
+
+export { triggerGroupperMoveFocusEvent, triggerMoverMoveFocusEvent };
 
 class Tabster implements Types.Tabster {
     keyboardNavigation: Types.KeyboardNavigationState;

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -26,8 +26,8 @@ import {
     disposeInstanceContext,
     startFakeWeakRefsCleanup,
     stopFakeWeakRefsCleanupAndClearStorage,
-    triggerGroupperMoveFocusEvent,
-    triggerMoverMoveFocusEvent,
+    dispatchGroupperMoveFocusEvent,
+    dispatchMoverMoveFocusEvent,
     DummyInputObserver,
 } from "./Utils";
 import { RestorerAPI } from "./Restorer";
@@ -35,7 +35,7 @@ import { RestorerAPI } from "./Restorer";
 export { Types };
 export * from "./AttributeHelpers";
 
-export { triggerGroupperMoveFocusEvent, triggerMoverMoveFocusEvent };
+export { dispatchGroupperMoveFocusEvent, dispatchMoverMoveFocusEvent };
 
 class Tabster implements Types.Tabster {
     keyboardNavigation: Types.KeyboardNavigationState;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -39,7 +39,7 @@ export interface TabsterMoveFocusEventDetails {
     by: "mover" | "groupper" | "modalizer" | "root";
     owner: HTMLElement; // Mover, Groupper, Modalizer or Root, the initiator.
     next: HTMLElement | null; // Next element to focus or null if Tabster wants to go outside of Root (i.e. to the address bar of the browser).
-    relatedEvent: KeyboardEvent; // The original keyboard event that triggered the move.
+    relatedEvent?: KeyboardEvent; // The original keyboard event that triggered the move.
 }
 
 export type TabsterMoveFocusEvent =
@@ -737,8 +737,32 @@ interface MoverAPIInternal {
     ): Mover;
 }
 
+export interface MoverKeys {
+    ArrowUp: 1;
+    ArrowDown: 2;
+    ArrowLeft: 3;
+    ArrowRight: 4;
+    PageUp: 5;
+    PageDown: 6;
+    Home: 7;
+    End: 8;
+}
+export type MoverKey = MoverKeys[keyof MoverKeys];
+export const MoverKeys: MoverKeys = {
+    ArrowUp: 1,
+    ArrowDown: 2,
+    ArrowLeft: 3,
+    ArrowRight: 4,
+    PageUp: 5,
+    PageDown: 6,
+    Home: 7,
+    End: 8,
+};
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface MoverAPI extends MoverAPIInternal, Disposable {}
+export interface MoverAPI extends MoverAPIInternal, Disposable {
+    moveFocus(fromElement: HTMLElement, key: MoverKey): HTMLElement | null;
+}
 
 export interface GroupperTabbabilities {
     Unlimited: 0;
@@ -798,7 +822,10 @@ export interface GroupperAPIInternal {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface GroupperAPI extends GroupperAPIInternal, Disposable {}
+export interface GroupperAPI extends GroupperAPIInternal, Disposable {
+    enterGroupper(element: HTMLElement): HTMLElement | null;
+    escapeGroupper(element: HTMLElement): HTMLElement | null;
+}
 
 export interface GroupperAPIInternal {
     forgetCurrentGrouppers(): void;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -41,9 +41,20 @@ export const FocusableSelector = [
 // Trigger move focus event on a Mover element.
 export type MoverMoveFocusEvent = CustomEvent<{ key: MoverKey } | undefined>;
 
+export interface GroupperMoveFocusActions {
+    Enter: 1;
+    Escape: 2;
+}
+export type GroupperMoveFocusAction =
+    GroupperMoveFocusActions[keyof GroupperMoveFocusActions];
+export const GroupperMoveFocusActions: GroupperMoveFocusActions = {
+    Enter: 1,
+    Escape: 2,
+};
+
 // Enter or escape Groupper. Enter when `enter` is true, escape when `enter` is false.
 export type GroupperMoveFocusEvent = CustomEvent<
-    { enter: boolean } | undefined
+    { action: GroupperMoveFocusAction } | undefined
 >;
 
 export type TabsterEventWithDetails<D> = CustomEvent<D | undefined>;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -847,8 +847,10 @@ export interface GroupperAPIInternal {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface GroupperAPI extends GroupperAPIInternal, Disposable {
-    enterGroupper(element: HTMLElement): HTMLElement | null;
-    escapeGroupper(element: HTMLElement): HTMLElement | null;
+    moveFocus(
+        element: HTMLElement,
+        action: GroupperMoveFocusAction
+    ): HTMLElement | null;
 }
 
 export interface GroupperAPIInternal {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -21,6 +21,13 @@ export const FocusOutEventName = "tabster:focusout";
 // some custom logic.
 export const MoveFocusEventName = "tabster:movefocus";
 
+// Event that can be triggered by the application to programmatically move
+// focus inside Mover.
+export const MoverMoveFocusEventName = "tabster:mover:movefocus";
+// Event that can be triggered by the application to programmatically enter
+// or escape Groupper.
+export const GroupperMoveFocusEventName = "tabster:groupper:movefocus";
+
 export const FocusableSelector = [
     "a[href]",
     "button:not([disabled])",
@@ -31,9 +38,15 @@ export const FocusableSelector = [
     "*[contenteditable]",
 ].join(", ");
 
-export interface TabsterEventWithDetails<D> extends Event {
-    details: D;
-}
+// Trigger move focus event on a Mover element.
+export type MoverMoveFocusEvent = CustomEvent<{ key: MoverKey } | undefined>;
+
+// Enter or escape Groupper. Enter when `enter` is true, escape when `enter` is false.
+export type GroupperMoveFocusEvent = CustomEvent<
+    { enter: boolean } | undefined
+>;
+
+export type TabsterEventWithDetails<D> = CustomEvent<D | undefined>;
 
 export interface TabsterMoveFocusEventDetails {
     by: "mover" | "groupper" | "modalizer" | "root";

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -785,6 +785,7 @@ export const MoverKeys: MoverKeys = {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MoverAPI extends MoverAPIInternal, Disposable {
+    /** @internal (will likely be exposed once the API is fully stable) */
     moveFocus(fromElement: HTMLElement, key: MoverKey): HTMLElement | null;
 }
 
@@ -847,6 +848,7 @@ export interface GroupperAPIInternal {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface GroupperAPI extends GroupperAPIInternal, Disposable {
+    /** @internal (will likely be exposed once the API is fully stable) */
     moveFocus(
         element: HTMLElement,
         action: GroupperMoveFocusAction

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1040,7 +1040,7 @@ export class DummyInputManager {
 
             if (
                 parent &&
-                triggerMoveFocusEvent({
+                dispatchMoveFocusEvent({
                     by: "root",
                     owner: parent,
                     next: null,
@@ -1551,7 +1551,7 @@ class DummyInputManagerCore {
 
                 if (
                     toFocus &&
-                    triggerMoveFocusEvent({
+                    dispatchMoveFocusEvent({
                         by: "root",
                         owner: element,
                         next: null,
@@ -1791,24 +1791,24 @@ export function triggerEvent<D>(
     return !event.defaultPrevented;
 }
 
-export function triggerMoveFocusEvent(
+export function dispatchMoveFocusEvent(
     details: Types.TabsterMoveFocusEventDetails
 ): boolean {
     return triggerEvent(details.owner, Types.MoveFocusEventName, details);
 }
 
-export function triggerMoverMoveFocusEvent(
+export function dispatchMoverMoveFocusEvent(
     target: HTMLElement,
     key: Types.MoverKey
 ) {
     return triggerEvent(target, Types.MoverMoveFocusEventName, { key });
 }
 
-export function triggerGroupperMoveFocusEvent(
+export function dispatchGroupperMoveFocusEvent(
     target: HTMLElement,
-    enter: boolean
+    action: Types.GroupperMoveFocusAction
 ) {
-    return triggerEvent(target, Types.GroupperMoveFocusEventName, { enter });
+    return triggerEvent(target, Types.GroupperMoveFocusEventName, { action });
 }
 
 export function augmentAttribute(

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1773,15 +1773,18 @@ export function getAdjacentElement(
 export function triggerEvent<D>(
     target: HTMLElement | EventTarget,
     name: string,
-    details: D
+    detail?: D
 ): boolean {
-    const event = document.createEvent(
-        "HTMLEvents"
-    ) as Types.TabsterEventWithDetails<D>;
+    const event = new CustomEvent(name, {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        detail,
+    });
 
-    event.initEvent(name, true, true);
-
-    event.details = details;
+    // For the sake of backward compatibility, we're adding `details` property.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (event as any).details = detail;
 
     target.dispatchEvent(event);
 
@@ -1792,6 +1795,20 @@ export function triggerMoveFocusEvent(
     details: Types.TabsterMoveFocusEventDetails
 ): boolean {
     return triggerEvent(details.owner, Types.MoveFocusEventName, details);
+}
+
+export function triggerMoverMoveFocusEvent(
+    target: HTMLElement,
+    key: Types.MoverKey
+) {
+    return triggerEvent(target, Types.MoverMoveFocusEventName, { key });
+}
+
+export function triggerGroupperMoveFocusEvent(
+    target: HTMLElement,
+    enter: boolean
+) {
+    return triggerEvent(target, Types.GroupperMoveFocusEventName, { enter });
 }
 
 export function augmentAttribute(

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,5 +22,7 @@ export {
     getRestorer,
     makeNoOp,
     isNoOp,
+    triggerGroupperMoveFocusEvent,
+    triggerMoverMoveFocusEvent,
     Types,
 } from "./Tabster";

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export {
     getRestorer,
     makeNoOp,
     isNoOp,
-    triggerGroupperMoveFocusEvent,
-    triggerMoverMoveFocusEvent,
+    dispatchGroupperMoveFocusEvent,
+    dispatchMoverMoveFocusEvent,
     Types,
 } from "./Tabster";

--- a/tests/FocusedElement.test.tsx
+++ b/tests/FocusedElement.test.tsx
@@ -99,8 +99,8 @@ describe("onKeyDown", () => {
                             ).__tabsterFocusEvents?.push(
                                 `${eventName} ${
                                     (e.target as HTMLElement)?.id
-                                } ${e.details.isFocusedProgrammatically} ${
-                                    e.details.modalizerId
+                                } ${e.detail?.isFocusedProgrammatically} ${
+                                    e.detail?.modalizerId
                                 }`
                             );
                         }

--- a/tests/Groupper.test.tsx
+++ b/tests/Groupper.test.tsx
@@ -413,19 +413,19 @@ describe("Groupper - limited focus trap", () => {
                 .activeElement((el) =>
                     expect(el?.textContent).toEqual("Foo1Bar1")
                 )
-                .eval(() => {
-                    getTabsterTestVariables()?.triggerGroupperMoveFocusEvent?.(
+                .eval((action) => {
+                    getTabsterTestVariables()?.dispatchGroupperMoveFocusEvent?.(
                         document.activeElement as HTMLElement,
-                        true
+                        action
                     );
-                })
+                }, Types.GroupperMoveFocusActions.Enter)
                 .activeElement((el) => expect(el?.textContent).toEqual("Foo1"))
-                .eval(() => {
-                    getTabsterTestVariables()?.triggerGroupperMoveFocusEvent?.(
+                .eval((action) => {
+                    getTabsterTestVariables()?.dispatchGroupperMoveFocusEvent?.(
                         document.activeElement as HTMLElement,
-                        false
+                        action
                     );
-                })
+                }, Types.GroupperMoveFocusActions.Escape)
                 .activeElement((el) =>
                     expect(el?.textContent).toEqual("Foo1Bar1")
                 );

--- a/tests/Groupper.test.tsx
+++ b/tests/Groupper.test.tsx
@@ -398,6 +398,39 @@ describe("Groupper - limited focus trap", () => {
                 );
         }
     );
+
+    it.each<["div" | "li"]>([["div"], ["li"]])(
+        "should enter and escape groupper as <%s> with tabster:groupper:movefocus event",
+        async (tagName) => {
+            await new BroTest.BroTest(getTestHtml(tagName, true, false))
+                .pressTab()
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Foo1Bar1")
+                )
+                .pressEnter()
+                .activeElement((el) => expect(el?.textContent).toEqual("Foo1"))
+                .pressEsc()
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Foo1Bar1")
+                )
+                .eval(() => {
+                    getTabsterTestVariables()?.triggerGroupperMoveFocusEvent?.(
+                        document.activeElement as HTMLElement,
+                        true
+                    );
+                })
+                .activeElement((el) => expect(el?.textContent).toEqual("Foo1"))
+                .eval(() => {
+                    getTabsterTestVariables()?.triggerGroupperMoveFocusEvent?.(
+                        document.activeElement as HTMLElement,
+                        false
+                    );
+                })
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Foo1Bar1")
+                );
+        }
+    );
 });
 
 describe("Groupper tabbing forward and backwards", () => {
@@ -679,14 +712,14 @@ describe("Groupper with tabster:groupper:movefocus", () => {
                     document.addEventListener(
                         "tabster:movefocus",
                         (e: Types.TabsterMoveFocusEvent) => {
-                            if (e.details.relatedEvent.key === "Enter") {
+                            if (e.detail?.relatedEvent?.key === "Enter") {
                                 if (
                                     (window as WindowWithButton2)
                                         .__enteredGroupper
                                 ) {
                                     // Enter was pressed for the second time, let's alter the default behaviour.
                                     e.preventDefault();
-                                    e.details.relatedEvent.preventDefault();
+                                    e.detail.relatedEvent.preventDefault();
                                     document.getElementById("button1")?.focus();
                                 }
 
@@ -704,7 +737,7 @@ describe("Groupper with tabster:groupper:movefocus", () => {
                                     (window as WindowWithButton2).__hadButton3
                                 ) {
                                     e.preventDefault();
-                                    e.details.relatedEvent.preventDefault();
+                                    e.detail?.relatedEvent?.preventDefault();
                                     document.getElementById("button4")?.focus();
                                 }
 

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -1831,7 +1831,7 @@ describe("Modalizer events", () => {
                                 (
                                     window as WindowWithModalizerEventsHistory
                                 ).__tabsterModalizerEvents?.push(
-                                    `${e.details.eventName} ${e.details.id} ${e.details.element.id}`
+                                    `${e.detail?.eventName} ${e.detail?.id} ${e.detail?.element.id}`
                                 );
                             }
                         );
@@ -2321,7 +2321,7 @@ describe("Modalizer with tabster:movefocus event handling", () => {
                             "ModalButton1"
                         ) {
                             e.preventDefault();
-                            e.details.relatedEvent.preventDefault();
+                            e.detail?.relatedEvent?.preventDefault();
                             document.getElementById("button-3")?.focus();
                         }
 
@@ -2330,7 +2330,7 @@ describe("Modalizer with tabster:movefocus event handling", () => {
                             "ModalButton2"
                         ) {
                             e.preventDefault();
-                            e.details.relatedEvent.preventDefault();
+                            e.detail?.relatedEvent?.preventDefault();
                             document.getElementById("button-1")?.focus();
                         }
                     }

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -1198,7 +1198,7 @@ describe("Mover with trackState", () => {
                     (e: Types.MoverEvent) => {
                         let className = "item";
 
-                        switch (e.details.visibility) {
+                        switch (e.detail?.visibility) {
                             case 0:
                                 className += " invisible";
                                 break;
@@ -1210,7 +1210,7 @@ describe("Mover with trackState", () => {
                                 break;
                         }
 
-                        if (e.details.isCurrent) {
+                        if (e.detail?.isCurrent) {
                             className += " active";
                         }
 
@@ -2740,13 +2740,13 @@ describe("Mover with tabster:movefocus event handling", () => {
                     (e: Types.TabsterMoveFocusEvent) => {
                         if (document.activeElement?.textContent === "Button3") {
                             e.preventDefault();
-                            e.details.relatedEvent.preventDefault();
+                            e.detail?.relatedEvent?.preventDefault();
                             document.getElementById("button-6")?.focus();
                         }
 
                         if (document.activeElement?.textContent === "Button4") {
                             e.preventDefault();
-                            e.details.relatedEvent.preventDefault();
+                            e.detail?.relatedEvent?.preventDefault();
                             document.getElementById("button-1")?.focus();
                         }
                     }
@@ -2763,5 +2763,113 @@ describe("Mover with tabster:movefocus event handling", () => {
             .activeElement((el) => expect(el?.textContent).toEqual("Button4"))
             .press("PageDown")
             .activeElement((el) => expect(el?.textContent).toEqual("Button1"));
+    });
+});
+
+describe("Mover moves focus by tabster:mover:movefocus", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({ mover: true });
+    });
+
+    it("should move focus with tabster:mover:movefocus", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: {},
+                        })}
+                    >
+                        <button>Button1</button>
+                        <button>Button2</button>
+                        <button>Button3</button>
+                        <button>Button4</button>
+                        <button>Button5</button>
+                    </div>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .press("PageDown")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            })
+            .pressUp()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .press("PageUp")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .press("End")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            })
+            .press("Home")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .eval((key) => {
+                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                    document.activeElement as HTMLElement,
+                    key
+                );
+            }, Types.MoverKeys.ArrowDown)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .eval((key) => {
+                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                    document.activeElement as HTMLElement,
+                    key
+                );
+            }, Types.MoverKeys.PageDown)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            })
+            .eval((key) => {
+                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                    document.activeElement as HTMLElement,
+                    key
+                );
+            }, Types.MoverKeys.ArrowUp)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            })
+            .eval((key) => {
+                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                    document.activeElement as HTMLElement,
+                    key
+                );
+            }, Types.MoverKeys.PageUp)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .eval((key) => {
+                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                    document.activeElement as HTMLElement,
+                    key
+                );
+            }, Types.MoverKeys.End)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            })
+            .eval((key) => {
+                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                    document.activeElement as HTMLElement,
+                    key
+                );
+            }, Types.MoverKeys.Home)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            });
     });
 });

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -2818,7 +2818,7 @@ describe("Mover moves focus by tabster:mover:movefocus", () => {
                 expect(el?.textContent).toEqual("Button1");
             })
             .eval((key) => {
-                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                getTabsterTestVariables()?.dispatchMoverMoveFocusEvent?.(
                     document.activeElement as HTMLElement,
                     key
                 );
@@ -2827,7 +2827,7 @@ describe("Mover moves focus by tabster:mover:movefocus", () => {
                 expect(el?.textContent).toEqual("Button2");
             })
             .eval((key) => {
-                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                getTabsterTestVariables()?.dispatchMoverMoveFocusEvent?.(
                     document.activeElement as HTMLElement,
                     key
                 );
@@ -2836,7 +2836,7 @@ describe("Mover moves focus by tabster:mover:movefocus", () => {
                 expect(el?.textContent).toEqual("Button5");
             })
             .eval((key) => {
-                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                getTabsterTestVariables()?.dispatchMoverMoveFocusEvent?.(
                     document.activeElement as HTMLElement,
                     key
                 );
@@ -2845,7 +2845,7 @@ describe("Mover moves focus by tabster:mover:movefocus", () => {
                 expect(el?.textContent).toEqual("Button4");
             })
             .eval((key) => {
-                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                getTabsterTestVariables()?.dispatchMoverMoveFocusEvent?.(
                     document.activeElement as HTMLElement,
                     key
                 );
@@ -2854,7 +2854,7 @@ describe("Mover moves focus by tabster:mover:movefocus", () => {
                 expect(el?.textContent).toEqual("Button1");
             })
             .eval((key) => {
-                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                getTabsterTestVariables()?.dispatchMoverMoveFocusEvent?.(
                     document.activeElement as HTMLElement,
                     key
                 );
@@ -2863,7 +2863,7 @@ describe("Mover moves focus by tabster:mover:movefocus", () => {
                 expect(el?.textContent).toEqual("Button5");
             })
             .eval((key) => {
-                getTabsterTestVariables()?.triggerMoverMoveFocusEvent?.(
+                getTabsterTestVariables()?.dispatchMoverMoveFocusEvent?.(
                     document.activeElement as HTMLElement,
                     key
                 );

--- a/tests/Root.test.tsx
+++ b/tests/Root.test.tsx
@@ -147,9 +147,9 @@ describe("Root", () => {
                     (
                         e: TabsterTypes.TabsterEventWithDetails<TabsterTypes.RootFocusEventDetails>
                     ) => {
-                        if (e.details.element.id) {
+                        if (e.detail?.element.id) {
                             focusedRoot.events.push({
-                                elementId: e.details.element.id,
+                                elementId: e.detail.element.id,
                                 type: "focus",
                             });
                         }
@@ -161,9 +161,9 @@ describe("Root", () => {
                     (
                         e: TabsterTypes.TabsterEventWithDetails<TabsterTypes.RootFocusEventDetails>
                     ) => {
-                        if (e.details.element.id) {
+                        if (e.detail?.element.id) {
                             focusedRoot.events.push({
-                                elementId: e.details.element.id,
+                                elementId: e.detail.element.id,
                                 type: "blur",
                             });
                         }

--- a/tests/index.html
+++ b/tests/index.html
@@ -19,6 +19,8 @@
                 mergeTabsterProps,
                 getTabsterAttribute,
                 setTabsterAttribute,
+                triggerGroupperMoveFocusEvent,
+                triggerMoverMoveFocusEvent,
             } from "../src";
 
             const tabsterTest = {};
@@ -47,6 +49,9 @@
             tabsterTest.getTabsterAttribute = getTabsterAttribute;
             tabsterTest.setTabsterAttribute = setTabsterAttribute;
             tabsterTest.mergeTabsterProps = mergeTabsterProps;
+            tabsterTest.triggerGroupperMoveFocusEvent =
+                triggerGroupperMoveFocusEvent;
+            tabsterTest.triggerMoverMoveFocusEvent = triggerMoverMoveFocusEvent;
 
             if (parts !== undefined) {
                 for (let part of parts) {
@@ -112,5 +117,6 @@
             window.getTabsterTestVariables = () => tabsterTest;
         </script>
     </head>
+
     <body></body>
 </html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -19,8 +19,8 @@
                 mergeTabsterProps,
                 getTabsterAttribute,
                 setTabsterAttribute,
-                triggerGroupperMoveFocusEvent,
-                triggerMoverMoveFocusEvent,
+                dispatchGroupperMoveFocusEvent,
+                dispatchMoverMoveFocusEvent,
             } from "../src";
 
             const tabsterTest = {};
@@ -49,9 +49,10 @@
             tabsterTest.getTabsterAttribute = getTabsterAttribute;
             tabsterTest.setTabsterAttribute = setTabsterAttribute;
             tabsterTest.mergeTabsterProps = mergeTabsterProps;
-            tabsterTest.triggerGroupperMoveFocusEvent =
-                triggerGroupperMoveFocusEvent;
-            tabsterTest.triggerMoverMoveFocusEvent = triggerMoverMoveFocusEvent;
+            tabsterTest.dispatchGroupperMoveFocusEvent =
+                dispatchGroupperMoveFocusEvent;
+            tabsterTest.dispatchMoverMoveFocusEvent =
+                dispatchMoverMoveFocusEvent;
 
             if (parts !== undefined) {
                 for (let part of parts) {

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -22,6 +22,8 @@ import {
     setTabsterAttribute,
     Types,
     getRestorer,
+    triggerGroupperMoveFocusEvent,
+    triggerMoverMoveFocusEvent,
 } from "tabster";
 
 // Importing the production version so that React doesn't complain in the test output.
@@ -112,6 +114,8 @@ export interface BroTestTabsterTestVariables {
     getTabsterAttribute?: typeof getTabsterAttribute;
     setTabsterAttribute?: typeof setTabsterAttribute;
     mergeTabsterProps?: typeof mergeTabsterProps;
+    triggerGroupperMoveFocusEvent?: typeof triggerGroupperMoveFocusEvent;
+    triggerMoverMoveFocusEvent?: typeof triggerMoverMoveFocusEvent;
     core?: Types.Tabster;
     modalizer?: Types.ModalizerAPI;
     deloser?: Types.DeloserAPI;

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -22,8 +22,8 @@ import {
     setTabsterAttribute,
     Types,
     getRestorer,
-    triggerGroupperMoveFocusEvent,
-    triggerMoverMoveFocusEvent,
+    dispatchGroupperMoveFocusEvent,
+    dispatchMoverMoveFocusEvent,
 } from "tabster";
 
 // Importing the production version so that React doesn't complain in the test output.
@@ -114,8 +114,8 @@ export interface BroTestTabsterTestVariables {
     getTabsterAttribute?: typeof getTabsterAttribute;
     setTabsterAttribute?: typeof setTabsterAttribute;
     mergeTabsterProps?: typeof mergeTabsterProps;
-    triggerGroupperMoveFocusEvent?: typeof triggerGroupperMoveFocusEvent;
-    triggerMoverMoveFocusEvent?: typeof triggerMoverMoveFocusEvent;
+    dispatchGroupperMoveFocusEvent?: typeof dispatchGroupperMoveFocusEvent;
+    dispatchMoverMoveFocusEvent?: typeof dispatchMoverMoveFocusEvent;
     core?: Types.Tabster;
     modalizer?: Types.ModalizerAPI;
     deloser?: Types.DeloserAPI;


### PR DESCRIPTION
Adding `tabster:groupper:movefocus` and `tabster:mover:movefocus` for the application to move focus by triggering them.