### PR TITLE
ci(release): invoke npm install directly instead of using azure task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,10 +53,9 @@ extends:
                 inputs:
                   versionSpec: 16.x
             
-              - task: Npm@1
+              - script: | 
+                  npm install
                 displayName: npm install
-                inputs:
-                  verbose: false
             
               - task: CmdLine@2
                 displayName: Authenticate git for pushes


### PR DESCRIPTION
## Issue:
Release pipeline is hanging on `Npm@1` task

<img width="855" alt="image" src="https://github.com/user-attachments/assets/3d35d82b-d6e8-4a7e-bf00-7341ef40b394">


## Changes:
Now using `npm install` command directly which will hopefully fix the issue