### PR TITLE
ci(release): fix npm install hang and address critical security deps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ extends:
                   versionSpec: 16.x
             
               - script: | 
-                  npm install --verbose
+                  npm install --no-audit --verbose
                 displayName: npm install 
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,12 +49,12 @@ extends:
                     git pull
             
               - task: UseNode@1
-                displayName: Use Node 16.x
+                displayName: Use Node 18.x
                 inputs:
-                  version: '16.x'
+                  version: '18.x'
             
               - script: | 
-                  npm install --no-audit --verbose
+                  npm install --verbose
                 displayName: npm install
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,10 +53,9 @@ extends:
                 inputs:
                   version: '16.x'
             
-              - task: Npm@1
+              - script: | 
+                  npm install --no-audit --verbose
                 displayName: npm install
-                inputs:
-                  verbose: true
             
               # - task: CmdLine@2
               #   displayName: Authenticate git for pushes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,11 +49,11 @@ extends:
                     git pull
             
               - task: UseNode@1
-                displayName: Use Node 16.x
+                displayName: Use Node 18.x
                 inputs:
-                  version: 16.x
+                  version: 18.x
             
-              - script: npm ci --verbose
+              - script: npm ci --no-audit --verbose
                 displayName: 'npm install'
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,19 +41,19 @@ extends:
               - checkout: self
                 clean: true
             
-              # - task: CmdLine@2
-              #   displayName: Re-attach head
-              #   inputs:
-              #     script: |
-              #       git checkout --track "origin/${BUILD_SOURCEBRANCH//refs\/heads\/}"
-              #       git pull
+              - task: CmdLine@2
+                displayName: Re-attach head
+                inputs:
+                  script: |
+                    git checkout --track "origin/${BUILD_SOURCEBRANCH//refs\/heads\/}"
+                    git pull
             
               - task: UseNode@1
                 displayName: Use Node 16.x
                 inputs:
                   version: 16.x
             
-              - script: npm install --verbose
+              - script: npm ci 
                 displayName: 'npm install'
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ extends:
                   versionSpec: 16.x
             
               - script: | 
-                  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install
+                  PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public npm install
                 displayName: npm install
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,13 +48,14 @@ extends:
                     git checkout --track "origin/${BUILD_SOURCEBRANCH//refs\/heads\/}"
                     git pull
             
-              - task: UseNode@1
-                displayName: Use Node 18.x
+              - task: NodeTool@0
+                displayName: Use Node 16.x
                 inputs:
-                  version: '18.x'
+                  versionSpec: 16.x
             
-              - script: | 
-                  npm install --verbose --no-audit
+              - task: Npm@1.241.1
+                inputs:
+                  verbose: true
                 displayName: npm install
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,19 +41,19 @@ extends:
               - checkout: self
                 clean: true
             
-              - task: CmdLine@2
-                displayName: Re-attach head
-                inputs:
-                  script: |
-                    git checkout --track "origin/${BUILD_SOURCEBRANCH//refs\/heads\/}"
-                    git pull
+              # - task: CmdLine@2
+              #   displayName: Re-attach head
+              #   inputs:
+              #     script: |
+              #       git checkout --track "origin/${BUILD_SOURCEBRANCH//refs\/heads\/}"
+              #       git pull
             
               - task: UseNode@1
-                displayName: Use Node 18.x
+                displayName: Use Node 16.x
                 inputs:
-                  version: 18.x
+                  version: 16.x
             
-              - script: npm ci --no-audit --verbose
+              - script: npm install --verbose
                 displayName: 'npm install'
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,12 +48,13 @@ extends:
                     git checkout --track "origin/${BUILD_SOURCEBRANCH//refs\/heads\/}"
                     git pull
             
-              - task: UseNode@1
+              - task: NodeTool@0
                 displayName: Use Node 16.x
                 inputs:
-                  version: 16.x
+                  versionSpec: 16.x
             
-              - script: npm install 
+              - script: | 
+                  npm install 
                 displayName: 'npm install'
             
               - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ extends:
                 inputs:
                   version: 16.x
             
-              - script: npm ci 
+              - script: npm install 
                 displayName: 'npm install'
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ extends:
               - task: UseNode@1
                 displayName: Use Node 16.x
                 inputs:
-                  versionSpec: 16.x
+                  version: '16.x'
             
               - task: Npm@1
                 displayName: npm install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,34 +56,34 @@ extends:
               - script: npm install 
                 displayName: 'npm install'
             
-              # - task: CmdLine@2
-              #   displayName: Authenticate git for pushes
-              #   inputs:
-              #     script: >-
-              #       git config user.name "Tabster Build"
+              - task: CmdLine@2
+                displayName: Authenticate git for pushes
+                inputs:
+                  script: >-
+                    git config user.name "Tabster Build"
             
-              #       git config user.email "fluentui-internal@service.microsoft.com"
+                    git config user.email "fluentui-internal@service.microsoft.com"
             
-              #       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/tabster.git
+                    git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/tabster.git
             
-              # - task: CmdLine@2
-              #   displayName: Write npmrc for publish token
-              #   inputs:
-              #     script: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
-              #   condition: eq(variables.skipPublish, false)
+              - task: CmdLine@2
+                displayName: Write npmrc for publish token
+                inputs:
+                  script: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+                condition: eq(variables.skipPublish, false)
             
-              # - task: CmdLine@2
-              #   displayName: Publish (official)
-              #   condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, false))
-              #   inputs:
-              #     script: 'npm run release -- $(publishVersion) --ci '
-              #   env:
-              #       NPM_TOKEN: $(npmToken)
+              - task: CmdLine@2
+                displayName: Publish (official)
+                condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, false))
+                inputs:
+                  script: 'npm run release -- $(publishVersion) --ci '
+                env:
+                    NPM_TOKEN: $(npmToken)
             
-              # - task: CmdLine@2
-              #   displayName: Publish (prerelease)
-              #   condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, true))
-              #   inputs:
-              #     script: npm run release -- $(publishVersion) --preRelease $(prereleaseTag) --ci
-              #   env:
-              #       NPM_TOKEN: $(npmToken)
+              - task: CmdLine@2
+                displayName: Publish (prerelease)
+                condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, true))
+                inputs:
+                  script: npm run release -- $(publishVersion) --preRelease $(prereleaseTag) --ci
+                env:
+                    NPM_TOKEN: $(npmToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,8 +54,8 @@ extends:
                   versionSpec: 16.x
             
               - script: | 
-                  npm install
-                displayName: npm install --verbose
+                  npm install --verbose
+                displayName: npm install 
             
               # - task: CmdLine@2
               #   displayName: Authenticate git for pushes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ extends:
                   version: '18.x'
             
               - script: | 
-                  npm install --verbose
+                  npm install --verbose --no-audit
                 displayName: npm install
             
               # - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,37 +54,37 @@ extends:
                   versionSpec: 16.x
             
               - script: | 
-                  npm install 
-                displayName: 'npm install'
+                  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install
+                displayName: npm install
             
-              - task: CmdLine@2
-                displayName: Authenticate git for pushes
-                inputs:
-                  script: >-
-                    git config user.name "Tabster Build"
+              # - task: CmdLine@2
+              #   displayName: Authenticate git for pushes
+              #   inputs:
+              #     script: >-
+              #       git config user.name "Tabster Build"
             
-                    git config user.email "fluentui-internal@service.microsoft.com"
+              #       git config user.email "fluentui-internal@service.microsoft.com"
             
-                    git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/tabster.git
+              #       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/tabster.git
             
-              - task: CmdLine@2
-                displayName: Write npmrc for publish token
-                inputs:
-                  script: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
-                condition: eq(variables.skipPublish, false)
+              # - task: CmdLine@2
+              #   displayName: Write npmrc for publish token
+              #   inputs:
+              #     script: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+              #   condition: eq(variables.skipPublish, false)
             
-              - task: CmdLine@2
-                displayName: Publish (official)
-                condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, false))
-                inputs:
-                  script: 'npm run release -- $(publishVersion) --ci '
-                env:
-                    NPM_TOKEN: $(npmToken)
+              # - task: CmdLine@2
+              #   displayName: Publish (official)
+              #   condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, false))
+              #   inputs:
+              #     script: 'npm run release -- $(publishVersion) --ci '
+              #   env:
+              #       NPM_TOKEN: $(npmToken)
             
