### PR TITLE
getDummyInputContainer() utility function.

### DIFF
--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -28,6 +28,7 @@ import {
     startFakeWeakRefsCleanup,
     stopFakeWeakRefsCleanupAndClearStorage,
     DummyInputObserver,
+    getDummyInputContainer,
 } from "./Utils";
 import { RestorerAPI } from "./Restorer";
 import { dom, setDOMAPI } from "./DOMAPI";
@@ -36,6 +37,7 @@ import * as shadowDOMAPI from "./Shadowdomize";
 export { Types };
 export { Events };
 export * from "./AttributeHelpers";
+export { getDummyInputContainer };
 
 class Tabster implements Types.Tabster {
     keyboardNavigation: Types.KeyboardNavigationState;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1925,3 +1925,18 @@ export function isDisplayNone(element: HTMLElement): boolean {
 
     return false;
 }
+
+/**
+ * If the passed element is Tabster dummy input, returns the container element this dummy input belongs to.
+ * @param element Element to check for being dummy input.
+ * @returns Dummy input container element (if the passed element is a dummy input) or null.
+ */
+export function getDummyInputContainer(
+    element: HTMLElement
+): HTMLElement | null {
+    return (
+        (
+            element as HTMLElementWithDummyContainer
+        ).__tabsterDummyContainer?.get() || null
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export {
     makeNoOp,
     isNoOp,
     getShadowDOMAPI,
+    getDummyInputContainer,
     Types,
     Events,
 } from "./Tabster";

--- a/tests/index.html
+++ b/tests/index.html
@@ -19,6 +19,7 @@
                 mergeTabsterProps,
                 getTabsterAttribute,
                 setTabsterAttribute,
+                getDummyInputContainer,
             } from "../src";
             import * as Events from "../src/Events";
             import * as shadowDOM from "../src/Shadowdomize";
@@ -55,6 +56,7 @@
             tabsterTest.getTabsterAttribute = getTabsterAttribute;
             tabsterTest.setTabsterAttribute = setTabsterAttribute;
             tabsterTest.mergeTabsterProps = mergeTabsterProps;
+            tabsterTest.getDummyInputContainer = getDummyInputContainer;
             tabsterTest.dom = dom;
             tabsterTest.shadowDOM = shadowDOM;
             tabsterTest.Events = Events;

--- a/tests/utils/BroTest.ts
+++ b/tests/utils/BroTest.ts
@@ -21,6 +21,7 @@ import {
     mergeTabsterProps,
     setTabsterAttribute,
     getRestorer,
+    getDummyInputContainer,
     Types,
     Events,
 } from "tabster";
@@ -117,6 +118,7 @@ export interface BroTestTabsterTestVariables {
     getTabsterAttribute?: typeof getTabsterAttribute;
     setTabsterAttribute?: typeof setTabsterAttribute;
     mergeTabsterProps?: typeof mergeTabsterProps;
+    getDummyInputContainer?: typeof getDummyInputContainer;
     core?: Types.Tabster;
     modalizer?: Types.ModalizerAPI;
     deloser?: Types.DeloserAPI;


### PR DESCRIPTION
Sometimes it might be useful to be able to distinguish if an element is a dummy input in the application code. Exposing a function for that.