### PR TITLE
Fixing races between parts of Tabster that want to focus something asynchronously.

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -429,8 +429,6 @@ export class GroupperAPI implements Types.GroupperAPI {
     private _win: Types.GetWindow;
     private _current: Record<string, Types.Groupper> = {};
     private _grouppers: Record<string, Types.Groupper> = {};
-    private _handleKeyPressTimer: number | undefined;
-    private _asyncFocusIntent: Types.AsyncFocusIntent | undefined;
 
     constructor(tabster: Types.TabsterCore, getWindow: Types.GetWindow) {
         this._tabster = tabster;
@@ -460,15 +458,9 @@ export class GroupperAPI implements Types.GroupperAPI {
     dispose(): void {
         const win = this._win();
 
-        if (this._asyncFocusIntent) {
-            this._asyncFocusIntent.cancel();
-            delete this._asyncFocusIntent;
-        }
-
-        if (this._handleKeyPressTimer) {
-            win.clearTimeout(this._handleKeyPressTimer);
-            delete this._handleKeyPressTimer;
-        }
+        this._tabster.focusedElement.cancelAsyncFocus(
+            Types.AsyncFocusSources.EscapeGroupper
+        );
 
         this._current = {};
 
@@ -773,17 +765,9 @@ export class GroupperAPI implements Types.GroupperAPI {
         const ctx = RootAPI.getTabsterContext(tabster, element);
 
         if (ctx && (ctx?.groupper || ctx?.modalizerInGroupper)) {
-            const win = this._win();
-
-            if (this._handleKeyPressTimer) {
-                win.clearTimeout(this._handleKeyPressTimer);
-                delete this._handleKeyPressTimer;
-            }
-
-            if (this._asyncFocusIntent) {
-                this._asyncFocusIntent.cancel();
-                delete this._asyncFocusIntent;
-            }
+            tabster.focusedElement.cancelAsyncFocus(
+                Types.AsyncFocusSources.EscapeGroupper
+            );
 
             if (ctx.ignoreKeydown(event)) {
                 return;
@@ -797,36 +781,25 @@ export class GroupperAPI implements Types.GroupperAPI {
                 const focusedElement =
                     tabster.focusedElement.getFocusedElement();
 
-                this._asyncFocusIntent =
-                    tabster.focusedElement.registerAsyncFocusIntent(
-                        Types.AsyncFocusIntentSources.EscapeGroupper
-                    );
+                tabster.focusedElement.registerAsyncFocus(
+                    Types.AsyncFocusSources.EscapeGroupper,
+                    () => {
+                        if (
+                            focusedElement !==
+                                tabster.focusedElement.getFocusedElement() &&
+                            // A part of Modalizer that has called this handler to escape the active groupper
+                            // might have been removed from DOM, if the focus is on body, we still want to handle Esc.
+                            ((fromModalizer && !focusedElement) ||
+                                !fromModalizer)
+                        ) {
+                            // Something else in the application has moved focus, we will not handle Esc.
+                            return;
+                        }
 
-                this._handleKeyPressTimer = win.setTimeout(() => {
-                    delete this._handleKeyPressTimer;
-
-                    const asyncFocusIntent = this._asyncFocusIntent;
-
-                    delete this._asyncFocusIntent;
-
-                    if (!asyncFocusIntent?.commit()) {
-                        // Some other focus intent has won.
-                        return;
-                    }
-
-                    if (
-                        focusedElement !==
-                            tabster.focusedElement.getFocusedElement() &&
-                        // A part of Modalizer that has called this handler to escape the active groupper
-                        // might have been removed from DOM, if the focus is on body, we still want to handle Esc.
-                        ((fromModalizer && !focusedElement) || !fromModalizer)
-                    ) {
-                        // Something else in the application has moved focus, we will not handle Esc.
-                        return;
-                    }
-
-                    this._escapeGroupper(element, event, fromModalizer);
-                }, 0);
+                        this._escapeGroupper(element, event, fromModalizer);
+                    },
+                    0
+                );
             }
         }
     }

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -781,7 +781,7 @@ export class GroupperAPI implements Types.GroupperAPI {
                 const focusedElement =
                     tabster.focusedElement.getFocusedElement();
 
-                tabster.focusedElement.registerAsyncFocus(
+                tabster.focusedElement.requestAsyncFocus(
                     Types.AsyncFocusSources.EscapeGroupper,
                     () => {
                         if (

--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -117,7 +117,7 @@ export class RestorerAPI implements RestorerAPIType {
         const target = e.composedPath()[0];
 
         if (target) {
-            this._focusedElementState.registerAsyncFocus(
+            this._focusedElementState.requestAsyncFocus(
                 AsyncFocusSources.Restorer,
                 () => this._restoreFocus(target as HTMLElement),
                 0

--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -13,11 +13,7 @@ import type {
     FocusedElementState,
     TabsterCore,
 } from "./Types";
-import {
-    RestorerTypes,
-    AsyncFocusIntent,
-    AsyncFocusIntentSources,
-} from "./Types";
+import { RestorerTypes, AsyncFocusSources } from "./Types";
 import {
     RestorerRestoreFocusEventName,
     RestorerRestoreFocusEvent,
@@ -86,9 +82,7 @@ export class RestorerAPI implements RestorerAPIType {
     private _history: WeakHTMLElement<HTMLElement>[] = [];
     private _keyboardNavState: KeyboardNavigationState;
     private _focusedElementState: FocusedElementState;
-    private _restoreFocusTimeout = 0;
     private _getWindow: GetWindow;
-    private _asyncFocusIntent: AsyncFocusIntent | undefined;
 
     constructor(tabster: TabsterCore) {
         this._tabster = tabster;
@@ -108,50 +102,26 @@ export class RestorerAPI implements RestorerAPIType {
         const win = this._getWindow();
         this._focusedElementState.unsubscribe(this._onFocusIn);
 
-        if (this._asyncFocusIntent) {
-            this._asyncFocusIntent.cancel();
-            delete this._asyncFocusIntent;
-        }
+        this._focusedElementState.cancelAsyncFocus(AsyncFocusSources.Restorer);
 
         win.removeEventListener(
             RestorerRestoreFocusEventName,
             this._onRestoreFocus
         );
-
-        if (this._restoreFocusTimeout) {
-            win.clearTimeout(this._restoreFocusTimeout);
-        }
     }
 
     private _onRestoreFocus = (e: Event) => {
-        const win = this._getWindow();
-
-        if (this._asyncFocusIntent) {
-            this._asyncFocusIntent.cancel();
-            delete this._asyncFocusIntent;
-        }
-
-        if (this._restoreFocusTimeout) {
-            win.clearTimeout(this._restoreFocusTimeout);
-            this._restoreFocusTimeout = 0;
-        }
+        this._focusedElementState.cancelAsyncFocus(AsyncFocusSources.Restorer);
 
         // ShadowDOM will have shadowRoot as e.target.
         const target = e.composedPath()[0];
 
         if (target) {
-            this._asyncFocusIntent =
-                this._tabster.focusedElement.registerAsyncFocusIntent(
-                    AsyncFocusIntentSources.Restorer
-                );
-
-            this._restoreFocusTimeout = win.setTimeout(() => {
-                if (this._asyncFocusIntent?.commit()) {
-                    this._restoreFocus(target as HTMLElement);
-                }
-
-                delete this._asyncFocusIntent;
-            });
+            this._focusedElementState.registerAsyncFocus(
+                AsyncFocusSources.Restorer,
+                () => this._restoreFocus(target as HTMLElement),
+                0
+            );
         }
     };
 

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -297,7 +297,7 @@ export class FocusedElementState
         return true;
     }
 
-    registerAsyncFocus(
+    requestAsyncFocus(
         source: Types.AsyncFocusSource,
         callback: () => void,
         delay: number

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -167,7 +167,7 @@ export interface FocusedElementState
      * is removed from DOM).
      */
     /** @internal */
-    registerAsyncFocus(
+    requestAsyncFocus(
         source: AsyncFocusSource,
         callback: () => void,
         delay: number

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -129,6 +129,32 @@ export interface FocusedElementDetail {
     modalizerId?: string;
 }
 
+export interface AsyncFocusIntentSources {
+    EscapeGroupper: 1;
+    Restorer: 2;
+    Deloser: 3;
+}
+export type AsyncFocusIntentSource =
+    AsyncFocusIntentSources[keyof AsyncFocusIntentSources];
+export const AsyncFocusIntentSources: AsyncFocusIntentSources = {
+    EscapeGroupper: 1,
+    Restorer: 2,
+    Deloser: 3,
+};
+
+export interface AsyncFocusIntent {
+    readonly source: AsyncFocusIntentSource;
+    /**
+     * To cancel the intent, call this method.
+     */
+    cancel(): void;
+    /**
+     * When Tabster wants to do the real focusing, this method should be called.
+     * @returns true if the focusing is allowed.
+     */
+    commit(): boolean;
+}
+
 export interface FocusedElementState
     extends Subscribable<HTMLElement | undefined, FocusedElementDetail>,
         Disposable {
@@ -148,6 +174,13 @@ export interface FocusedElementState
     focusFirst(props: FindFirstProps): boolean;
     focusLast(props: FindFirstProps): boolean;
     resetFocus(container: HTMLElement): boolean;
+    /**
+     * When Tabster wants to move focus asynchronously, it it should call this method to register its intent.
+     * This is a way to avoid conflicts between different parts that might want to move focus asynchronously
+     * at the same moment (for example when both Deloser and Restorer want to move focus when the focused element
+     * is removed from DOM).
+     * @internal */
+    registerAsyncFocusIntent(source: AsyncFocusIntentSource): AsyncFocusIntent;
 }
 
 export interface WeakHTMLElement<D = undefined> {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -129,31 +129,17 @@ export interface FocusedElementDetail {
     modalizerId?: string;
 }
 
-export interface AsyncFocusIntentSources {
+export interface AsyncFocusSources {
     EscapeGroupper: 1;
     Restorer: 2;
     Deloser: 3;
 }
-export type AsyncFocusIntentSource =
-    AsyncFocusIntentSources[keyof AsyncFocusIntentSources];
-export const AsyncFocusIntentSources: AsyncFocusIntentSources = {
+export type AsyncFocusSource = AsyncFocusSources[keyof AsyncFocusSources];
+export const AsyncFocusSources: AsyncFocusSources = {
     EscapeGroupper: 1,
     Restorer: 2,
     Deloser: 3,
 };
-
-export interface AsyncFocusIntent {
-    readonly source: AsyncFocusIntentSource;
-    /**
-     * To cancel the intent, call this method.
-     */
-    cancel(): void;
-    /**
-     * When Tabster wants to do the real focusing, this method should be called.
-     * @returns true if the focusing is allowed.
-     */
-    commit(): boolean;
-}
 
 export interface FocusedElementState
     extends Subscribable<HTMLElement | undefined, FocusedElementDetail>,
@@ -179,8 +165,15 @@ export interface FocusedElementState
      * This is a way to avoid conflicts between different parts that might want to move focus asynchronously
      * at the same moment (for example when both Deloser and Restorer want to move focus when the focused element
      * is removed from DOM).
-     * @internal */
-    registerAsyncFocusIntent(source: AsyncFocusIntentSource): AsyncFocusIntent;
+     */
+    /** @internal */
+    registerAsyncFocus(
+        source: AsyncFocusSource,
+        callback: () => void,
+        delay: number
+    ): void;
+    /** @internal */
+    cancelAsyncFocus(source: AsyncFocusSource): void;
 }
 
 export interface WeakHTMLElement<D = undefined> {

--- a/tests/Restorer.test.tsx
+++ b/tests/Restorer.test.tsx
@@ -369,7 +369,7 @@ describe("Restorer focus priority", () => {
             modalizer: true,
         });
     });
-    it("should restore focus when focus is moved to body from source", async () => {
+    it("should prioritize Restorer before Groupper when both want to move focus", async () => {
         await new BroTest.BroTest(
             (
                 <div {...getTabsterAttribute({ root: {} })}>

--- a/tests/Restorer.test.tsx
+++ b/tests/Restorer.test.tsx
@@ -360,3 +360,85 @@ describe("Restorer", () => {
             .activeElement((el) => expect(el?.textContent).toEqual("target"));
     });
 });
+
+describe("Restorer focus priority", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({
+            restorer: true,
+            groupper: true,
+            modalizer: true,
+        });
+    });
+    it("should restore focus when focus is moved to body from source", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        tabIndex={0}
+                        {...getTabsterAttribute({
+                            groupper: { tabbability: 2 },
+                            modalizer: { id: "modal" },
+                        })}
+                    >
+                        <button
+                            id="target"
+                            {...getTabsterAttribute({
+                                restorer: { type: Types.RestorerTypes.Target },
+                            })}
+                        >
+                            target
+                        </button>
+                        <button>button</button>
+                    </div>
+
+                    <div
+                        id="source"
+                        {...getTabsterAttribute({
+                            restorer: { type: Types.RestorerTypes.Source },
+                            modalizer: { id: "modal" },
+                        })}
+                    >
+                        <button>source</button>
+                    </div>
+                </div>
+            )
+        )
+            .focusElement("#target")
+            .pressTab()
+            .activeElement((el) => expect(el?.textContent).toEqual("button"))
+            .pressTab()
+            .activeElement((el) => expect(el?.textContent).toEqual("source"))
+            .pressEsc()
+            // When Esc is pressed, groupper handles is asynchronously, and restorer is not
+            // involved, because the source is still in the DOM. So, the groupper should handle
+            // the Esc normally.
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("targetbutton")
+            )
+            .pressEnter()
+            .pressTab()
+            .pressTab()
+            .activeElement((el) => expect(el?.textContent).toEqual("source"))
+            .eval(() => {
+                const source = getTabsterTestVariables().dom?.getElementById(
+                    document,
+                    "source"
+                );
+
+                if (source) {
+                    // This will trigger both async Esc handling and restorer focus restoration at the same time.
+                    // The async focus intent from the Restorer should win.
+                    source.dispatchEvent(
+                        new KeyboardEvent("keydown", {
+                            key: "Esc",
+                            keyCode: 27,
+                            bubbles: true,
+                            composed: true,
+                        })
+                    );
+                    source.remove();
+                }
+            })
+            .activeElement((el) => expect(el?.textContent).toEqual("target"));
+    });
+});


### PR DESCRIPTION
Tabster does some focus movements asynchronously. Restorer restores lost focus asynchronously (to give the DOM the opportunity to finish the changes), Groupper handles Esc asynchronously (to give the application ability to handle Esc inside the Groupper).

This PR fixes the conflicts when both Groupper and Restorer want to move focus at the same time.