-              - task: CmdLine@2
-                displayName: Publish (prerelease)
-                condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, true))
-                inputs:
-                  script: npm run release -- $(publishVersion) --preRelease $(prereleaseTag) --ci
-                env:
-                    NPM_TOKEN: $(npmToken)
+              # - task: CmdLine@2
+              #   displayName: Publish (prerelease)
+              #   condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, true))
+              #   inputs:
+              #     script: npm run release -- $(publishVersion) --preRelease $(prereleaseTag) --ci
+              #   env:
+              #       NPM_TOKEN: $(npmToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,39 +52,41 @@ extends:
                 displayName: Use Node 16.x
                 inputs:
                   versionSpec: 16.x
-            
+              # PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public is a workaround for puppeteer 
+              # as puppeteer versions <22.0.0 will cause npm install to hang in CI environments.
+              # see issue: https://github.com/puppeteer/puppeteer/issues/12833
               - script: | 
                   PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public npm install
                 displayName: npm install
             
-              # - task: CmdLine@2
-              #   displayName: Authenticate git for pushes
-              #   inputs:
-              #     script: >-
-              #       git config user.name "Tabster Build"
+              - task: CmdLine@2
+                displayName: Authenticate git for pushes
+                inputs:
+                  script: >-
+                    git config user.name "Tabster Build"
             
-              #       git config user.email "fluentui-internal@service.microsoft.com"
+                    git config user.email "fluentui-internal@service.microsoft.com"
             
-              #       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/tabster.git
+                    git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/tabster.git
             
-              # - task: CmdLine@2
-              #   displayName: Write npmrc for publish token
-              #   inputs:
-              #     script: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
-              #   condition: eq(variables.skipPublish, false)
+              - task: CmdLine@2
+                displayName: Write npmrc for publish token
+                inputs:
+                  script: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+                condition: eq(variables.skipPublish, false)
             
-              # - task: CmdLine@2
-              #   displayName: Publish (official)
-              #   condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, false))
-              #   inputs:
-              #     script: 'npm run release -- $(publishVersion) --ci '
-              #   env:
-              #       NPM_TOKEN: $(npmToken)
+              - task: CmdLine@2
+                displayName: Publish (official)
+                condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, false))
+                inputs:
+                  script: 'npm run release -- $(publishVersion) --ci '
+                env:
+                    NPM_TOKEN: $(npmToken)
             
-              # - task: CmdLine@2
-              #   displayName: Publish (prerelease)
-              #   condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, true))
-              #   inputs:
-              #     script: npm run release -- $(publishVersion) --preRelease $(prereleaseTag) --ci
-              #   env:
-              #       NPM_TOKEN: $(npmToken)
+              - task: CmdLine@2
+                displayName: Publish (prerelease)
+                condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, true))
+                inputs:
+                  script: npm run release -- $(publishVersion) --preRelease $(prereleaseTag) --ci
+                env:
+                    NPM_TOKEN: $(npmToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,36 +55,36 @@ extends:
             
               - script: | 
                   npm install
-                displayName: npm install
+                displayName: npm install --verbose
             
-              - task: CmdLine@2
-                displayName: Authenticate git for pushes
-                inputs:
-                  script: >-
-                    git config user.name "Tabster Build"
+              # - task: CmdLine@2
+              #   displayName: Authenticate git for pushes
+              #   inputs:
+              #     script: >-
+              #       git config user.name "Tabster Build"
             
-                    git config user.email "fluentui-internal@service.microsoft.com"
+              #       git config user.email "fluentui-internal@service.microsoft.com"
             
-                    git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/tabster.git
+              #       git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/tabster.git
             
-              - task: CmdLine@2
-                displayName: Write npmrc for publish token
-                inputs:
-                  script: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
-                condition: eq(variables.skipPublish, false)
+              # - task: CmdLine@2
+              #   displayName: Write npmrc for publish token
+              #   inputs:
+              #     script: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+              #   condition: eq(variables.skipPublish, false)
             
-              - task: CmdLine@2
-                displayName: Publish (official)
-                condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, false))
-                inputs:
-                  script: 'npm run release -- $(publishVersion) --ci '
-                env:
-                    NPM_TOKEN: $(npmToken)
+              # - task: CmdLine@2
+              #   displayName: Publish (official)
+              #   condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, false))
+              #   inputs:
+              #     script: 'npm run release -- $(publishVersion) --ci '
+              #   env:
+              #       NPM_TOKEN: $(npmToken)
             
-              - task: CmdLine@2
-                displayName: Publish (prerelease)
-                condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, true))
-                inputs:
-                  script: npm run release -- $(publishVersion) --preRelease $(prereleaseTag) --ci
-                env:
-                    NPM_TOKEN: $(npmToken)
+              # - task: CmdLine@2
+              #   displayName: Publish (prerelease)
+              #   condition: and(eq(variables.skipPublish, false), eq(variables.prerelease, true))
+              #   inputs:
+              #     script: npm run release -- $(publishVersion) --preRelease $(prereleaseTag) --ci
+              #   env:
+              #       NPM_TOKEN: $(npmToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,14 +48,15 @@ extends:
                     git checkout --track "origin/${BUILD_SOURCEBRANCH//refs\/heads\/}"
                     git pull
             
-              - task: NodeTool@0
+              - task: UseNode@1
                 displayName: Use Node 16.x
                 inputs:
                   versionSpec: 16.x
             
-              - script: | 
-                  npm install --no-audit --verbose
-                displayName: npm install 
+              - task: Npm@1
+                displayName: npm install
+                inputs:
+                  verbose: true
             
               # - task: CmdLine@2
               #   displayName: Authenticate git for pushes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,16 +48,13 @@ extends:
                     git checkout --track "origin/${BUILD_SOURCEBRANCH//refs\/heads\/}"
                     git pull
             
-              - task: NodeTool@0
+              - task: UseNode@1
                 displayName: Use Node 16.x
                 inputs:
-                  versionSpec: 16.x
+                  version: 16.x
             
-              - task: Npm@1.241.1
-                inputs:
-                  command: 'ci'
-                  verbose: true
-                displayName: npm install
+              - script: npm ci --verbose
+                displayName: 'npm install'
             
               # - task: CmdLine@2
               #   displayName: Authenticate git for pushes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,7 @@ extends:
             
               - task: Npm@1.241.1
                 inputs:
+                  command: 'ci'
                   verbose: true
                 displayName: npm install
             

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8939,20 +8939,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/docusaurus/node_modules/loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-            "license": "MIT",
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
-        },
         "node_modules/docusaurus/node_modules/mdn-data": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -9743,12 +9729,6 @@
             "bin": {
                 "semver": "bin/semver"
             }
-        },
-        "node_modules/docusaurus/node_modules/shell-quote": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
-            "license": "MIT"
         },
         "node_modules/docusaurus/node_modules/sitemap": {
             "version": "3.2.2",
@@ -26681,7 +26661,7 @@
             "integrity": "sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==",
             "requires": {
                 "find-cache-dir": "^3.3.1",
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "make-dir": "^3.1.0",
                 "schema-utils": "^2.6.5"
             },
@@ -29581,16 +29561,6 @@
                         }
                     }
                 },
