### PR TITLE
feat(Mover): Event to forget or alter memorized element in Mover with memorizeCurrent.

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -701,6 +701,10 @@ export class MoverAPI implements Types.MoverAPI {
 
         win.addEventListener("keydown", this._onKeyDown, true);
         win.addEventListener(Types.MoverMoveFocusEventName, this._onMoveFocus);
+        win.addEventListener(
+            Types.MoverMemorizedElementEventName,
+            this._onMemorizedElement
+        );
 
         this._tabster.focusedElement.subscribe(this._onFocus);
     };
@@ -721,6 +725,10 @@ export class MoverAPI implements Types.MoverAPI {
         win.removeEventListener(
             Types.MoverMoveFocusEventName,
             this._onMoveFocus
+        );
+        win.removeEventListener(
+            Types.MoverMemorizedElementEventName,
+            this._onMemorizedElement
         );
 
         Object.keys(this._movers).forEach((moverId) => {
@@ -1271,6 +1279,31 @@ export class MoverAPI implements Types.MoverAPI {
         if (element && key !== undefined && !e.defaultPrevented) {
             this._moveFocus(element, key);
             e.stopImmediatePropagation();
+        }
+    };
+
+    private _onMemorizedElement = (
+        e: Types.MoverMemorizedElementEvent
+    ): void => {
+        const target = e.composedPath()[0] as HTMLElement | null | undefined;
+        let memorizedElement = e.detail?.memorizedElement;
+
+        if (target) {
+            const ctx = RootAPI.getTabsterContext(this._tabster, target);
+            const mover = ctx?.mover;
+
+            if (mover) {
+                if (
+                    memorizedElement &&
+                    !dom.nodeContains(mover.getElement(), memorizedElement)
+                ) {
+                    memorizedElement = undefined;
+                }
+
+                mover.setCurrent(memorizedElement);
+
+                e.stopImmediatePropagation();
+            }
         }
     };
 

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -28,6 +28,7 @@ import {
     stopFakeWeakRefsCleanupAndClearStorage,
     dispatchGroupperMoveFocusEvent,
     dispatchMoverMoveFocusEvent,
+    dispatchMoverMemorizedElementEvent,
     DummyInputObserver,
 } from "./Utils";
 import { RestorerAPI } from "./Restorer";
@@ -37,7 +38,11 @@ import * as shadowDOMAPI from "./Shadowdomize";
 export { Types };
 export * from "./AttributeHelpers";
 
-export { dispatchGroupperMoveFocusEvent, dispatchMoverMoveFocusEvent };
+export {
+    dispatchGroupperMoveFocusEvent,
+    dispatchMoverMoveFocusEvent,
+    dispatchMoverMemorizedElementEvent,
+};
 
 class Tabster implements Types.Tabster {
     keyboardNavigation: Types.KeyboardNavigationState;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -16,17 +16,21 @@ export const MoverEventName = "tabster:mover";
 export const FocusInEventName = "tabster:focusin";
 export const FocusOutEventName = "tabster:focusout";
 
-// Event to be triggered when Tabster wants to move focus as the result of
+// Event to be dispatched when Tabster wants to move focus as the result of
 // keyboard event. This allows to preventDefault() if you want to have
 // some custom logic.
 export const MoveFocusEventName = "tabster:movefocus";
 
-// Event that can be triggered by the application to programmatically move
+// Event that can be dispatched by the application to programmatically move
 // focus inside Mover.
 export const MoverMoveFocusEventName = "tabster:mover:movefocus";
-// Event that can be triggered by the application to programmatically enter
+// Event that can be dispatched by the application to programmatically enter
 // or escape Groupper.
 export const GroupperMoveFocusEventName = "tabster:groupper:movefocus";
+
+// Event that can be dispatched by the application to forget or modify
+// memorized element in Mover with memorizeCurrent property.
+export const MoverMemorizedElementEventName = "tabster:mover:memorized-element";
 
 export const FocusableSelector = [
     "a[href]",
@@ -38,8 +42,17 @@ export const FocusableSelector = [
     "*[contenteditable]",
 ].join(", ");
 
-// Trigger move focus event on a Mover element.
+// Dispatch move focus event on a Mover element.
 export type MoverMoveFocusEvent = CustomEvent<{ key: MoverKey } | undefined>;
+
+export interface MoverMemorizedElementEventDetails {
+    memorizedElement: HTMLElement | undefined;
+}
+// To be dispatched by the application to forget or modify memorized element
+// in Mover with memorizeCurrent property.
+export type MoverMemorizedElementEvent = CustomEvent<
+    MoverMemorizedElementEventDetails | undefined
+>;
 
 export interface GroupperMoveFocusActions {
     Enter: 1;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1837,6 +1837,17 @@ export function dispatchMoverMoveFocusEvent(
     return triggerEvent(target, Types.MoverMoveFocusEventName, { key });
 }
 
+export function dispatchMoverMemorizedElementEvent(
+    target: HTMLElement,
+    memorizedElement: HTMLElement | undefined
+) {
+    return triggerEvent<Types.MoverMemorizedElementEventDetails>(
+        target,
+        Types.MoverMemorizedElementEventName,
+        { memorizedElement }
+    );
+}
+
 export function dispatchGroupperMoveFocusEvent(
     target: HTMLElement,
     action: Types.GroupperMoveFocusAction

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,5 +25,6 @@ export {
     getShadowDOMAPI,
     dispatchGroupperMoveFocusEvent,
     dispatchMoverMoveFocusEvent,
+    dispatchMoverMemorizedElementEvent,
     Types,
 } from "./Tabster";

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -526,6 +526,74 @@ describe("Mover memorizing current", () => {
                 expect(el?.textContent).toEqual("Button3");
             });
     });
+
+    it("should forget or modify memorized element when tabster:mover:memorized-element is dispatched", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button>Button1</button>
+                    <div
+                        id="mover"
+                        {...getTabsterAttribute({
+                            mover: { memorizeCurrent: true },
+                        })}
+                    >
+                        <button>Button2</button>
+                        <button>Button3</button>
+                        <button id="button4">Button4</button>
+                        <button>Button5</button>
+                    </div>
+                    <button>Button6</button>
+                </div>
+            )
+        )
+            .pressTab()
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button6");
+            })
+            .eval(() => {
+                const vars = getTabsterTestVariables();
+
+                const target = vars.dom?.getElementById(document, "mover");
+
+                if (target && vars.dispatchMoverMemorizedElementEvent) {
+                    vars.dispatchMoverMemorizedElementEvent?.(
+                        target,
+                        undefined
+                    );
+                }
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button5");
+            })
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .eval(() => {
+                const vars = getTabsterTestVariables();
+
+                const target = vars.dom?.getElementById(document, "button4");
+
+                if (target && vars.dispatchMoverMemorizedElementEvent) {
+                    vars.dispatchMoverMemorizedElementEvent?.(target, target);
+                }
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            });
+    });
 });
 
 describe("Mover with excluded part", () => {

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,6 +21,7 @@
                 setTabsterAttribute,
                 dispatchGroupperMoveFocusEvent,
                 dispatchMoverMoveFocusEvent,
+                dispatchMoverMemorizedElementEvent,
             } from "../src";
             import * as shadowDOM from "../src/Shadowdomize";
             import { dom } from "../src/DOMAPI";
@@ -62,6 +63,8 @@
                 dispatchGroupperMoveFocusEvent;
             tabsterTest.dispatchMoverMoveFocusEvent =
                 dispatchMoverMoveFocusEvent;
+            tabsterTest.dispatchMoverMemorizedElementEvent =
+                dispatchMoverMemorizedElementEvent;
 
             if (parts !== undefined) {
                 for (let part of parts) {

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -24,6 +24,7 @@ import {
     getRestorer,
     dispatchGroupperMoveFocusEvent,
     dispatchMoverMoveFocusEvent,
+    dispatchMoverMemorizedElementEvent,
 } from "tabster";
 
 const domKey = process.env.SHADOWDOM ? "shadowDOM" : "dom";
@@ -120,6 +121,7 @@ export interface BroTestTabsterTestVariables {
     mergeTabsterProps?: typeof mergeTabsterProps;
     dispatchGroupperMoveFocusEvent?: typeof dispatchGroupperMoveFocusEvent;
     dispatchMoverMoveFocusEvent?: typeof dispatchMoverMoveFocusEvent;
+    dispatchMoverMemorizedElementEvent?: typeof dispatchMoverMemorizedElementEvent;
     core?: Types.Tabster;
     modalizer?: Types.ModalizerAPI;
     deloser?: Types.DeloserAPI;


### PR DESCRIPTION
It is now possible to dispatch `tabster:mover:memorized-element` custom event to an element inside Mover to forget or alter the memorized element. Comes with `dispatchMoverMemorizedElementEvent()` convenience method.