### PR TITLE
chore: bump loader-utils and shell-quote deps 

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -15099,10 +15099,9 @@
             }
         },
         "node_modules/loader-utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-            "license": "MIT",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -18195,10 +18194,9 @@
             }
         },
         "node_modules/react-dev-utils/node_modules/loader-utils": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-            "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==",
-            "license": "MIT",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
+            "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
             "engines": {
                 "node": ">= 12.13.0"
             }
@@ -33911,9 +33909,9 @@
             "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
         },
         "loader-utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -35948,9 +35946,9 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
                 },
                 "loader-utils": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-                    "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ=="
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
+                    "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg=="
                 },
                 "locate-path": {
                     "version": "6.0.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -20011,10 +20011,12 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-            "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-            "license": "MIT"
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
@@ -37262,9 +37264,9 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "shell-quote": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-            "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA=="
         },
         "shelljs": {
             "version": "0.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4336,20 +4336,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/@mdx-js/loader/node_modules/loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
-        },
         "node_modules/@mdx-js/mdx": {
             "version": "1.6.22",
             "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.22.tgz",
@@ -8372,6 +8358,20 @@
                 "webpack": "^4.27.0 || ^5.0.0"
             }
         },
+        "node_modules/@storybook/builder-webpack5/node_modules/css-loader/node_modules/loader-utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
         "node_modules/@storybook/builder-webpack5/node_modules/css-loader/node_modules/semver": {
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -8450,20 +8450,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6.11.5"
-            }
-        },
-        "node_modules/@storybook/builder-webpack5/node_modules/loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
             }
         },
         "node_modules/@storybook/builder-webpack5/node_modules/path-browserify": {
@@ -8620,6 +8606,20 @@
             },
             "peerDependencies": {
                 "webpack": "^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/@storybook/builder-webpack5/node_modules/style-loader/node_modules/loader-utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
             }
         },
         "node_modules/@storybook/builder-webpack5/node_modules/terser-webpack-plugin": {
@@ -11031,6 +11031,20 @@
                 "webpack": "^4.27.0 || ^5.0.0"
             }
         },
+        "node_modules/@storybook/manager-webpack5/node_modules/css-loader/node_modules/loader-utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
         "node_modules/@storybook/manager-webpack5/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -11103,20 +11117,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6.11.5"
-            }
-        },
-        "node_modules/@storybook/manager-webpack5/node_modules/loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
             }
         },
         "node_modules/@storybook/manager-webpack5/node_modules/postcss": {
@@ -11282,6 +11282,20 @@
             },
             "peerDependencies": {
                 "webpack": "^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/@storybook/manager-webpack5/node_modules/style-loader/node_modules/loader-utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
             }
         },
         "node_modules/@storybook/manager-webpack5/node_modules/supports-color": {
@@ -26494,29 +26508,17 @@
             }
         },
         "node_modules/loader-utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
             "dev": true,
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
+                "json5": "^2.1.2"
             },
             "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/loader-utils/node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