-                "loader-utils": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                },
                 "mdn-data": {
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -30117,13 +30087,13 @@
                         "gzip-size": "5.1.1",
                         "immer": "8.0.1",
                         "is-root": "2.1.0",
-                        "loader-utils": "2.0.0",
+                        "loader-utils": "^2.0.3",
                         "open": "^7.0.2",
                         "pkg-up": "3.1.0",
                         "prompts": "2.4.0",
                         "react-error-overlay": "^6.0.9",
                         "recursive-readdir": "2.2.2",
-                        "shell-quote": "1.7.2",
+                        "shell-quote": "^1.7.3",
                         "strip-ansi": "6.0.0",
                         "text-table": "0.2.0"
                     },
@@ -30212,11 +30182,6 @@
                     "version": "5.7.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
                     "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-                },
-                "shell-quote": {
-                    "version": "1.7.2",
-                    "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-                    "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
                 },
                 "sitemap": {
                     "version": "3.2.2",
@@ -31464,7 +31429,7 @@
             "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
             "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
             "requires": {
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "schema-utils": "^3.0.0"
             }
         },
@@ -35862,7 +35827,7 @@
                 "gzip-size": "^6.0.0",
                 "immer": "^9.0.7",
                 "is-root": "^2.1.0",
-                "loader-utils": "^3.2.0",
+                "loader-utils": "^2.0.3",
                 "open": "^8.4.0",
                 "pkg-up": "^3.1.0",
                 "prompts": "^2.4.2",
@@ -35948,8 +35913,7 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
                 },
                 "loader-utils": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
+                    "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
                     "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg=="
                 },
                 "locate-path": {
@@ -38804,7 +38768,7 @@
             "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
             "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
             "requires": {
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "mime-types": "^2.1.27",
                 "schema-utils": "^3.0.0"
             }

--- a/docs/package.json
+++ b/docs/package.json
@@ -37,5 +37,9 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
+    },
+    "overrides": {
+        "loader-utils": "^2.0.3",
+        "shell-quote": "^1.7.3"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "jest": "^27.5.1",
                 "jest-puppeteer": "^6.1.0",
                 "prettier": "^2.5.1",
-                "puppeteer": "21.4.0",
+                "puppeteer": "^21.4.1",
                 "react": "^17.0.0",
                 "react-dom": "^17.0.0",
                 "release-it": "^15.4.1",
@@ -4756,9 +4756,9 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
-            "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+            "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
             "dev": true,
             "dependencies": {
                 "debug": "4.3.4",
@@ -15635,13 +15635,13 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "0.4.32",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.32.tgz",
-            "integrity": "sha512-RJnw0PW3sNdx1WclINVfVVx8JUH+tWTHZNpnEzlcM+Qgvf40dUH34U7gJq+cc/0LE+rbPxeT6ldqWrCbUf4jeg==",
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+            "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
             "dev": true,
             "dependencies": {
                 "mitt": "3.0.1",
-                "urlpattern-polyfill": "9.0.0"
+                "urlpattern-polyfill": "10.0.0"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -17438,9 +17438,9 @@
             "dev": true
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1191157",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1191157.tgz",
-            "integrity": "sha512-Fu2mUhX7zkzLHMJZk5wQTiHdl1eJrhK0GypUoSzogUt51MmYEv/46pCz4PtGGFlr0f2ZyYDzzx5CPtbEkuvcTA==",
+            "version": "0.0.1232444",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+            "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
             "dev": true
         },
         "node_modules/diff-sequences": {
@@ -17805,6 +17805,15 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/errno": {
@@ -29285,36 +29294,39 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "21.4.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.0.tgz",
-            "integrity": "sha512-KkiDe39NJxlw7fyiN6fieM9SVsewzt037nUZRoffNuFtYdAl5rRLVtleBuVZ5i1swK/R4CmA6Pbka/ytpFCu4Q==",
+            "version": "21.11.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.11.0.tgz",
+            "integrity": "sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==",
             "deprecated": "< 22.8.2 is no longer supported",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@puppeteer/browsers": "1.8.0",
-                "cosmiconfig": "8.3.6",
-                "puppeteer-core": "21.4.0"
+                "@puppeteer/browsers": "1.9.1",
+                "cosmiconfig": "9.0.0",
+                "puppeteer-core": "21.11.0"
+            },
+            "bin": {
+                "puppeteer": "lib/esm/puppeteer/node/cli.js"
             },
             "engines": {
-                "node": ">=16.3.0"
+                "node": ">=16.13.2"
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "21.4.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.0.tgz",
-            "integrity": "sha512-ONYjYgHItm6i9WdJf+MnRTRPB4HegwPbPfi1jjNN0LCW3rnNich/5hXgZFcn2oWvgFc8DWLDIcwly7C8z+EvIw==",
+            "version": "21.11.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+            "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
             "dev": true,
             "dependencies": {
-                "@puppeteer/browsers": "1.8.0",
-                "chromium-bidi": "0.4.32",
+                "@puppeteer/browsers": "1.9.1",
+                "chromium-bidi": "0.5.8",
                 "cross-fetch": "4.0.0",
                 "debug": "4.3.4",
-                "devtools-protocol": "0.0.1191157",
-                "ws": "8.14.2"
+                "devtools-protocol": "0.0.1232444",
+                "ws": "8.16.0"
             },
             "engines": {
-                "node": ">=16.3.0"
+                "node": ">=16.13.2"
             }
         },
         "node_modules/puppeteer-core/node_modules/debug": {
@@ -29335,9 +29347,9 @@
             }
         },
         "node_modules/puppeteer-core/node_modules/ws": {
-            "version": "8.14.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -29356,15 +29368,15 @@
             }
         },
         "node_modules/puppeteer/node_modules/cosmiconfig": {
-            "version": "8.3.6",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "dependencies": {
+                "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0",
-                "path-type": "^4.0.0"
+                "parse-json": "^5.2.0"
             },
             "engines": {
                 "node": ">=14"
@@ -34086,9 +34098,9 @@
             "dev": true
         },
         "node_modules/urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "node_modules/use": {
@@ -39293,9 +39305,9 @@
             "dev": true
         },
         "@puppeteer/browsers": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
