### PR TITLE
ci(release): fix npm install hang and address critical security deps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,9 +52,11 @@ extends:
                 displayName: Use Node 16.x
                 inputs:
                   versionSpec: 16.x
-            
+              # PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public is a workaround for puppeteer 
+              # as puppeteer versions <22.0.0 will cause npm install to hang in CI environments.
+              # see issue: https://github.com/puppeteer/puppeteer/issues/12833
               - script: | 
-                  npm install
+                  PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public npm install
                 displayName: npm install
             
               - task: CmdLine@2

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8939,20 +8939,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/docusaurus/node_modules/loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-            "license": "MIT",
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
-        },
         "node_modules/docusaurus/node_modules/mdn-data": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -9743,12 +9729,6 @@
             "bin": {
                 "semver": "bin/semver"
             }
-        },
-        "node_modules/docusaurus/node_modules/shell-quote": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
-            "license": "MIT"
         },
         "node_modules/docusaurus/node_modules/sitemap": {
             "version": "3.2.2",
@@ -26681,7 +26661,7 @@
             "integrity": "sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==",
             "requires": {
                 "find-cache-dir": "^3.3.1",
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "make-dir": "^3.1.0",
                 "schema-utils": "^2.6.5"
             },
@@ -29581,16 +29561,6 @@
                         }
                     }
                 },
-                "loader-utils": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                },
                 "mdn-data": {
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -30117,13 +30087,13 @@
                         "gzip-size": "5.1.1",
                         "immer": "8.0.1",
                         "is-root": "2.1.0",
-                        "loader-utils": "2.0.0",
+                        "loader-utils": "^2.0.3",
                         "open": "^7.0.2",
                         "pkg-up": "3.1.0",
                         "prompts": "2.4.0",
                         "react-error-overlay": "^6.0.9",
                         "recursive-readdir": "2.2.2",
-                        "shell-quote": "1.7.2",
+                        "shell-quote": "^1.7.3",
                         "strip-ansi": "6.0.0",
                         "text-table": "0.2.0"
                     },
@@ -30212,11 +30182,6 @@
                     "version": "5.7.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
                     "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-                },
-                "shell-quote": {
-                    "version": "1.7.2",
-                    "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-                    "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
                 },
                 "sitemap": {
                     "version": "3.2.2",
@@ -31464,7 +31429,7 @@
             "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
             "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
             "requires": {
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "schema-utils": "^3.0.0"
             }
         },
@@ -35862,7 +35827,7 @@
                 "gzip-size": "^6.0.0",
                 "immer": "^9.0.7",
                 "is-root": "^2.1.0",
-                "loader-utils": "^3.2.0",
+                "loader-utils": "^2.0.3",
                 "open": "^8.4.0",
                 "pkg-up": "^3.1.0",
                 "prompts": "^2.4.2",
@@ -35948,8 +35913,7 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
                 },
                 "loader-utils": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
+                    "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
                     "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg=="
                 },
                 "locate-path": {
@@ -38804,7 +38768,7 @@
             "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
             "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
             "requires": {
-                "loader-utils": "^2.0.0",
+                "loader-utils": "^2.0.3",
                 "mime-types": "^2.1.27",
                 "schema-utils": "^3.0.0"
             }

--- a/docs/package.json
+++ b/docs/package.json
@@ -37,5 +37,9 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
+    },
+    "overrides": {
+        "loader-utils": "^2.0.3",
+        "shell-quote": "^1.7.3"
     }
 }


### PR DESCRIPTION
## Changes:
- `npm install` was hanging in CI and that's caused by puppeteer versions < 22 . Workaround suggested by [this comment](https://github.com/puppeteer/puppeteer/issues/12833#issuecomment-2255014295) and it does work in installing packages in CI successfully ([see test pipeline run](https://dev.azure.com/uifabric/UI%20Fabric/_build/results?buildId=358181&view=logs&j=7494ae37-3ecd-50c6-9ffe-c77a2768c545&t=e3b22a90-6f85-5d9d-3b61-aa02f6a40c65))
- adds overrides for `loader-utils` and `shell-quote` deps to `docs` package as those were still being flagged by component governance
<img width="870" alt="image" src="https://github.com/user-attachments/assets/0d41536a-9bd0-40ad-82bd-928b36eef151">


## Related:
Related to this issue: https://github.com/npm/cli/issues/4028