### PR TITLE
feat(mover): make isDefault always win against other props

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -308,19 +308,19 @@ export class Mover
         ) {
             let found: HTMLElement | undefined | null;
 
-            if (memorizeCurrent) {
+            if (hasDefault) {
+                found = this._tabster.focusable.findDefault({
+                    container: moverElement,
+                    useActiveModalizer: true,
+                });
+            }
+
+            if (!found && memorizeCurrent) {
                 const current = this._current?.get();
 
                 if (current && state.acceptCondition(current)) {
                     found = current;
                 }
-            }
-
-            if (!found && hasDefault) {
-                found = this._tabster.focusable.findDefault({
-                    container: moverElement,
-                    useActiveModalizer: true,
-                });
             }
 
             if (!found && visibilityAware) {

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -2576,7 +2576,7 @@ describe("Mover with default element", () => {
             });
     });
 
-    it("should focus memorized element or default focusable when tabbing from outside", async () => {
+    it("should focus prioritize isDefault over memorizeCurrent when tabbing from outside", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>
@@ -2619,7 +2619,7 @@ describe("Mover with default element", () => {
             })
             .pressTab(true)
             .activeElement((el) => {
-                expect(el?.textContent).toEqual("Button3");
+                expect(el?.textContent).toEqual("Button4");
             });
     });
 


### PR DESCRIPTION
Chatted with @ling1726 about this some time ago, this PR updates Mover to have `isDefault` always "win" when determining which element to focus when tabbing into a group.

This is related to work on Copilot messages (https://github.com/microsoft/tabster/issues/348), where we want `memorizeCurrent`, but sometimes need to override it, e.g. when a new message comes in.