-            "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+            "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
             "dev": true,
             "requires": {
                 "debug": "4.3.4",
@@ -47481,13 +47493,13 @@
             "dev": true
         },
         "chromium-bidi": {
-            "version": "0.4.32",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.32.tgz",
-            "integrity": "sha512-RJnw0PW3sNdx1WclINVfVVx8JUH+tWTHZNpnEzlcM+Qgvf40dUH34U7gJq+cc/0LE+rbPxeT6ldqWrCbUf4jeg==",
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+            "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
             "dev": true,
             "requires": {
                 "mitt": "3.0.1",
-                "urlpattern-polyfill": "9.0.0"
+                "urlpattern-polyfill": "10.0.0"
             }
         },
         "ci-info": {
@@ -48906,9 +48918,9 @@
             }
         },
         "devtools-protocol": {
-            "version": "0.0.1191157",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1191157.tgz",
-            "integrity": "sha512-Fu2mUhX7zkzLHMJZk5wQTiHdl1eJrhK0GypUoSzogUt51MmYEv/46pCz4PtGGFlr0f2ZyYDzzx5CPtbEkuvcTA==",
+            "version": "0.0.1232444",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+            "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
             "dev": true
         },
         "diff-sequences": {
@@ -49216,6 +49228,12 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true
+        },
+        "env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "dev": true
         },
         "errno": {
@@ -58030,26 +58048,26 @@
             }
         },
         "puppeteer": {
-            "version": "21.4.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.0.tgz",
-            "integrity": "sha512-KkiDe39NJxlw7fyiN6fieM9SVsewzt037nUZRoffNuFtYdAl5rRLVtleBuVZ5i1swK/R4CmA6Pbka/ytpFCu4Q==",
+            "version": "21.11.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.11.0.tgz",
+            "integrity": "sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==",
             "dev": true,
             "requires": {
-                "@puppeteer/browsers": "1.8.0",
-                "cosmiconfig": "8.3.6",
-                "puppeteer-core": "21.4.0"
+                "@puppeteer/browsers": "1.9.1",
+                "cosmiconfig": "9.0.0",
+                "puppeteer-core": "21.11.0"
             },
             "dependencies": {
                 "cosmiconfig": {
-                    "version": "8.3.6",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-                    "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+                    "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
                     "dev": true,
                     "requires": {
+                        "env-paths": "^2.2.1",
                         "import-fresh": "^3.3.0",
                         "js-yaml": "^4.1.0",
-                        "parse-json": "^5.2.0",
-                        "path-type": "^4.0.0"
+                        "parse-json": "^5.2.0"
                     }
                 },
                 "typescript": {
@@ -58063,17 +58081,17 @@
             }
         },
         "puppeteer-core": {
-            "version": "21.4.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.0.tgz",
-            "integrity": "sha512-ONYjYgHItm6i9WdJf+MnRTRPB4HegwPbPfi1jjNN0LCW3rnNich/5hXgZFcn2oWvgFc8DWLDIcwly7C8z+EvIw==",
+            "version": "21.11.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+            "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
             "dev": true,
             "requires": {
-                "@puppeteer/browsers": "1.8.0",
-                "chromium-bidi": "0.4.32",
+                "@puppeteer/browsers": "1.9.1",
+                "chromium-bidi": "0.5.8",
                 "cross-fetch": "4.0.0",
                 "debug": "4.3.4",
-                "devtools-protocol": "0.0.1191157",
-                "ws": "8.14.2"
+                "devtools-protocol": "0.0.1232444",
+                "ws": "8.16.0"
             },
             "dependencies": {
                 "debug": {
@@ -58086,9 +58104,9 @@
                     }
                 },
                 "ws": {
-                    "version": "8.14.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-                    "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+                    "version": "8.16.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+                    "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
                     "dev": true,
                     "requires": {}
                 }
@@ -61694,9 +61712,9 @@
             }
         },
         "urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "use": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "jest": "^27.5.1",
                 "jest-puppeteer": "^6.1.0",
                 "prettier": "^2.5.1",
-                "puppeteer": "^21.4.1",
+                "puppeteer": "^22.15.0",
                 "react": "^17.0.0",
                 "react-dom": "^17.0.0",
                 "release-it": "^15.4.1",
@@ -4756,30 +4756,31 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
-            "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+            "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
             "dev": true,
             "dependencies": {
-                "debug": "4.3.4",
-                "extract-zip": "2.0.1",
-                "progress": "2.0.3",
-                "proxy-agent": "6.3.1",
-                "tar-fs": "3.0.4",
-                "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.2"
+                "debug": "^4.3.5",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.4.0",
+                "semver": "^7.6.3",
+                "tar-fs": "^3.0.6",
+                "unbzip2-stream": "^1.4.3",
+                "yargs": "^17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
             },
             "engines": {
-                "node": ">=16.3.0"
+                "node": ">=18"
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.3.4"
@@ -4836,9 +4837,9 @@
             "dev": true
         },
         "node_modules/@puppeteer/browsers/node_modules/data-uri-to-buffer": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.1.tgz",
-            "integrity": "sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "dev": true,
             "engines": {
                 "node": ">= 14"
@@ -4859,38 +4860,38 @@
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=6 <7 || >=8"
+                "node": ">=14.14"
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/get-uri": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.2.tgz",
-            "integrity": "sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
             "dev": true,
             "dependencies": {
                 "basic-ftp": "^5.0.2",
-                "data-uri-to-buffer": "^6.0.0",
+                "data-uri-to-buffer": "^6.0.2",
                 "debug": "^4.3.4",
-                "fs-extra": "^8.1.0"
+                "fs-extra": "^11.2.0"
             },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/http-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
@@ -4901,9 +4902,9 @@
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/https-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.0.2",
@@ -4911,6 +4912,18 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/@puppeteer/browsers/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/lru-cache": {
@@ -4923,9 +4936,9 @@
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/pac-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
             "dev": true,
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -4933,22 +4946,21 @@
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.2",
-                "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.2"
+                "https-proxy-agent": "^7.0.5",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.4"
             },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/pac-resolver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-            "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "dev": true,
             "dependencies": {
                 "degenerator": "^5.0.0",
-                "ip": "^1.1.8",
                 "netmask": "^2.0.2"
             },
             "engines": {
@@ -4956,15 +4968,15 @@
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/proxy-agent": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-            "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.2",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
                 "lru-cache": "^7.14.1",
                 "pac-proxy-agent": "^7.0.1",
                 "proxy-from-env": "^1.1.0",
@@ -4974,15 +4986,27 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/@puppeteer/browsers/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@puppeteer/browsers/node_modules/socks-proxy-agent": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
-            "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+            "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
             "dev": true,
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.1",
                 "debug": "^4.3.4",
-                "socks": "^2.7.1"
+                "socks": "^2.8.3"
             },
             "engines": {
                 "node": ">= 14"
@@ -4998,6 +5022,15 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@puppeteer/browsers/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
@@ -12994,9 +13027,9 @@
             "dev": true
         },
         "node_modules/@types/yauzl": {
-            "version": "2.10.2",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.2.tgz",
-            "integrity": "sha512-Km7XAtUIduROw7QPgvcft0lIupeG8a8rdKL8RiSyKvlE7dYY31fEn41HVuQsRFDuROA8tA4K2UVL+WdfFmErBA==",
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "dev": true,
             "optional": true,
             "dependencies": {
@@ -14105,9 +14138,9 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-            "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
             "dev": true
         },
         "node_modules/babel-jest": {
@@ -14680,6 +14713,52 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/bare-events": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+            "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/bare-fs": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
+            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "bare-events": "^2.0.0",
+                "bare-path": "^2.0.0",
+                "bare-stream": "^2.0.0"
+            }
+        },
+        "node_modules/bare-os": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
+            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/bare-path": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "bare-os": "^2.1.0"
+            }
+        },
+        "node_modules/bare-stream": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
+            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "streamx": "^2.18.0"
+            }
+        },
         "node_modules/base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
@@ -14769,9 +14848,9 @@
             ]
         },
         "node_modules/basic-ftp": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-            "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -15591,13 +15670,14 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "0.4.32",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.32.tgz",
-            "integrity": "sha512-RJnw0PW3sNdx1WclINVfVVx8JUH+tWTHZNpnEzlcM+Qgvf40dUH34U7gJq+cc/0LE+rbPxeT6ldqWrCbUf4jeg==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+            "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
             "dev": true,
             "dependencies": {
                 "mitt": "3.0.1",
-                "urlpattern-polyfill": "9.0.0"
+                "urlpattern-polyfill": "10.0.0",
+                "zod": "3.23.8"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -16802,15 +16882,6 @@
                 "sha.js": "^2.4.8"
             }
         },
-        "node_modules/cross-fetch": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-            "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-            "dev": true,
-            "dependencies": {
-                "node-fetch": "^2.6.12"
-            }
-        },
         "node_modules/cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -17027,9 +17098,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
             "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
