### PR TITLE
fix: Add backwards compat for event type

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -61,7 +61,13 @@ export type GroupperMoveFocusEvent = CustomEvent<
  * Tabster event type - uses `details` for backwards compat with previous versions
  * @see triggerEvent()
  */
-export type TabsterEventWithDetails<D> = CustomEvent<D | undefined> & { details: D | undefined };
+export type TabsterEventWithDetails<D> = CustomEvent<D | undefined> & {
+    /**
+     * @deprecated - please use the detail property
+     * @see detail
+     */
+    details: D | undefined;
+};
 
 export interface TabsterMoveFocusEventDetails {
     by: "mover" | "groupper" | "modalizer" | "root";

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -57,7 +57,11 @@ export type GroupperMoveFocusEvent = CustomEvent<
     { action: GroupperMoveFocusAction } | undefined
 >;
 
-export type TabsterEventWithDetails<D> = CustomEvent<D | undefined>;
+/**
+ * Tabster event type - uses `details` for backwards compat with previous versions
+ * @see triggerEvent()
+ */
+export type TabsterEventWithDetails<D> = CustomEvent<D | undefined> & { details: D | undefined };
 
 export interface TabsterMoveFocusEventDetails {
     by: "mover" | "groupper" | "modalizer" | "root";


### PR DESCRIPTION
Adds `details` as a type for `TabsterEventWithDetails` for backwards compat. The events are already triggered with the correct details in triggerEvent.

https://github.com/microsoft/tabster/blob/5423336d16b9dc975f222d1be241905fb05f244f/src/Utils.ts#L1818-L1820