### PR TITLE
fix: hidden fixed elements do not receive focus

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1915,7 +1915,10 @@ export function isDisplayNone(element: HTMLElement): boolean {
             return true;
         }
 
-        if (element.parentElement?.offsetParent === null && elementDocument.body !== element.parentElement) {
+        if (
+            element.parentElement?.offsetParent === null &&
+            elementDocument.body !== element.parentElement
+        ) {
             return true;
         }
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1902,10 +1902,21 @@ export function isDisplayNone(element: HTMLElement): boolean {
         return true;
     }
 
-    // For our purposes of looking for focusable elements, visibility:hidden has the same
-    // effect as display:none.
+    // check visibility:hidden
     if (computedStyle?.visibility === "hidden") {
         return true;
+    }
+
+    // if an element has display: fixed, we need to check if it is also hidden with CSS,
+    // or within a parent hidden with CSS
+    if (computedStyle?.position === "fixed") {
+        if (computedStyle.display === "none") {
+            return true;
+        }
+
+        if (element.parentElement?.offsetParent === null && elementDocument.body !== element.parentElement) {
+            return true;
+        }
     }
 
     return false;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1902,7 +1902,8 @@ export function isDisplayNone(element: HTMLElement): boolean {
         return true;
     }
 
-    // check visibility:hidden
+    // For our purposes of looking for focusable elements, visibility:hidden has the same
+    // effect as display:none.
     if (computedStyle?.visibility === "hidden") {
         return true;
     }

--- a/tests/Focusable.test.tsx
+++ b/tests/Focusable.test.tsx
@@ -530,59 +530,71 @@ describe("Focusable", () => {
                         <div style={{ visibility: "hidden" }}>
                             <button>Button3</button>
                         </div>
-                        <button style={{ visibility: "hidden" }}>Button4</button>
+                        <button style={{ visibility: "hidden" }}>
+                            Button4
+                        </button>
                         <button>Button5</button>
                     </div>
                 )
             )
-            .eval(() => {
-                return getTabsterTestVariables()
-                    .core?.focusable.findAll({ container: document.body })
-                    .map((el) => el.textContent);
-            })
-            .check((evalRet: string[]) => {
-                expect(evalRet).toEqual([
-                    "Button5",
-                ]);
-            });
+                .eval(() => {
+                    return getTabsterTestVariables()
+                        .core?.focusable.findAll({ container: document.body })
+                        .map((el) => el.textContent);
+                })
+                .check((evalRet: string[]) => {
+                    expect(evalRet).toEqual(["Button5"]);
+                });
         });
         it("should handle hidden fixed elements", async () => {
             await new BroTest.BroTest(
                 (
                     <div {...getTabsterAttribute({ root: {} })}>
-                        <button style={{ position: "fixed", display: "none" }}>Button1</button>
+                        <button style={{ position: "fixed", display: "none" }}>
+                            Button1
+                        </button>
                         <div style={{ position: "fixed", display: "none" }}>
                             <button>Button2</button>
                         </div>
                         <div style={{ display: "none" }}>
-                            <button style={{ position: "fixed" }}>Button3</button>
+                            <button style={{ position: "fixed" }}>
+                                Button3
+                            </button>
                         </div>
-                        <button style={{ position: "fixed", visibility: "hidden" }}>Button4</button>
-                        <div style={{ position: "fixed", visibility: "hidden" }}>
+                        <button
+                            style={{ position: "fixed", visibility: "hidden" }}
+                        >
+                            Button4
+                        </button>
+                        <div
+                            style={{ position: "fixed", visibility: "hidden" }}
+                        >
                             <button>Button5</button>
                         </div>
                         <div style={{ visibility: "hidden" }}>
-                            <button style={{ position: "fixed" }}>Button6</button>
+                            <button style={{ position: "fixed" }}>
+                                Button6
+                            </button>
                         </div>
                         <div style={{ visibility: "hidden" }}>
                             <div>
-                                <button style={{ position: "fixed" }}>Button6</button>
+                                <button style={{ position: "fixed" }}>
+                                    Button6
+                                </button>
                             </div>
                         </div>
                         <button>Button7</button>
                     </div>
                 )
             )
-            .eval(() => {
-                return getTabsterTestVariables()
-                    .core?.focusable.findAll({ container: document.body })
-                    .map((el) => el.textContent);
-            })
-            .check((evalRet: string[]) => {
-                expect(evalRet).toEqual([
-                    "Button7",
-                ]);
-            });
-        })
+                .eval(() => {
+                    return getTabsterTestVariables()
+                        .core?.focusable.findAll({ container: document.body })
+                        .map((el) => el.textContent);
+                })
+                .check((evalRet: string[]) => {
+                    expect(evalRet).toEqual(["Button7"]);
+                });
+        });
     });
 });