@@ -17394,9 +17465,9 @@
             "dev": true
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1191157",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1191157.tgz",
-            "integrity": "sha512-Fu2mUhX7zkzLHMJZk5wQTiHdl1eJrhK0GypUoSzogUt51MmYEv/46pCz4PtGGFlr0f2ZyYDzzx5CPtbEkuvcTA==",
+            "version": "0.0.1312386",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+            "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
             "dev": true
         },
         "node_modules/diff-sequences": {
@@ -17761,6 +17832,15 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/errno": {
@@ -21717,6 +21797,25 @@
             "version": "1.1.9",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
             "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
+            "dev": true
+        },
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dev": true,
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ip-address/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "dev": true
         },
         "node_modules/ipaddr.js": {
@@ -26306,6 +26405,12 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+            "dev": true
+        },
         "node_modules/jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -27295,12 +27400,6 @@
             "bin": {
                 "mkdirp": "bin/cmd.js"
             }
-        },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
         },
         "node_modules/move-concurrently": {
             "version": "1.0.1",
@@ -29216,47 +29315,50 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "21.4.1",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.1.tgz",
-            "integrity": "sha512-opJqQeYMjAB3ICG8lCF3wtSs9k05dozmrEMrHgo3ZWbISiy8qbv/yAJz/6Io221qSh3yURfVf6Z7crrlzKZjLQ==",
+            "version": "22.15.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
+            "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@puppeteer/browsers": "1.8.0",
-                "cosmiconfig": "8.3.6",
-                "puppeteer-core": "21.4.1"
+                "@puppeteer/browsers": "2.3.0",
+                "cosmiconfig": "^9.0.0",
+                "devtools-protocol": "0.0.1312386",
+                "puppeteer-core": "22.15.0"
+            },
+            "bin": {
+                "puppeteer": "lib/esm/puppeteer/node/cli.js"
             },
             "engines": {
-                "node": ">=16.3.0"
+                "node": ">=18"
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "21.4.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.1.tgz",
-            "integrity": "sha512-Lh0e+oGhUquxVOi1U701gTfFLFvw5gDBFh3CWpnfAvtItmyZKUce4R54VNfOJfi+KKnzhVPdB/lDrg65gdRIng==",
+            "version": "22.15.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+            "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
             "dev": true,
             "dependencies": {
-                "@puppeteer/browsers": "1.8.0",
-                "chromium-bidi": "0.4.32",
-                "cross-fetch": "4.0.0",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1191157",
-                "ws": "8.14.2"
+                "@puppeteer/browsers": "2.3.0",
+                "chromium-bidi": "0.6.3",
+                "debug": "^4.3.6",
+                "devtools-protocol": "0.0.1312386",
+                "ws": "^8.18.0"
             },
             "engines": {
-                "node": ">=16.3.0"
+                "node": ">=18"
             }
         },
         "node_modules/puppeteer/node_modules/cosmiconfig": {
-            "version": "8.3.6",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "dependencies": {
+                "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0",
-                "path-type": "^4.0.0"
+                "parse-json": "^5.2.0"
             },
             "engines": {
                 "node": ">=14"
@@ -29274,9 +29376,9 @@
             }
         },
         "node_modules/puppeteer/node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
             "optional": true,
             "peer": true,
@@ -31814,16 +31916,16 @@
             "dev": true
         },
         "node_modules/socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "dev": true,
             "dependencies": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 10.0.0",
                 "npm": ">= 3.0.0"
             }
         },
@@ -31840,12 +31942,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/socks/node_modules/ip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-            "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-            "dev": true
         },
         "node_modules/source-list-map": {
             "version": "2.0.1",
@@ -32162,13 +32258,17 @@
             "dev": true
         },
         "node_modules/streamx": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
-            "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.19.0.tgz",
+            "integrity": "sha512-5z6CNR4gtkPbwlxyEqoDGDmWIzoNJqCBt4Eac1ICP9YaIT08ct712cFj0u1rx4F8luAuL+3Qc+RFIdI4OX00kg==",
             "dev": true,
             "dependencies": {
-                "fast-fifo": "^1.1.0",
-                "queue-tick": "^1.0.1"
+                "fast-fifo": "^1.3.2",
+                "queue-tick": "^1.0.1",
+                "text-decoder": "^1.1.0"
+            },
+            "optionalDependencies": {
+                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string_decoder": {
@@ -32578,20 +32678,23 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-            "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
             "dev": true,
             "dependencies": {
-                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
+            },
+            "optionalDependencies": {
+                "bare-fs": "^2.1.1",
+                "bare-path": "^2.1.0"
             }
         },
         "node_modules/tar-stream": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-            "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "dev": true,
             "dependencies": {
                 "b4a": "^1.6.4",
@@ -32754,6 +32857,15 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/text-decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+            "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+            "dev": true,
+            "dependencies": {
+                "b4a": "^1.6.4"
             }
         },
         "node_modules/text-table": {
@@ -33971,9 +34083,9 @@
             "dev": true
         },
         "node_modules/urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "node_modules/use": {
@@ -35414,9 +35526,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.14.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -35650,6 +35762,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.23.8",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/zwitch": {
@@ -39178,24 +39299,25 @@
             "dev": true
         },
         "@puppeteer/browsers": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
-            "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+            "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
             "dev": true,
             "requires": {
-                "debug": "4.3.4",
-                "extract-zip": "2.0.1",
-                "progress": "2.0.3",
-                "proxy-agent": "6.3.1",
-                "tar-fs": "3.0.4",
-                "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.2"
+                "debug": "^4.3.5",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.4.0",
+                "semver": "^7.6.3",
+                "tar-fs": "^3.0.6",
+                "unbzip2-stream": "^1.4.3",
+                "yargs": "^17.7.2"
             },
             "dependencies": {
                 "agent-base": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-                    "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
                     "dev": true,
                     "requires": {
                         "debug": "^4.3.4"
@@ -39237,9 +39359,9 @@
                     "dev": true
                 },
                 "data-uri-to-buffer": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.1.tgz",
-                    "integrity": "sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==",
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+                    "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
                     "dev": true
                 },
                 "degenerator": {
@@ -39254,32 +39376,32 @@
                     }
                 },
                 "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                    "version": "11.2.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+                    "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
                     }
                 },
                 "get-uri": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.2.tgz",
-                    "integrity": "sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==",
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+                    "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
                     "dev": true,
                     "requires": {
                         "basic-ftp": "^5.0.2",
-                        "data-uri-to-buffer": "^6.0.0",
+                        "data-uri-to-buffer": "^6.0.2",
                         "debug": "^4.3.4",
-                        "fs-extra": "^8.1.0"
+                        "fs-extra": "^11.2.0"
                     }
                 },
                 "http-proxy-agent": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-                    "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+                    "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
                     "dev": true,
                     "requires": {
                         "agent-base": "^7.1.0",
@@ -39287,13 +39409,23 @@
                     }
                 },
                 "https-proxy-agent": {
-                    "version": "7.0.2",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-                    "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+                    "version": "7.0.5",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+                    "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
                     "dev": true,
                     "requires": {
                         "agent-base": "^7.0.2",
                         "debug": "4"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
                     }
                 },
                 "lru-cache": {
@@ -39303,9 +39435,9 @@
                     "dev": true
                 },
                 "pac-proxy-agent": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-                    "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+                    "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
                     "dev": true,
                     "requires": {
                         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -39313,47 +39445,52 @@
                         "debug": "^4.3.4",
                         "get-uri": "^6.0.1",
                         "http-proxy-agent": "^7.0.0",
-                        "https-proxy-agent": "^7.0.2",
-                        "pac-resolver": "^7.0.0",
-                        "socks-proxy-agent": "^8.0.2"
+                        "https-proxy-agent": "^7.0.5",
+                        "pac-resolver": "^7.0.1",
+                        "socks-proxy-agent": "^8.0.4"
                     }
                 },
                 "pac-resolver": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-                    "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+                    "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
                     "dev": true,
                     "requires": {
                         "degenerator": "^5.0.0",
-                        "ip": "^1.1.8",
                         "netmask": "^2.0.2"
                     }
                 },
                 "proxy-agent": {
-                    "version": "6.3.1",
-                    "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-                    "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+                    "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
                     "dev": true,
                     "requires": {
                         "agent-base": "^7.0.2",
                         "debug": "^4.3.4",
-                        "http-proxy-agent": "^7.0.0",
-                        "https-proxy-agent": "^7.0.2",
+                        "http-proxy-agent": "^7.0.1",
+                        "https-proxy-agent": "^7.0.3",
                         "lru-cache": "^7.14.1",
                         "pac-proxy-agent": "^7.0.1",
                         "proxy-from-env": "^1.1.0",
                         "socks-proxy-agent": "^8.0.2"
                     }
                 },
