### PR TITLE
fix: add details > summary, audio, and video to focusable selector

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -14,6 +14,9 @@ export const FocusableSelector = [
     "textarea:not([disabled])",
     "*[tabindex]",
     "*[contenteditable]",
+    'details > summary',
+    'audio[controls]',
+    'video[controls]',
 ].join(", ");
 
 export interface TabsterDOMAttribute {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -707,7 +707,7 @@ export const RestorerTypes = {
     Target: 1,
 } as const;
 
-export type RestorerType = (typeof RestorerTypes)[keyof typeof RestorerTypes];
+export type RestorerType = typeof RestorerTypes[keyof typeof RestorerTypes];
 
 export const MoverDirections: MoverDirections = {
     Both: 0,

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -14,9 +14,9 @@ export const FocusableSelector = [
     "textarea:not([disabled])",
     "*[tabindex]",
     "*[contenteditable]",
-    'details > summary',
-    'audio[controls]',
-    'video[controls]',
+    "details > summary",
+    "audio[controls]",
+    "video[controls]",
 ].join(", ");
 
 export interface TabsterDOMAttribute {
@@ -707,7 +707,7 @@ export const RestorerTypes = {
     Target: 1,
 } as const;
 
-export type RestorerType = typeof RestorerTypes[keyof typeof RestorerTypes];
+export type RestorerType = (typeof RestorerTypes)[keyof typeof RestorerTypes];
 
 export const MoverDirections: MoverDirections = {
     Both: 0,


### PR DESCRIPTION
Adds missing elements to focusable selector (fixes a bug on the Fluent docs site).

It might also be worth considering taking a dependency on https://github.com/KittyGiraudel/focusable-selectors instead of maintaining this internally.