### PR TITLE
feat(Modalizer): Adding semi-internal noDirectAriaHidden flag to tap into the process of setting aria-hidden.

### DIFF
--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -767,9 +767,13 @@ export class ModalizerAPI implements Types.ModalizerAPI {
 
         const walk = (element: HTMLElement) => {
             for (
-                let el = dom.getFirstElementChild(element);
+                let el = dom.getFirstElementChild(
+                    element
+                ) as Types.HTMLElementWithTabsterFlags | null;
                 el;
-                el = dom.getNextElementSibling(el)
+                el = dom.getNextElementSibling(
+                    el
+                ) as Types.HTMLElementWithTabsterFlags | null
             ) {
                 let skip = false;
                 let containsModalizer = false;
@@ -796,7 +800,10 @@ export class ModalizerAPI implements Types.ModalizerAPI {
                         }
                     }
 
-                    if (containsModalizer) {
+                    if (
+                        containsModalizer ||
+                        el.__tabsterElementFlags?.noDirectAriaHidden
+                    ) {
                         walk(el as HTMLElement);
                     } else if (!skip && !containedByModalizer) {
                         toggle(el as HTMLElement, true);

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -21,6 +21,10 @@ export const FocusableSelector = [
 
 export interface HTMLElementWithTabsterFlags extends HTMLElement {
     __tabsterElementFlags?: {
+        /**
+         * @deprecated This option is added to support interop between Fluent UI V9 and Fluent UI V8.
+         * Once Fluent UI V8 is not supported anymore, this option should be removed.
+         */
         noDirectAriaHidden?: boolean; // When Modalizer sets aria-hidden on everything outside of the modal,
         // do not set aria-hidden directly on this element, go inside and check its children,
         // and set aria-hidden on the children. This is to be set on a container that hosts

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -19,6 +19,15 @@ export const FocusableSelector = [
     "video[controls]",
 ].join(", ");
 
+export interface HTMLElementWithTabsterFlags extends HTMLElement {
+    __tabsterElementFlags?: {
+        noDirectAriaHidden?: boolean; // When Modalizer sets aria-hidden on everything outside of the modal,
+        // do not set aria-hidden directly on this element, go inside and check its children,
+        // and set aria-hidden on the children. This is to be set on a container that hosts
+        // elements which have the active modal dialog as virtual parent.
+    };
+}
+
 export interface TabsterDOMAttribute {
     [TabsterAttributeName]: string | undefined;
 }

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -2318,6 +2318,188 @@ describe("Modalizer with checkAccessible callback", () => {
     });
 });
 
+describe("Modalizer with noDirectAriaHidden flag", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({ modalizer: true });
+    });
+
+    it.only("should not set aria-hidden on elements with noDirectAriaHidden flag", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div id="div1">
+                        <button>Button1</button>
+                    </div>
+                    <div
+                        id="div2"
+                        {...getTabsterAttribute({
+                            modalizer: { id: "modal", isTrapped: true },
+                        })}
+                    >
+                        <button id="button2">Button2</button>
+                    </div>
+                    <div id="div3">
+                        <button id="button3">Button3</button>
+                        <div id="div4">
+                            <button id="button4">Button4</button>
+                        </div>
+                        <div id="div5">
+                            <button id="button5">Button5</button>
+                        </div>
+                    </div>
+                </div>
+            )
+        )
+            .focusElement("#button2")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .wait(500)
+            .eval(() => [
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div1")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div2")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div3")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div4")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div5")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button3")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button4")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button5")
+                    ?.hasAttribute("aria-hidden"),
+            ])
+            .check(
+                ([div1, div2, div3, div4, div5, button3, button4, button5]) => {
+                    expect(div1).toEqual(true);
+                    expect(div2).toEqual(false);
+                    expect(div3).toEqual(true);
+                    expect(div4).toEqual(false);
+                    expect(div5).toEqual(false);
+                    expect(button3).toEqual(false);
+                    expect(button4).toEqual(false);
+                    expect(button5).toEqual(false);
+                }
+            )
+            .focusElement("#button3")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button3");
+            })
+            .wait(500)
+            .eval(() => [
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div1")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div2")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div3")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div4")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div5")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button3")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button4")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button5")
+                    ?.hasAttribute("aria-hidden"),
+            ])
+            .check(
+                ([div1, div2, div3, div4, div5, button3, button4, button5]) => {
+                    expect(div1).toEqual(false);
+                    expect(div2).toEqual(true);
+                    expect(div3).toEqual(false);
+                    expect(div4).toEqual(false);
+                    expect(div5).toEqual(false);
+                    expect(button3).toEqual(false);
+                    expect(button4).toEqual(false);
+                    expect(button5).toEqual(false);
+                }
+            )
+            .eval(() => {
+                const div3 = getTabsterTestVariables().dom?.getElementById(
+                    document,
+                    "div3"
+                ) as Types.HTMLElementWithTabsterFlags | null;
+                const div4 = getTabsterTestVariables().dom?.getElementById(
+                    document,
+                    "div4"
+                ) as Types.HTMLElementWithTabsterFlags | null;
+
+                if (div3) {
+                    div3.__tabsterElementFlags = { noDirectAriaHidden: true };
+                }
+
+                if (div4) {
+                    div4.__tabsterElementFlags = { noDirectAriaHidden: true };
+                }
+            })
+            .focusElement("#button2")
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .wait(500)
+            .eval(() => [
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div1")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div2")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div3")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div4")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "div5")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button3")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button4")
+                    ?.hasAttribute("aria-hidden"),
+                getTabsterTestVariables()
+                    .dom?.getElementById(document, "button5")
+                    ?.hasAttribute("aria-hidden"),
+            ])
+            .check(
+                ([div1, div2, div3, div4, div5, button3, button4, button5]) => {
+                    expect(div1).toEqual(true);
+                    expect(div2).toEqual(false);
+                    expect(div3).toEqual(false);
+                    expect(div4).toEqual(false);
+                    expect(div5).toEqual(true);
+                    expect(button3).toEqual(true);
+                    expect(button4).toEqual(true);
+                    expect(button5).toEqual(false);
+                }
+            );
+    });
+});
+
 describe("Modalizer with tabster:movefocus event handling", () => {
     beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ modalizer: true });


### PR DESCRIPTION
When Modalizer sets aria-hidden for elements outside of active modalizer, it checks if the element is inside the modalizer first. In combination with custom getParent() this allows to avoid setting aria-hidden on elements which are virtually part of the modalizer (like popups rendered to body). However, this is not enough when the virtual children are placed into an extra container. noDirectAriaHidden could be set on the container and instead of setting aria-hidden directly,  Modalizer will go inside the container and set aria-hidden on its children considering the virtual parenthood of each child.