### PR TITLE
fix(Mover): Checking that memorized element is still focusable.

### DIFF
--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -76,7 +76,8 @@ class MoverDummyManager extends DummyInputManager {
             }
 
             const memorized = this._getMemorized()?.get();
-            if (memorized) {
+
+            if (memorized && this._tabster.focusable.isFocusable(memorized)) {
                 toFocus = memorized;
             }
 

--- a/tests/Mover.test.tsx
+++ b/tests/Mover.test.tsx
@@ -592,6 +592,42 @@ describe("Mover memorizing current", () => {
                 expect(el?.textContent).toEqual("Button4");
             });
     });
+
+    it("should move to first element when the previously memorized one is removed from DOM", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        {...getTabsterAttribute({
+                            mover: { memorizeCurrent: true },
+                        })}
+                    >
+                        <button>Button1</button>
+                        <button id="button2">Button2</button>
+                        <button>Button3</button>
+                        <button>Button4</button>
+                    </div>
+                </div>
+            )
+        )
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button1");
+            })
+            .pressDown()
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button2");
+            })
+            .pressTab()
+            .activeElement((el) => {
+                expect(el?.textContent).toBeUndefined();
+            })
+            .removeElement("#button2")
+            .pressTab(true)
+            .activeElement((el) => {
+                expect(el?.textContent).toEqual("Button4");
+            });
+    });
 });
 
 describe("Mover with excluded part", () => {


### PR DESCRIPTION
Making sure Mover doesn't try to focus memorized element that is removed from DOM, but hasn't been garbage collected yet.