+                "node": ">=8.9.0"
             }
         },
         "node_modules/locate-path": {
@@ -38846,20 +38848,7 @@
             "requires": {
                 "@mdx-js/mdx": "1.6.22",
                 "@mdx-js/react": "1.6.22",
-                "loader-utils": "2.0.0"
-            },
-            "dependencies": {
-                "loader-utils": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                }
+                "loader-utils": "^2.0.3"
             }
         },
         "@mdx-js/mdx": {
@@ -39998,7 +39987,7 @@
                 "global": "^4.4.0",
                 "html-tags": "^3.1.0",
                 "js-string-escape": "^1.0.1",
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "lodash": "^4.17.21",
                 "nanoid": "^3.1.23",
                 "p-limit": "^3.1.0",
@@ -41800,7 +41789,7 @@
                     "dev": true,
                     "requires": {
                         "icss-utils": "^5.1.0",
-                        "loader-utils": "^2.0.0",
+                        "loader-utils": "^2.0.3",
                         "postcss": "^8.2.15",
                         "postcss-modules-extract-imports": "^3.0.0",
                         "postcss-modules-local-by-default": "^4.0.0",
@@ -41811,6 +41800,17 @@
                         "semver": "^7.3.5"
                     },
                     "dependencies": {
+                        "loader-utils": {
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+                            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+                            "dev": true,
+                            "requires": {
+                                "big.js": "^5.2.2",
+                                "emojis-list": "^3.0.0",
+                                "json5": "^2.1.2"
+                            }
+                        },
                         "semver": {
                             "version": "7.3.5",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -41862,17 +41862,6 @@
                     "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
                     "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
                     "dev": true
-                },
-                "loader-utils": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-                    "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
                 },
                 "path-browserify": {
                     "version": "1.0.1",
@@ -41980,8 +41969,21 @@
                     "integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
                     "dev": true,
                     "requires": {
-                        "loader-utils": "^2.0.0",
+                        "loader-utils": "^2.0.3",
                         "schema-utils": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "loader-utils": {
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+                            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+                            "dev": true,
+                            "requires": {
+                                "big.js": "^5.2.2",
+                                "emojis-list": "^3.0.0",
+                                "json5": "^2.1.2"
+                            }
+                        }
                     }
                 },
                 "terser-webpack-plugin": {
@@ -43770,7 +43772,7 @@
                     "dev": true,
                     "requires": {
                         "icss-utils": "^5.1.0",
-                        "loader-utils": "^2.0.0",
+                        "loader-utils": "^2.0.3",
                         "postcss": "^8.2.15",
                         "postcss-modules-extract-imports": "^3.0.0",
                         "postcss-modules-local-by-default": "^4.0.0",
@@ -43779,6 +43781,19 @@
                         "postcss-value-parser": "^4.1.0",
                         "schema-utils": "^3.0.0",
                         "semver": "^7.3.5"
+                    },
+                    "dependencies": {
+                        "loader-utils": {
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+                            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+                            "dev": true,
+                            "requires": {
+                                "big.js": "^5.2.2",
+                                "emojis-list": "^3.0.0",
+                                "json5": "^2.1.2"
+                            }
+                        }
                     }
                 },
                 "has-flag": {
@@ -43827,17 +43842,6 @@
                     "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
                     "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
                     "dev": true
-                },
-                "loader-utils": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-                    "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
                 },
                 "postcss": {
                     "version": "8.4.6",
@@ -43948,8 +43952,21 @@
                     "integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
                     "dev": true,
                     "requires": {
-                        "loader-utils": "^2.0.0",
+                        "loader-utils": "^2.0.3",
                         "schema-utils": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "loader-utils": {
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+                            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+                            "dev": true,
+                            "requires": {
+                                "big.js": "^5.2.2",
+                                "emojis-list": "^3.0.0",
+                                "json5": "^2.1.2"
+                            }
+                        }
                     }
                 },
                 "supports-color": {
@@ -44326,7 +44343,7 @@
                 "core-js": "^3.8.2",
                 "estraverse": "^5.2.0",
                 "global": "^4.4.0",
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "lodash": "^4.17.21",
                 "prettier": ">=2.2.1 <=2.3.0",
                 "regenerator-runtime": "^0.13.7"
@@ -46355,7 +46372,7 @@
             "dev": true,
             "requires": {
                 "find-cache-dir": "^3.3.1",
-                "loader-utils": "^1.4.0",
+                "loader-utils": "^2.0.3",
                 "make-dir": "^3.1.0",
                 "schema-utils": "^2.6.5"
             },
@@ -48370,7 +48387,7 @@
                 "camelcase": "^5.3.1",
                 "cssesc": "^3.0.0",
                 "icss-utils": "^4.1.1",
-                "loader-utils": "^1.2.3",
+                "loader-utils": "^2.0.3",
                 "normalize-path": "^3.0.0",
                 "postcss": "^7.0.32",
                 "postcss-modules-extract-imports": "^2.0.0",
@@ -50251,7 +50268,7 @@
             "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
             "dev": true,
             "requires": {
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
@@ -51603,7 +51620,7 @@
             "requires": {
                 "html-minifier-terser": "^5.1.1",
                 "htmlparser2": "^4.1.0",
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
@@ -51711,7 +51728,7 @@
                 "@types/tapable": "^1.0.5",
                 "@types/webpack": "^4.41.8",
                 "html-minifier-terser": "^5.0.1",
-                "loader-utils": "^1.2.3",
+                "loader-utils": "^2.0.3",
                 "lodash": "^4.17.20",
                 "pretty-error": "^2.1.1",
                 "tapable": "^1.1.3",
@@ -55700,25 +55717,14 @@
             "dev": true
         },
         "loader-utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
             "dev": true,
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
-            },
-            "dependencies": {
-                "json5": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-                    "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                }
+                "json5": "^2.1.2"
             }
         },
         "locate-path": {
@@ -57469,7 +57475,7 @@
             "requires": {
                 "cosmiconfig": "^7.0.0",
                 "klona": "^2.0.4",
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "schema-utils": "^3.0.0",
                 "semver": "^7.3.4"
             },
@@ -57994,7 +58000,7 @@
             "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
             "dev": true,
             "requires": {
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "schema-utils": "^3.0.0"
             },
             "dependencies": {
@@ -60330,7 +60336,7 @@
             "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
             "dev": true,
             "requires": {
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "schema-utils": "^2.7.0"
             },
             "dependencies": {
@@ -61468,7 +61474,7 @@
             "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
             "dev": true,
             "requires": {
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "mime-types": "^2.1.27",
                 "schema-utils": "^3.0.0"
             },
@@ -62060,7 +62066,7 @@
                 "eslint-scope": "^4.0.3",
                 "json-parse-better-errors": "^1.0.2",
                 "loader-runner": "^2.4.0",
-                "loader-utils": "^1.2.3",
+                "loader-utils": "^2.0.3",
                 "memory-fs": "^0.4.1",
                 "micromatch": "^3.1.10",
                 "mkdirp": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -106,5 +106,8 @@
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "typescript": "^4.9.4",
         "vite": "^2.9.12"
+    },
+    "overrides": {
+        "loader-utils": "^2.0.3"
     }
 }


### PR DESCRIPTION
- bumps vulnerable `loader-utils` and `shell-quote` deps to versions where fix was employed. Fix for `loader-utils` is version `2.0.3` and up while for `shell-quote` it's version `1.7.3` and up.
  - had to use `override` `loader-utils` for root `package.json` because the repo relies on storybook 6 which brings in webpack 4 and that uses version`1.x` of `loader-utils`. Upgrading from storybook 6 is a big undertaking so skipped that step in this case.
  
   <img width="451" alt="image" src="https://github.com/user-attachments/assets/114cde78-dc78-4baf-9552-da1a6cc9f221">

  - bumps made in `docs/` `package.json` were simply done with `npm update loader-utils` and `npm update shell-quote` respectively