--- a/tests/Focusable.test.tsx
+++ b/tests/Focusable.test.tsx
@@ -517,4 +517,67 @@ describe("Focusable", () => {
                 });
         });
     });
+
+    describe("CSS styles affecting focusability", () => {
+        it("should ignore elements with display:none or visibility:hidden", async () => {
+            await new BroTest.BroTest(
+                (
+                    <div {...getTabsterAttribute({ root: {} })}>
+                        <div style={{ display: "none" }}>
+                            <button>Button1</button>
+                        </div>
+                        <button style={{ display: "none" }}>Button2</button>
+                        <div style={{ visibility: "hidden" }}>
+                            <button>Button3</button>
+                        </div>
+                        <button style={{ visibility: "hidden" }}>Button4</button>
+                        <button>Button5</button>
+                    </div>
+                )
+            )
+            .eval(() => {
+                return getTabsterTestVariables()
+                    .core?.focusable.findAll({ container: document.body })
+                    .map((el) => el.textContent);
+            })
+            .check((evalRet: string[]) => {
+                expect(evalRet).toEqual([
+                    "Button5",
+                ]);
+            });
+        });
+        it("should handle hidden fixed elements", async () => {
+            await new BroTest.BroTest(
+                (
+                    <div {...getTabsterAttribute({ root: {} })}>
+                        <button style={{ position: "fixed", display: "none" }}>Button1</button>
+                        <div style={{ position: "fixed", display: "none" }}>
+                            <button>Button2</button>
+                        </div>
+                        <div style={{ display: "none" }}>
+                            <button style={{ position: "fixed" }}>Button3</button>
+                        </div>
+                        <button style={{ position: "fixed", visibility: "hidden" }}>Button4</button>
+                        <div style={{ position: "fixed", visibility: "hidden" }}>
+                            <button>Button5</button>
+                        </div>
+                        <div style={{ visibility: "hidden" }}>
+                            <button style={{ position: "fixed" }}>Button6</button>
+                        </div>
+                        <button>Button7</button>
+                    </div>
+                )
+            )
+            .eval(() => {
+                return getTabsterTestVariables()
+                    .core?.focusable.findAll({ container: document.body })
+                    .map((el) => el.textContent);
+            })
+            .check((evalRet: string[]) => {
+                expect(evalRet).toEqual([
+                    "Button7",
+                ]);
+            });
+        })
+    });
 });

--- a/tests/Focusable.test.tsx
+++ b/tests/Focusable.test.tsx
@@ -564,6 +564,11 @@ describe("Focusable", () => {
                         <div style={{ visibility: "hidden" }}>
                             <button style={{ position: "fixed" }}>Button6</button>
                         </div>
+                        <div style={{ visibility: "hidden" }}>
+                            <div>
+                                <button style={{ position: "fixed" }}>Button6</button>
+                            </div>
+                        </div>
                         <button>Button7</button>
                     </div>
                 )


### PR DESCRIPTION
Related to #329

There's a bug where fixed elements that are hidden with `display: none`, or nested within another element with `display: none` were still treated as focusable.

This adds an additional check to `isDisplayNone` to catch fixed & hidden elements, as well as tests.