### PR TITLE
feat(ObservedElementAPI): add `options` to `requestFocus()`

### DIFF
--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -180,7 +180,8 @@ export class FocusedElementState
     focus(
         element: HTMLElement,
         noFocusedProgrammaticallyFlag?: boolean,
-        noAccessibleCheck?: boolean
+        noAccessibleCheck?: boolean,
+        preventScroll?: boolean
     ): boolean {
         if (
             !this._tabster.focusable.isFocusable(
@@ -193,7 +194,7 @@ export class FocusedElementState
             return false;
         }
 
-        element.focus();
+        element.focus({ preventScroll });
 
         return true;
     }

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -240,7 +240,8 @@ export class ObservedElementAPI
 
     requestFocus(
         observedName: string,
-        timeout: number
+        timeout: number,
+        options: Pick<FocusOptions, "preventScroll"> = {}
     ): Types.ObservedElementAsyncRequest<boolean> {
         const requestId = ++this._lastRequestFocusId;
         const currentRequestFocus = this._currentRequest;
@@ -267,7 +268,12 @@ export class ObservedElementAPI
         return {
             result: request.result.then((element) =>
                 this._lastRequestFocusId === requestId && element
-                    ? this._tabster.focusedElement.focus(element, true)
+                    ? this._tabster.focusedElement.focus(
+                          element,
+                          true,
+                          undefined,
+                          options.preventScroll
+                      )
                     : false
             ),
             cancel: () => {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -148,7 +148,8 @@ export interface FocusedElementState
     focus(
         element: HTMLElement,
         noFocusedProgrammaticallyFlag?: boolean,
-        noAccessibleCheck?: boolean
+        noAccessibleCheck?: boolean,
+        preventScroll?: boolean
     ): boolean;
     focusDefault(container: HTMLElement): boolean;
     /** @internal */


### PR DESCRIPTION
### Before

```ts
.requestFocus("name", 1000);
```

### After

`.requestFocus()` gets `options` as a param and exposes `preventScroll` option:

```ts
.requestFocus("name", 1000);
.requestFocus("name", 1000, { preventScroll: true });
```

This aligns `.requestFocus()` with [`.focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus).
