### PR TITLE
Replacing keyCode usages with key.

### DIFF
--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -601,7 +601,7 @@ export class GroupperAPI implements Types.GroupperAPI {
     }
 
     private _onKeyDown = (event: KeyboardEvent): void => {
-        if (event.keyCode !== Keys.Enter && event.keyCode !== Keys.Esc) {
+        if (event.key !== Keys.Enter && event.key !== Keys.Escape) {
             return;
         }
 
@@ -773,9 +773,9 @@ export class GroupperAPI implements Types.GroupperAPI {
                 return;
             }
 
-            if (event.keyCode === Keys.Enter) {
+            if (event.key === Keys.Enter) {
                 this._enterGroupper(element, event);
-            } else if (event.keyCode === Keys.Esc) {
+            } else if (event.key === Keys.Escape) {
                 // We will handle Esc asynchronously, if something in the application will
                 // move focus during the keypress handling, we will not interfere.
                 const focusedElement =

--- a/src/Keys.ts
+++ b/src/Keys.ts
@@ -4,31 +4,31 @@
  */
 
 export const Keys: {
-    Tab: 9;
-    Enter: 13;
-    Esc: 27;
-    Space: 32;
-    PageUp: 33;
-    PageDown: 34;
-    End: 35;
-    Home: 36;
-    Left: 37;
-    Up: 38;
-    Right: 39;
-    Down: 40;
+    Tab: "Tab";
+    Enter: "Enter";
+    Escape: "Escape";
+    Space: " ";
+    PageUp: "PageUp";
+    PageDown: "PageDown";
+    End: "End";
+    Home: "Home";
+    ArrowLeft: "ArrowLeft";
+    ArrowUp: "ArrowUp";
+    ArrowRight: "ArrowRight";
+    ArrowDown: "ArrowDown";
 } = {
-    Tab: 9,
-    Enter: 13,
-    Esc: 27,
-    Space: 32,
-    PageUp: 33,
-    PageDown: 34,
-    End: 35,
-    Home: 36,
-    Left: 37,
-    Up: 38,
-    Right: 39,
-    Down: 40,
+    Tab: "Tab",
+    Enter: "Enter",
+    Escape: "Escape",
+    Space: " ",
+    PageUp: "PageUp",
+    PageDown: "PageDown",
+    End: "End",
+    Home: "Home",
+    ArrowLeft: "ArrowLeft",
+    ArrowUp: "ArrowUp",
+    ArrowRight: "ArrowRight",
+    ArrowDown: "ArrowDown",
 };
 
 export type Key = typeof Keys[keyof typeof Keys];

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -473,7 +473,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     };
 
     private _onKeyDown = (event: KeyboardEvent): void => {
-        if (event.keyCode !== Keys.Esc) {
+        if (event.key !== Keys.Escape) {
             return;
         }
 

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -1243,24 +1243,24 @@ export class MoverAPI implements Types.MoverAPI {
             return;
         }
 
-        const keyCode = event.keyCode;
+        const key = event.key;
         let moverKey: Types.MoverKey | undefined;
 
-        if (keyCode === Keys.Down) {
+        if (key === Keys.ArrowDown) {
             moverKey = Types.MoverKeys.ArrowDown;
-        } else if (keyCode === Keys.Right) {
+        } else if (key === Keys.ArrowRight) {
             moverKey = Types.MoverKeys.ArrowRight;
-        } else if (keyCode === Keys.Up) {
+        } else if (key === Keys.ArrowUp) {
             moverKey = Types.MoverKeys.ArrowUp;
-        } else if (keyCode === Keys.Left) {
+        } else if (key === Keys.ArrowLeft) {
             moverKey = Types.MoverKeys.ArrowLeft;
-        } else if (keyCode === Keys.PageDown) {
+        } else if (key === Keys.PageDown) {
             moverKey = Types.MoverKeys.PageDown;
-        } else if (keyCode === Keys.PageUp) {
+        } else if (key === Keys.PageUp) {
             moverKey = Types.MoverKeys.PageUp;
-        } else if (keyCode === Keys.Home) {
+        } else if (key === Keys.Home) {
             moverKey = Types.MoverKeys.Home;
-        } else if (keyCode === Keys.End) {
+        } else if (key === Keys.End) {
             moverKey = Types.MoverKeys.End;
         }
 
@@ -1270,7 +1270,7 @@ export class MoverAPI implements Types.MoverAPI {
 
         const focused = this._tabster.focusedElement.getFocusedElement();
 
-        if (!focused || (await this._isIgnoredInput(focused, keyCode))) {
+        if (!focused || (await this._isIgnoredInput(focused, key))) {
             return;
         }
 
@@ -1312,7 +1312,7 @@ export class MoverAPI implements Types.MoverAPI {
 
     private async _isIgnoredInput(
         element: HTMLElement,
-        keyCode: number
+        key: string
     ): Promise<boolean> {
         if (
             element.getAttribute("aria-expanded") === "true" &&
@@ -1346,7 +1346,7 @@ export class MoverAPI implements Types.MoverAPI {
                         if (selection) {
                             const initialLength = selection.toString().length;
                             const isBackward =
-                                keyCode === Keys.Left || keyCode === Keys.Up;
+                                key === Keys.ArrowLeft || key === Keys.ArrowUp;
 
                             selection.modify(
                                 "extend",
@@ -1495,18 +1495,18 @@ export class MoverAPI implements Types.MoverAPI {
 
             if (
                 selectionStart > 0 &&
-                (keyCode === Keys.Left ||
-                    keyCode === Keys.Up ||
-                    keyCode === Keys.Home)
+                (key === Keys.ArrowLeft ||
+                    key === Keys.ArrowUp ||
+                    key === Keys.Home)
             ) {
                 return true;
             }
 
             if (
                 selectionStart < textLength &&
-                (keyCode === Keys.Right ||
-                    keyCode === Keys.Down ||
-                    keyCode === Keys.End)
+                (key === Keys.ArrowRight ||
+                    key === Keys.ArrowDown ||
+                    key === Keys.End)
             ) {
                 return true;
             }

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -553,7 +553,7 @@ export class FocusedElementState
     };
 
     private _onKeyDown = (event: KeyboardEvent): void => {
-        if (event.keyCode !== Keys.Tab || event.ctrlKey) {
+        if (event.key !== Keys.Tab || event.ctrlKey) {
             return;
         }
 

--- a/tests/Groupper.test.tsx
+++ b/tests/Groupper.test.tsx
@@ -101,12 +101,10 @@ describe("Groupper - default", () => {
 
             await new BroTest.BroTest(getTestHtml(tagName))
                 .eval(() => {
-                    const keyEsc = 27;
-
                     (window as WindowWithEscFlag).__escPressed1 = 0;
 
                     window.addEventListener("keydown", (e) => {
-                        if (e.keyCode === keyEsc) {
+                        if (e.key === "Escape") {
                             (window as WindowWithEscFlag).__escPressed1!++;
                         }
                     });
@@ -134,12 +132,10 @@ describe("Groupper - default", () => {
 
             await new BroTest.BroTest(getTestHtml(tagName, true))
                 .eval(() => {
-                    const keyEsc = 27;
-
                     (window as WindowWithEscFlag).__escPressed2 = 0;
 
                     window.addEventListener("keydown", (e) => {
-                        if (e.keyCode === keyEsc) {
+                        if (e.key === "Escape") {
                             (window as WindowWithEscFlag).__escPressed2!++;
                         }
                     });
@@ -165,12 +161,10 @@ describe("Groupper - default", () => {
 
             await new BroTest.BroTest(getTestHtml(tagName))
                 .eval(() => {
-                    const keyEnter = 13;
-
                     (window as WindowWithEnterFlag).__enterPressed1 = 0;
 
                     window.addEventListener("keydown", (e) => {
-                        if (e.keyCode === keyEnter) {
+                        if (e.key === "Enter") {
                             (window as WindowWithEnterFlag).__enterPressed1!++;
                         }
                     });
@@ -196,12 +190,10 @@ describe("Groupper - default", () => {
                 getTestHtml(tagName, undefined, true, true)
             )
                 .eval(() => {
-                    const keyEnter = 13;
-
                     (window as WindowWithEnterFlag).__enterPressed2 = 0;
 
                     window.addEventListener("keydown", (e) => {
-                        if (e.keyCode === keyEnter) {
+                        if (e.key === "Enter") {
                             (window as WindowWithEnterFlag).__enterPressed2!++;
                         }
                     });
@@ -223,10 +215,8 @@ describe("Groupper - default", () => {
         async (tagName) => {
             await new BroTest.BroTest(getTestHtml(tagName))
                 .eval(() => {
-                    const keyEsc = 27;
-
                     window.addEventListener("keydown", (e) => {
-                        if (e.keyCode === keyEsc) {
+                        if (e.key === "Escape") {
                             // Focusing next button.
                             (
                                 getTabsterTestVariables().dom?.getActiveElement(

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -956,7 +956,7 @@ describe("Modalizer with multiple containers", () => {
         )
             .eval(() => {
                 document.addEventListener("keydown", (e) => {
-                    if (e.keyCode === 13) {
+                    if (e.key === "Enter") {
                         getTabsterTestVariables()
                             .dom?.getElementById(document, "modal-button-1")
                             ?.focus();
@@ -1759,7 +1759,7 @@ describe("Modalizer with multiple containers", () => {
                 document
                     .getElementById("remove-me-on-esc")
                     ?.addEventListener("keydown", (e) => {
-                        if (e.keyCode === 27) {
+                        if (e.key === "Escape") {
                             document
                                 .getElementById("remove-me-on-esc")
                                 ?.remove();

--- a/tests/Restorer.test.tsx
+++ b/tests/Restorer.test.tsx
@@ -430,8 +430,7 @@ describe("Restorer focus priority", () => {
                     // The async focus intent from the Restorer should win.
                     source.dispatchEvent(
                         new KeyboardEvent("keydown", {
-                            key: "Esc",
-                            keyCode: 27,
+                            key: "Escape",
                             bubbles: true,
                             composed: true,
                         })


### PR DESCRIPTION
`KeyboardEvent.keyCode` is deprecated and some testing frameworks are dropping support for it. Replacing `keyCode` usages with `key` usages.