+                "semver": {
+                    "version": "7.6.3",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+                    "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+                    "dev": true
+                },
                 "socks-proxy-agent": {
-                    "version": "8.0.2",
-                    "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
-                    "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+                    "version": "8.0.4",
+                    "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+                    "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
                     "dev": true,
                     "requires": {
-                        "agent-base": "^7.0.2",
+                        "agent-base": "^7.1.1",
                         "debug": "^4.3.4",
-                        "socks": "^2.7.1"
+                        "socks": "^2.8.3"
                     }
                 },
                 "strip-ansi": {
@@ -39364,6 +39501,12 @@
                     "requires": {
                         "ansi-regex": "^5.0.1"
                     }
+                },
+                "universalify": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+                    "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+                    "dev": true
                 },
                 "wrap-ansi": {
                     "version": "7.0.0",
@@ -45328,9 +45471,9 @@
             "dev": true
         },
         "@types/yauzl": {
-            "version": "2.10.2",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.2.tgz",
-            "integrity": "sha512-Km7XAtUIduROw7QPgvcft0lIupeG8a8rdKL8RiSyKvlE7dYY31fEn41HVuQsRFDuROA8tA4K2UVL+WdfFmErBA==",
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -46191,9 +46334,9 @@
             }
         },
         "b4a": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-            "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
             "dev": true
         },
         "babel-jest": {
@@ -46639,6 +46782,52 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "bare-events": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+            "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+            "dev": true,
+            "optional": true
+        },
+        "bare-fs": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
+            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "bare-events": "^2.0.0",
+                "bare-path": "^2.0.0",
+                "bare-stream": "^2.0.0"
+            }
+        },
+        "bare-os": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
+            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
+            "dev": true,
+            "optional": true
+        },
+        "bare-path": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "bare-os": "^2.1.0"
+            }
+        },
+        "bare-stream": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
+            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "streamx": "^2.18.0"
+            }
+        },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
@@ -46701,9 +46890,9 @@
             "dev": true
         },
         "basic-ftp": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-            "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
             "dev": true
         },
         "batch-processor": {
@@ -47335,13 +47524,14 @@
             "dev": true
         },
         "chromium-bidi": {
-            "version": "0.4.32",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.32.tgz",
-            "integrity": "sha512-RJnw0PW3sNdx1WclINVfVVx8JUH+tWTHZNpnEzlcM+Qgvf40dUH34U7gJq+cc/0LE+rbPxeT6ldqWrCbUf4jeg==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+            "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
             "dev": true,
             "requires": {
                 "mitt": "3.0.1",
-                "urlpattern-polyfill": "9.0.0"
+                "urlpattern-polyfill": "10.0.0",
+                "zod": "3.23.8"
             }
         },
         "ci-info": {
@@ -48312,15 +48502,6 @@
                 "sha.js": "^2.4.8"
             }
         },
-        "cross-fetch": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-            "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-            "dev": true,
-            "requires": {
-                "node-fetch": "^2.6.12"
-            }
-        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -48483,9 +48664,9 @@
             "dev": true
         },
         "debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
             "dev": true,
             "requires": {
                 "ms": "2.1.2"
@@ -48760,9 +48941,9 @@
             }
         },
         "devtools-protocol": {
-            "version": "0.0.1191157",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1191157.tgz",
-            "integrity": "sha512-Fu2mUhX7zkzLHMJZk5wQTiHdl1eJrhK0GypUoSzogUt51MmYEv/46pCz4PtGGFlr0f2ZyYDzzx5CPtbEkuvcTA==",
+            "version": "0.0.1312386",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+            "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
             "dev": true
         },
         "diff-sequences": {
@@ -49070,6 +49251,12 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true
+        },
+        "env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "dev": true
         },
         "errno": {
@@ -52092,6 +52279,24 @@
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
             "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
             "dev": true
+        },
+        "ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dev": true,
+            "requires": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+                    "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+                    "dev": true
+                }
+            }
         },
         "ipaddr.js": {
             "version": "1.9.1",
@@ -55562,6 +55767,12 @@
                 "argparse": "^2.0.1"
             }
         },
+        "jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+            "dev": true
+        },
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -56341,12 +56552,6 @@
             "requires": {
                 "minimist": "^1.2.5"
             }
-        },
-        "mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
         },
         "move-concurrently": {
             "version": "1.0.1",
@@ -57860,32 +58065,33 @@
             }
         },
         "puppeteer": {
-            "version": "21.4.1",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.1.tgz",
-            "integrity": "sha512-opJqQeYMjAB3ICG8lCF3wtSs9k05dozmrEMrHgo3ZWbISiy8qbv/yAJz/6Io221qSh3yURfVf6Z7crrlzKZjLQ==",
+            "version": "22.15.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
+            "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
             "dev": true,
             "requires": {
-                "@puppeteer/browsers": "1.8.0",
-                "cosmiconfig": "8.3.6",
-                "puppeteer-core": "21.4.1"
+                "@puppeteer/browsers": "2.3.0",
+                "cosmiconfig": "^9.0.0",
+                "devtools-protocol": "0.0.1312386",
+                "puppeteer-core": "22.15.0"
             },
             "dependencies": {
                 "cosmiconfig": {
-                    "version": "8.3.6",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-                    "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+                    "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
                     "dev": true,
                     "requires": {
+                        "env-paths": "^2.2.1",
                         "import-fresh": "^3.3.0",
                         "js-yaml": "^4.1.0",
-                        "parse-json": "^5.2.0",
-                        "path-type": "^4.0.0"
+                        "parse-json": "^5.2.0"
                     }
                 },
                 "typescript": {
-                    "version": "5.2.2",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-                    "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+                    "version": "5.5.4",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+                    "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
                     "dev": true,
                     "optional": true,
                     "peer": true
@@ -57893,17 +58099,16 @@
             }
         },
         "puppeteer-core": {
-            "version": "21.4.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.1.tgz",
-            "integrity": "sha512-Lh0e+oGhUquxVOi1U701gTfFLFvw5gDBFh3CWpnfAvtItmyZKUce4R54VNfOJfi+KKnzhVPdB/lDrg65gdRIng==",
+            "version": "22.15.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+            "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
             "dev": true,
             "requires": {
-                "@puppeteer/browsers": "1.8.0",
-                "chromium-bidi": "0.4.32",
-                "cross-fetch": "4.0.0",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1191157",
-                "ws": "8.14.2"
+                "@puppeteer/browsers": "2.3.0",
+                "chromium-bidi": "0.6.3",
+                "debug": "^4.3.6",
+                "devtools-protocol": "0.0.1312386",
+                "ws": "^8.18.0"
             }
         },
         "qs": {
@@ -59840,21 +60045,13 @@
             }
         },
         "socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "dev": true,
             "requires": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
-            },
-            "dependencies": {
-                "ip": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-                    "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-                    "dev": true
-                }
             }
         },
         "socks-proxy-agent": {
@@ -60156,13 +60353,15 @@
             "dev": true
         },
         "streamx": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
