### PR TITLE
Node.js environment compatibility for CustomEvent usage, exposing old dispatch event functions marked as deprecated.

### DIFF
--- a/src/Deprecated.ts
+++ b/src/Deprecated.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { GroupperMoveFocusAction, MoverKey } from "./Types";
+import {
+    GroupperMoveFocusEvent,
+    MoverMoveFocusEvent,
+    MoverMemorizedElementEvent,
+} from "./Events";
+
+/** @deprecated This function is obsolete, use native element.dispatchEvent(new GroupperMoveFocusEvent(...)). */
+export function dispatchGroupperMoveFocusEvent(
+    target: HTMLElement,
+    action: GroupperMoveFocusAction
+) {
+    return target.dispatchEvent(new GroupperMoveFocusEvent({ action }));
+}
+
+/** @deprecated This function is obsolete, use native element.dispatchEvent(new MoverMoveFocusEvent(...)). */
+export function dispatchMoverMoveFocusEvent(
+    target: HTMLElement,
+    key: MoverKey
+) {
+    return target.dispatchEvent(new MoverMoveFocusEvent({ key }));
+}
+
+/** @deprecated This function is obsolete, use native element.dispatchEvent(new MoverMemorizedElementEvent(...)). */
+export function dispatchMoverMemorizedElementEvent(
+    target: HTMLElement,
+    memorizedElement: HTMLElement | undefined
+) {
+    return target.dispatchEvent(
+        new MoverMemorizedElementEvent({ memorizedElement })
+    );
+}

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -77,7 +77,17 @@ export const RestorerRestoreFocusEventName = "tabster:restorer:restore-focus";
 export const RootFocusEventName = "tabster:root:focus";
 export const RootBlurEventName = "tabster:root:blur";
 
-export abstract class TabsterCustomEvent<D> extends CustomEvent<D> {
+// Node.js environments do not have CustomEvent and it is needed for the events to be
+// evaluated. It doesn't matter if it works or not in Node.js environment.
+// So, we just need to make sure that it doesn't throw undefined reference.
+const CustomEvent_ =
+    typeof CustomEvent !== "undefined"
+        ? CustomEvent
+        : (function () {
+              /* no-op */
+          } as typeof CustomEvent);
+
+export abstract class TabsterCustomEvent<D> extends CustomEvent_<D> {
     /**
      * @deprecated use `detail`.
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,5 @@ export {
     Types,
     Events,
 } from "./Tabster";
+
+export * from "./Deprecated";

--- a/tests/utils/BroTestEnvironment.ts
+++ b/tests/utils/BroTestEnvironment.ts
@@ -5,16 +5,4 @@
 
 import { default as PuppeteerEnvironment } from "jest-environment-puppeteer";
 
-export default class BroTestEnvironment extends PuppeteerEnvironment {
-    setup(): Promise<void> {
-        // PuppeteerEnvironment extends NodeEnvironment which doesn't have CustomEvent,
-        // and we need it in the global scope so that the derived classes can use it.
-        // On the Node.js side, we don't care if it works, because the actual test runs
-        // in the browser, and the browser has CustomEvent. Here we need it so that the
-        // test files could import types and utility functions
-        this.global.CustomEvent = function () {
-            /* no-op */
-        };
-        return super.setup();
-    }
-}
+export default class BroTestEnvironment extends PuppeteerEnvironment {}


### PR DESCRIPTION
Making sure CustomEvent usage doesn't throw undefined reference in Node.js environments.

Adding back custom dispatch event functions from before the events refactoring (done here: https://github.com/microsoft/tabster/pull/358) and marking them as deprecated.