### PR TITLE
fix(modalizer): stop focus from leaving trapped modal w/ no focusable descendants

### DIFF
--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -272,6 +272,10 @@ export class Modalizer
                     findPropsOut
                 );
 
+                if (next === null) {
+                    next = currentElement;
+                }
+
                 outOfDOMOrder = true;
             } else {
                 outOfDOMOrder = !!findPropsOut.outOfDOMOrder;

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -2705,3 +2705,30 @@ describe("Modalizer with virtual parents provided by getParent()", () => {
             );
     });
 });
+
+describe("Modal with focus trap", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage();
+    });
+
+    it("should not escape modalizer if it has no focusables", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <div
+                        aria-label="modal"
+                        {...getTabsterAttribute({
+                            modalizer: { id: "modal", isTrapped: true },
+                        })}
+                    >
+                        Hello
+                    </div>
+                </div>
+            )
+        )
+        .focusElement('#modal')
+        .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
+        .pressTab()
+        .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
+    });
+})

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -432,6 +432,29 @@ describe("Modalizer", () => {
                 .pressTab()
                 .activeElement((el) => expect(el?.attributes.id).toBe("foo"));
         });
+
+        it("if trapped, should not escape modalizer if it has no focusables", async () => {
+            await new BroTest.BroTest(
+                (
+                    <div {...getTabsterAttribute({ root: {} })}>
+                        <div
+                            id="modal"
+                            aria-label="modal"
+                            {...getTabsterAttribute({
+                                modalizer: { id: "modal", isTrapped: true },
+                            })}
+                            tabIndex={0}
+                        >
+                            Hello
+                        </div>
+                    </div>
+                )
+            )
+            .focusElement('#modal')
+            .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
+            .pressTab()
+            .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
+        });
     });
 });
 
@@ -2705,32 +2728,3 @@ describe("Modalizer with virtual parents provided by getParent()", () => {
             );
     });
 });
-
-describe("Modal with focus trap", () => {
-    beforeEach(async () => {
-        await BroTest.bootstrapTabsterPage();
-    });
-
-    it("should not escape modalizer if it has no focusables", async () => {
-        await new BroTest.BroTest(
-            (
-                <div {...getTabsterAttribute({ root: {} })}>
-                    <div
-                        id="modal"
-                        aria-label="modal"
-                        {...getTabsterAttribute({
-                            modalizer: { id: "modal", isTrapped: true },
-                        })}
-                        tabIndex={0}
-                    >
-                        Hello
-                    </div>
-                </div>
-            )
-        )
-        .focusElement('#modal')
-        .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
-        .pressTab()
-        .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
-    });
-})

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -2716,10 +2716,12 @@ describe("Modal with focus trap", () => {
             (
                 <div {...getTabsterAttribute({ root: {} })}>
                     <div
+                        id="modal"
                         aria-label="modal"
                         {...getTabsterAttribute({
                             modalizer: { id: "modal", isTrapped: true },
                         })}
+                        tabIndex={0}
                     >
                         Hello
                     </div>

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -450,10 +450,12 @@ describe("Modalizer", () => {
                     </div>
                 )
             )
-            .focusElement('#modal')
-            .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
-            .pressTab()
-            .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
+                .focusElement("#modal")
+                .activeElement((el) => expect(el?.textContent).toEqual("Hello"))
+                .pressTab()
+                .activeElement((el) =>
+                    expect(el?.textContent).toEqual("Hello")
+                );
         });
     });
 });


### PR DESCRIPTION
  For a trapped modal with no focusable descendants, tabster should prevent focus from leaving it.