-            "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.19.0.tgz",
+            "integrity": "sha512-5z6CNR4gtkPbwlxyEqoDGDmWIzoNJqCBt4Eac1ICP9YaIT08ct712cFj0u1rx4F8luAuL+3Qc+RFIdI4OX00kg==",
             "dev": true,
             "requires": {
-                "fast-fifo": "^1.1.0",
-                "queue-tick": "^1.0.1"
+                "bare-events": "^2.2.0",
+                "fast-fifo": "^1.3.2",
+                "queue-tick": "^1.0.1",
+                "text-decoder": "^1.1.0"
             }
         },
         "string_decoder": {
@@ -60474,20 +60673,21 @@
             }
         },
         "tar-fs": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-            "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
             "dev": true,
             "requires": {
-                "mkdirp-classic": "^0.5.2",
+                "bare-fs": "^2.1.1",
+                "bare-path": "^2.1.0",
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
             }
         },
         "tar-stream": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-            "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "dev": true,
             "requires": {
                 "b4a": "^1.6.4",
@@ -60597,6 +60797,15 @@
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
                 "minimatch": "^3.0.4"
+            }
+        },
+        "text-decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+            "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+            "dev": true,
+            "requires": {
+                "b4a": "^1.6.4"
             }
         },
         "text-table": {
@@ -61503,9 +61712,9 @@
             }
         },
         "urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "use": {
@@ -62649,9 +62858,9 @@
             }
         },
         "ws": {
-            "version": "8.14.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "requires": {}
         },
@@ -62822,6 +63031,12 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true
+        },
+        "zod": {
+            "version": "3.23.8",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
             "dev": true
         },
         "zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "jest": "^27.5.1",
                 "jest-puppeteer": "^6.1.0",
                 "prettier": "^2.5.1",
-                "puppeteer": "^22.15.0",
+                "puppeteer": "21.4.0",
                 "react": "^17.0.0",
                 "react-dom": "^17.0.0",
                 "release-it": "^15.4.1",
@@ -4756,25 +4756,24 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
-            "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
+            "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
             "dev": true,
             "dependencies": {
-                "debug": "^4.3.5",
-                "extract-zip": "^2.0.1",
-                "progress": "^2.0.3",
-                "proxy-agent": "^6.4.0",
-                "semver": "^7.6.3",
-                "tar-fs": "^3.0.6",
-                "unbzip2-stream": "^1.4.3",
-                "yargs": "^17.7.2"
+                "debug": "4.3.4",
+                "extract-zip": "2.0.1",
+                "progress": "2.0.3",
+                "proxy-agent": "6.3.1",
+                "tar-fs": "3.0.4",
+                "unbzip2-stream": "1.4.3",
+                "yargs": "17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=16.3.0"
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/agent-base": {
@@ -4843,6 +4842,23 @@
             "dev": true,
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/@puppeteer/browsers/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/degenerator": {
@@ -4968,15 +4984,15 @@
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/proxy-agent": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+            "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
-                "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.3",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
                 "lru-cache": "^7.14.1",
                 "pac-proxy-agent": "^7.0.1",
                 "proxy-from-env": "^1.1.0",
@@ -4984,18 +5000,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/socks-proxy-agent": {
@@ -14720,45 +14724,6 @@
             "dev": true,
             "optional": true
         },
-        "node_modules/bare-fs": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
-            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "bare-events": "^2.0.0",
-                "bare-path": "^2.0.0",
-                "bare-stream": "^2.0.0"
-            }
-        },
-        "node_modules/bare-os": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
-            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
-            "dev": true,
-            "optional": true
-        },
-        "node_modules/bare-path": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
-            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "bare-os": "^2.1.0"
-            }
-        },
-        "node_modules/bare-stream": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
-            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "streamx": "^2.18.0"
-            }
-        },
         "node_modules/base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
@@ -15670,14 +15635,13 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
-            "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
+            "version": "0.4.32",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.32.tgz",
+            "integrity": "sha512-RJnw0PW3sNdx1WclINVfVVx8JUH+tWTHZNpnEzlcM+Qgvf40dUH34U7gJq+cc/0LE+rbPxeT6ldqWrCbUf4jeg==",
             "dev": true,
             "dependencies": {
                 "mitt": "3.0.1",
-                "urlpattern-polyfill": "10.0.0",
-                "zod": "3.23.8"
+                "urlpattern-polyfill": "9.0.0"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -16882,6 +16846,15 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "node_modules/cross-fetch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+            "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+            "dev": true,
+            "dependencies": {
+                "node-fetch": "^2.6.12"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -17465,9 +17438,9 @@
             "dev": true
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1312386",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-            "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+            "version": "0.0.1191157",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1191157.tgz",
+            "integrity": "sha512-Fu2mUhX7zkzLHMJZk5wQTiHdl1eJrhK0GypUoSzogUt51MmYEv/46pCz4PtGGFlr0f2ZyYDzzx5CPtbEkuvcTA==",
             "dev": true
         },
         "node_modules/diff-sequences": {
@@ -17832,15 +17805,6 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/errno": {
@@ -27401,6 +27365,12 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "dev": true
+        },
         "node_modules/move-concurrently": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -29315,50 +29285,86 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "22.15.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
-            "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
+            "version": "21.4.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.0.tgz",
+            "integrity": "sha512-KkiDe39NJxlw7fyiN6fieM9SVsewzt037nUZRoffNuFtYdAl5rRLVtleBuVZ5i1swK/R4CmA6Pbka/ytpFCu4Q==",
+            "deprecated": "< 22.8.2 is no longer supported",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@puppeteer/browsers": "2.3.0",
-                "cosmiconfig": "^9.0.0",
-                "devtools-protocol": "0.0.1312386",
-                "puppeteer-core": "22.15.0"
-            },
-            "bin": {
-                "puppeteer": "lib/esm/puppeteer/node/cli.js"
+                "@puppeteer/browsers": "1.8.0",
+                "cosmiconfig": "8.3.6",
+                "puppeteer-core": "21.4.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=16.3.0"
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "22.15.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
-            "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
+            "version": "21.4.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.0.tgz",
+            "integrity": "sha512-ONYjYgHItm6i9WdJf+MnRTRPB4HegwPbPfi1jjNN0LCW3rnNich/5hXgZFcn2oWvgFc8DWLDIcwly7C8z+EvIw==",
             "dev": true,
             "dependencies": {
-                "@puppeteer/browsers": "2.3.0",
-                "chromium-bidi": "0.6.3",
-                "debug": "^4.3.6",
-                "devtools-protocol": "0.0.1312386",
-                "ws": "^8.18.0"
+                "@puppeteer/browsers": "1.8.0",
+                "chromium-bidi": "0.4.32",
+                "cross-fetch": "4.0.0",
+                "debug": "4.3.4",
+                "devtools-protocol": "0.0.1191157",
+                "ws": "8.14.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=16.3.0"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/ws": {
+            "version": "8.14.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+            "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/puppeteer/node_modules/cosmiconfig": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
             "dev": true,
             "dependencies": {
-                "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0"
+                "parse-json": "^5.2.0",
+                "path-type": "^4.0.0"
             },
             "engines": {
                 "node": ">=14"
@@ -32678,17 +32684,14 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+            "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
             "dev": true,
             "dependencies": {
+                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
-            },
-            "optionalDependencies": {
-                "bare-fs": "^2.1.1",
-                "bare-path": "^2.1.0"
             }
         },
         "node_modules/tar-stream": {
@@ -34083,9 +34086,9 @@
             "dev": true
         },
         "node_modules/urlpattern-polyfill": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
             "dev": true
         },
         "node_modules/use": {
@@ -35762,15 +35765,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/zod": {
-            "version": "3.23.8",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/zwitch": {
@@ -39299,19 +39293,18 @@
             "dev": true
         },
         "@puppeteer/browsers": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
-            "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
+            "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
             "dev": true,
             "requires": {
-                "debug": "^4.3.5",
-                "extract-zip": "^2.0.1",
-                "progress": "^2.0.3",
-                "proxy-agent": "^6.4.0",
-                "semver": "^7.6.3",
-                "tar-fs": "^3.0.6",
-                "unbzip2-stream": "^1.4.3",
-                "yargs": "^17.7.2"
+                "debug": "4.3.4",
+                "extract-zip": "2.0.1",
+                "progress": "2.0.3",
+                "proxy-agent": "6.3.1",
+                "tar-fs": "3.0.4",
+                "unbzip2-stream": "1.4.3",
+                "yargs": "17.7.2"
             },
             "dependencies": {
                 "agent-base": {
@@ -39363,6 +39356,15 @@
                     "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
                     "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
                     "dev": true
+                },
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
                 },
                 "degenerator": {
                     "version": "5.0.1",
@@ -39461,26 +39463,20 @@
                     }
                 },
                 "proxy-agent": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-                    "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+                    "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
                     "dev": true,
                     "requires": {
                         "agent-base": "^7.0.2",
                         "debug": "^4.3.4",
-                        "http-proxy-agent": "^7.0.1",
-                        "https-proxy-agent": "^7.0.3",
+                        "http-proxy-agent": "^7.0.0",
+                        "https-proxy-agent": "^7.0.2",
                         "lru-cache": "^7.14.1",
                         "pac-proxy-agent": "^7.0.1",
                         "proxy-from-env": "^1.1.0",
                         "socks-proxy-agent": "^8.0.2"
                     }
-                },
-                "semver": {
-                    "version": "7.6.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-                    "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-                    "dev": true
                 },
                 "socks-proxy-agent": {
                     "version": "8.0.4",
@@ -46789,45 +46785,6 @@
             "dev": true,
             "optional": true
         },
-        "bare-fs": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
-            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "bare-events": "^2.0.0",
-                "bare-path": "^2.0.0",
-                "bare-stream": "^2.0.0"
-            }
-        },
-        "bare-os": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
-            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
-            "dev": true,
-            "optional": true
-        },
-        "bare-path": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
-            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "bare-os": "^2.1.0"
-            }
-        },
-        "bare-stream": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
-            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "streamx": "^2.18.0"
-            }
-        },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
@@ -47524,14 +47481,13 @@
             "dev": true
         },
         "chromium-bidi": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
-            "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
+            "version": "0.4.32",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.32.tgz",
+            "integrity": "sha512-RJnw0PW3sNdx1WclINVfVVx8JUH+tWTHZNpnEzlcM+Qgvf40dUH34U7gJq+cc/0LE+rbPxeT6ldqWrCbUf4jeg==",
             "dev": true,
             "requires": {
                 "mitt": "3.0.1",
-                "urlpattern-polyfill": "10.0.0",
-                "zod": "3.23.8"
+                "urlpattern-polyfill": "9.0.0"
             }
         },
         "ci-info": {
@@ -48502,6 +48458,15 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "cross-fetch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+            "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+            "dev": true,
+            "requires": {
+                "node-fetch": "^2.6.12"
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -48941,9 +48906,9 @@
             }
         },
         "devtools-protocol": {
-            "version": "0.0.1312386",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-            "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+            "version": "0.0.1191157",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1191157.tgz",
+            "integrity": "sha512-Fu2mUhX7zkzLHMJZk5wQTiHdl1eJrhK0GypUoSzogUt51MmYEv/46pCz4PtGGFlr0f2ZyYDzzx5CPtbEkuvcTA==",
             "dev": true
         },
         "diff-sequences": {
@@ -49251,12 +49216,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "dev": true
-        },
-        "env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "dev": true
         },
         "errno": {
@@ -56553,6 +56512,12 @@
                 "minimist": "^1.2.5"
             }
         },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "dev": true
+        },
         "move-concurrently": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -58065,27 +58030,26 @@
             }
         },
         "puppeteer": {
-            "version": "22.15.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
-            "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
+            "version": "21.4.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.0.tgz",
+            "integrity": "sha512-KkiDe39NJxlw7fyiN6fieM9SVsewzt037nUZRoffNuFtYdAl5rRLVtleBuVZ5i1swK/R4CmA6Pbka/ytpFCu4Q==",
             "dev": true,
             "requires": {
-                "@puppeteer/browsers": "2.3.0",
-                "cosmiconfig": "^9.0.0",
-                "devtools-protocol": "0.0.1312386",
-                "puppeteer-core": "22.15.0"
+                "@puppeteer/browsers": "1.8.0",
+                "cosmiconfig": "8.3.6",
+                "puppeteer-core": "21.4.0"
             },
             "dependencies": {
                 "cosmiconfig": {
-                    "version": "9.0.0",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-                    "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+                    "version": "8.3.6",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+                    "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
                     "dev": true,
                     "requires": {
-                        "env-paths": "^2.2.1",
                         "import-fresh": "^3.3.0",
                         "js-yaml": "^4.1.0",
-                        "parse-json": "^5.2.0"
+                        "parse-json": "^5.2.0",
+                        "path-type": "^4.0.0"
                     }
                 },
                 "typescript": {
@@ -58099,16 +58063,35 @@
             }
         },
         "puppeteer-core": {
-            "version": "22.15.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
-            "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
+            "version": "21.4.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.0.tgz",
+            "integrity": "sha512-ONYjYgHItm6i9WdJf+MnRTRPB4HegwPbPfi1jjNN0LCW3rnNich/5hXgZFcn2oWvgFc8DWLDIcwly7C8z+EvIw==",
             "dev": true,
             "requires": {
-                "@puppeteer/browsers": "2.3.0",
-                "chromium-bidi": "0.6.3",
-                "debug": "^4.3.6",
-                "devtools-protocol": "0.0.1312386",
-                "ws": "^8.18.0"
+                "@puppeteer/browsers": "1.8.0",
+                "chromium-bidi": "0.4.32",
+                "cross-fetch": "4.0.0",
+                "debug": "4.3.4",
+                "devtools-protocol": "0.0.1191157",
+                "ws": "8.14.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ws": {
+                    "version": "8.14.2",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+                    "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+                    "dev": true,
+                    "requires": {}
+                }
             }
         },
         "qs": {
@@ -60673,13 +60656,12 @@
             }
         },
         "tar-fs": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+            "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
             "dev": true,
             "requires": {
-                "bare-fs": "^2.1.1",
-                "bare-path": "^2.1.0",
+                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
             }
@@ -61712,9 +61694,9 @@
             }
         },
         "urlpattern-polyfill": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
             "dev": true
         },
         "use": {
@@ -63031,12 +63013,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "dev": true
-        },
-        "zod": {
-            "version": "3.23.8",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
             "dev": true
         },
         "zwitch": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "jest": "^27.5.1",
         "jest-puppeteer": "^6.1.0",
         "prettier": "^2.5.1",
-        "puppeteer": "21.4.0",
+        "puppeteer": "^21.4.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "release-it": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "jest": "^27.5.1",
         "jest-puppeteer": "^6.1.0",
         "prettier": "^2.5.1",
-        "puppeteer": "^22.15.0",
+        "puppeteer": "21.4.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "release-it": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "jest": "^27.5.1",
         "jest-puppeteer": "^6.1.0",
         "prettier": "^2.5.1",
-        "puppeteer": "^21.4.1",
+        "puppeteer": "^22.15.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "release-it": "^15.4.1",


### PR DESCRIPTION
- `npm install` was hanging in CI and that was caused by puppeteer version 21 ([see comment](https://github.com/npm/cli/issues/4028#issuecomment-2257438109)). Bumped repo puppeteer version to `22.15.0` 
- adds overrides for `loader-utils` and `shell-quote` deps to `docs` package as those were still being flagged by component governance
<img width="870" alt="image" src="https://github.com/user-attachments/assets/0d41536a-9bd0-40ad-82bd-928b36eef151">
