### PR TITLE
feat(ObservedElement): Adding observed element request status.

### DIFF
--- a/src/Consts.ts
+++ b/src/Consts.ts
@@ -31,6 +31,13 @@ export const ObservedElementAccessibilities = {
     Focusable: 2,
 } as const;
 
+export const ObservedElementRequestStatuses = {
+    Waiting: 0,
+    Succeeded: 1,
+    Canceled: 2,
+    TimedOut: 3,
+} as const;
+
 export const RestoreFocusOrders = {
     History: 0,
     DeloserDefault: 1,

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -233,7 +233,9 @@ export class ObservedElementAPI
         const request: Types.ObservedElementAsyncRequest<HTMLElement | null> = {
             result: promise,
             cancel: () => {
-                request.status = ObservedElementRequestStatuses.Canceled;
+                if (request.status === ObservedElementRequestStatuses.Waiting) {
+                    request.status = ObservedElementRequestStatuses.Canceled;
+                }
                 this._rejectWaiting(key, true);
             },
             status: ObservedElementRequestStatuses.Waiting,

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -5,7 +5,10 @@
 
 import { getTabsterOnElement } from "../Instance";
 import * as Types from "../Types";
-import { ObservedElementAccessibilities } from "../Consts";
+import {
+    ObservedElementAccessibilities,
+    ObservedElementRequestStatuses,
+} from "../Consts";
 import {
     documentContains,
     getElementUId,
@@ -181,6 +184,7 @@ export class ObservedElementAPI
                 cancel: () => {
                     /**/
                 },
+                status: ObservedElementRequestStatuses.Succeeded,
             };
         }
 
@@ -209,6 +213,10 @@ export class ObservedElementAPI
 
                 delete this._waiting[key];
 
+                if (w.request) {
+                    w.request.status = ObservedElementRequestStatuses.TimedOut;
+                }
+
                 if (w.resolve) {
                     w.resolve(null);
                 }
@@ -222,12 +230,16 @@ export class ObservedElementAPI
             }
         );
 
-        w.request = {
+        const request: Types.ObservedElementAsyncRequest<HTMLElement | null> = {
             result: promise,
             cancel: () => {
+                request.status = ObservedElementRequestStatuses.Canceled;
                 this._rejectWaiting(key, true);
             },
+            status: ObservedElementRequestStatuses.Waiting,
         };
+
+        w.request = request;
 
         if (accessibility && this.getElement(observedName)) {
             // If the observed element is alread in DOM, but not accessible yet,
@@ -235,7 +247,7 @@ export class ObservedElementAPI
             this._waitConditional(observedName);
         }
 
-        return w.request;
+        return request;
     }
 
     requestFocus(
@@ -259,13 +271,7 @@ export class ObservedElementAPI
         this._currentRequest = request;
         this._currentRequestTimestamp = Date.now();
 
-        request.result.finally(() => {
-            if (this._currentRequest === request) {
-                delete this._currentRequest;
-            }
-        });
-
-        return {
+        const ret: Types.ObservedElementAsyncRequest<boolean> = {
             result: request.result.then((element) =>
                 this._lastRequestFocusId === requestId && element
                     ? this._tabster.focusedElement.focus(
@@ -279,7 +285,18 @@ export class ObservedElementAPI
             cancel: () => {
                 request.cancel();
             },
+            status: request.status,
         };
+
+        request.result.finally(() => {
+            if (this._currentRequest === request) {
+                delete this._currentRequest;
+            }
+
+            ret.status = request.status;
+        });
+
+        return ret;
     }
 
     onObservedElementUpdate = (element: HTMLElement): void => {
@@ -380,6 +397,11 @@ export class ObservedElementAPI
             }
 
             delete this._waiting[key];
+
+            if (waiting.request) {
+                waiting.request.status =
+                    ObservedElementRequestStatuses.Succeeded;
+            }
 
             if (waiting.resolve) {
                 waiting.resolve(element);

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -234,6 +234,8 @@ export class ObservedElementAPI
             result: promise,
             cancel: () => {
                 if (request.status === ObservedElementRequestStatuses.Waiting) {
+                    // cancel() function is callable by user, someone might call it after request is finished,
+                    // we are making sure that status of a finished request is not overriden.
                     request.status = ObservedElementRequestStatuses.Canceled;
                 }
                 this._rejectWaiting(key, true);

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -231,7 +231,7 @@ export type ObservedElementRequestStatus =
 export interface ObservedElementAsyncRequest<T> {
     result: Promise<T>;
     cancel(): void;
-    status: ObservedElementRequestStatus;
+    status?: ObservedElementRequestStatus; // Making status optional for the interface backwards compatibility.
 }
 
 interface ObservedElementAPIInternal {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -221,9 +221,17 @@ export type ObservedElementAccessibilities =
 export type ObservedElementAccessibility =
     ObservedElementAccessibilities[keyof ObservedElementAccessibilities];
 
+import { ObservedElementRequestStatuses as _ObservedElementRequestStatuses } from "./Consts";
+export type ObservedElementRequestStatuses =
+    typeof _ObservedElementRequestStatuses;
+
+export type ObservedElementRequestStatus =
+    ObservedElementRequestStatuses[keyof ObservedElementRequestStatuses];
+
 export interface ObservedElementAsyncRequest<T> {
     result: Promise<T>;
     cancel(): void;
+    status: ObservedElementRequestStatus;
 }
 
 interface ObservedElementAPIInternal {

--- a/tests/ObservedElement.test.tsx
+++ b/tests/ObservedElement.test.tsx
@@ -372,18 +372,26 @@ describe("Focusable", () => {
                     .dom?.getElementById(document, "test-button")
                     ?.removeAttribute("aria-hidden");
             })
-            .wait(500)
-            .eval(
-                () =>
-                    (
-                        window as {
-                            __tabsterTestRequest?: Types.ObservedElementAsyncRequest<boolean>;
-                        }
-                    ).__tabsterTestRequest?.status
-            )
-            .check((status: Types.ObservedElementRequestStatus) => {
-                expect(status).toBe(ObservedElementRequestStatuses.Succeeded);
+            .eval(async () => {
+                const request = (
+                    window as {
+                        __tabsterTestRequest?: Types.ObservedElementAsyncRequest<boolean>;
+                    }
+                ).__tabsterTestRequest;
+
+                return request ? [await request.result, request.status] : [];
             })
+            .check(
+                ([res, status]: [
+                    boolean,
+                    Types.ObservedElementRequestStatus
+                ]) => {
+                    expect(res).toBe(true);
+                    expect(status).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                }
+            )
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button1");
             });

--- a/tests/ObservedElement.test.tsx
+++ b/tests/ObservedElement.test.tsx
@@ -4,7 +4,11 @@
  */
 
 import * as React from "react";
-import { getTabsterAttribute, Types } from "tabster";
+import {
+    getTabsterAttribute,
+    Types,
+    ObservedElementRequestStatuses,
+} from "tabster";
 import * as BroTest from "./utils/BroTest";
 
 describe("Focusable", () => {
@@ -33,13 +37,35 @@ describe("Focusable", () => {
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button1");
             })
-            .eval((name) => {
-                return getTabsterTestVariables().observedElement?.requestFocus(
-                    name,
-                    0
-                ).result;
+            .eval(async (name) => {
+                const request =
+                    getTabsterTestVariables().observedElement?.requestFocus(
+                        name,
+                        0
+                    );
+
+                const initialStatus = request?.status;
+
+                return request
+                    ? [await request.result, request.status, initialStatus]
+                    : [];
             }, name)
-            .check((res: boolean) => expect(res).toBe(true))
+            .check(
+                ([res, status, initialStatus]: [
+                    boolean,
+                    Types.ObservedElementRequestStatus,
+                    Types.ObservedElementRequestStatus
+                ]) => {
+                    expect(res).toBe(true);
+                    expect(status).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                    // Given the element is already there, the initial status is Succeeded too.
+                    expect(initialStatus).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                }
+            )
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button2");
             });
@@ -67,13 +93,35 @@ describe("Focusable", () => {
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button1");
             })
-            .eval((name) => {
-                return getTabsterTestVariables().observedElement?.requestFocus(
-                    name,
-                    0
-                ).result;
+            .eval(async (name) => {
+                const request =
+                    getTabsterTestVariables().observedElement?.requestFocus(
+                        name,
+                        0
+                    );
+
+                const initialStatus = request?.status;
+
+                return request
+                    ? [await request.result, request.status, initialStatus]
+                    : [];
             }, names[0])
-            .check((res: boolean) => expect(res).toBe(true))
+            .check(
+                ([res, status, initialStatus]: [
+                    boolean,
+                    Types.ObservedElementRequestStatus,
+                    Types.ObservedElementRequestStatus
+                ]) => {
+                    expect(res).toBe(true);
+                    expect(status).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                    // Given the element is already there, the initial status is Succeeded too.
+                    expect(initialStatus).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                }
+            )
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button2");
             })
@@ -82,13 +130,35 @@ describe("Focusable", () => {
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button1");
             })
-            .eval((name) => {
-                return getTabsterTestVariables().observedElement?.requestFocus(
-                    name,
-                    0
-                ).result;
+            .eval(async (name) => {
+                const request =
+                    getTabsterTestVariables().observedElement?.requestFocus(
+                        name,
+                        0
+                    );
+
+                const initialStatus = request?.status;
+
+                return request
+                    ? [await request.result, request.status, initialStatus]
+                    : [];
             }, names[1])
-            .check((res: boolean) => expect(res).toBe(true))
+            .check(
+                ([res, status, initialStatus]: [
+                    boolean,
+                    Types.ObservedElementRequestStatus,
+                    Types.ObservedElementRequestStatus
+                ]) => {
+                    expect(res).toBe(true);
+                    expect(status).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                    // Given the element is already there, the initial status is Succeeded too.
+                    expect(initialStatus).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                }
+            )
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button2");
             });
@@ -99,12 +169,14 @@ describe("Focusable", () => {
         await new BroTest.BroTest(
             <div id="root" {...getTabsterAttribute({ root: {} })}></div>
         )
-            .eval((name) => {
+            .eval(async (name) => {
                 const request =
                     getTabsterTestVariables().observedElement?.requestFocus(
                         name,
                         5000
-                    ).result;
+                    );
+
+                const initialStatus = request?.status;
 
                 const observedButton = document.createElement("button");
                 observedButton.textContent = name;
@@ -119,9 +191,25 @@ describe("Focusable", () => {
                     JSON.stringify(observed)
                 );
 
-                return request;
+                return request
+                    ? [await request.result, request.status, initialStatus]
+                    : [];
             }, name)
-            .check((res: boolean) => expect(res).toBe(true))
+            .check(
+                ([res, status, initialStatus]: [
+                    boolean,
+                    Types.ObservedElementRequestStatus,
+                    Types.ObservedElementRequestStatus
+                ]) => {
+                    expect(res).toBe(true);
+                    expect(status).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                    expect(initialStatus).toBe(
+                        ObservedElementRequestStatuses.Waiting
+                    );
+                }
+            )
             .activeElement((el) => {
                 expect(el?.textContent).toEqual(name);
             });
@@ -129,13 +217,14 @@ describe("Focusable", () => {
 
     it("should cancel the focus request when the next one is happened", async () => {
         await new BroTest.BroTest(<div id="root"></div>)
-            .eval(() => {
-                return new Promise((resolve) => {
+            .eval(async () => {
+                return await new Promise((resolve) => {
                     const request1 =
                         getTabsterTestVariables().observedElement?.requestFocus(
                             "button1",
                             10005000
                         );
+                    const initialRequest1Status = request1?.status;
 
                     setTimeout(() => {
                         const request2 =
@@ -143,6 +232,7 @@ describe("Focusable", () => {
                                 "button2",
                                 10005000
                             );
+                        const initialRequest2Status = request2?.status;
 
                         setTimeout(() => {
                             const button1 = document.createElement("button");
@@ -160,7 +250,7 @@ describe("Focusable", () => {
 
                             root?.appendChild(button1);
 
-                            setTimeout(() => {
+                            setTimeout(async () => {
                                 const button2 =
                                     document.createElement("button");
                                 button2.setAttribute(
@@ -170,21 +260,56 @@ describe("Focusable", () => {
                                 button2.textContent = "Button2";
                                 root?.appendChild(button2);
 
-                                Promise.all([
-                                    request1?.result,
-                                    request2?.result,
-                                ]).then((onfulfilled) => {
-                                    resolve(onfulfilled);
-                                });
+                                resolve(
+                                    request1 && request2
+                                        ? [
+                                              await request1.result,
+                                              request1.status,
+                                              initialRequest1Status,
+                                              await request2.result,
+                                              request2.status,
+                                              initialRequest2Status,
+                                          ]
+                                        : []
+                                );
                             }, 100);
                         }, 100);
                     }, 100);
                 });
             })
-            .check((result: [boolean, boolean]) => {
-                expect(result[0]).toBe(false);
-                expect(result[1]).toBe(true);
-            })
+            .check(
+                ([
+                    res1,
+                    status1,
+                    initialStatus1,
+                    res2,
+                    status2,
+                    initialStatus2,
+                ]: [
+                    boolean,
+                    Types.ObservedElementRequestStatus,
+                    Types.ObservedElementRequestStatus,
+                    boolean,
+                    Types.ObservedElementRequestStatus,
+                    Types.ObservedElementRequestStatus
+                ]) => {
+                    expect(res1).toBe(false);
+                    expect(status1).toBe(
+                        ObservedElementRequestStatuses.Canceled
+                    );
+                    expect(initialStatus1).toBe(
+                        ObservedElementRequestStatuses.Waiting
+                    );
+
+                    expect(res2).toBe(true);
+                    expect(status2).toBe(
+                        ObservedElementRequestStatuses.Succeeded
+                    );
+                    expect(initialStatus2).toBe(
+                        ObservedElementRequestStatuses.Waiting
+                    );
+                }
+            )
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button2");
             });
@@ -208,12 +333,37 @@ describe("Focusable", () => {
             )
         )
             .eval((name) => {
-                getTabsterTestVariables().observedElement?.requestFocus(
-                    name,
-                    100500
-                );
+                const request =
+                    getTabsterTestVariables().observedElement?.requestFocus(
+                        name,
+                        100500
+                    );
+
+                (
+                    window as {
+                        __tabsterTestRequest?: Types.ObservedElementAsyncRequest<boolean>;
+                    }
+                ).__tabsterTestRequest = request;
+
+                return request?.status;
             }, name)
+            .check((initialStatus: Types.ObservedElementRequestStatus) => {
+                expect(initialStatus).toBe(
+                    ObservedElementRequestStatuses.Waiting
+                );
+            })
             .wait(500)
+            .eval(
+                () =>
+                    (
+                        window as {
+                            __tabsterTestRequest?: Types.ObservedElementAsyncRequest<boolean>;
+                        }
+                    ).__tabsterTestRequest?.status
+            )
+            .check((status: Types.ObservedElementRequestStatus) => {
+                expect(status).toBe(ObservedElementRequestStatuses.Waiting);
+            })
             .activeElement((el) => {
                 expect(el?.textContent).toBeUndefined();
             })
@@ -223,6 +373,17 @@ describe("Focusable", () => {
                     ?.removeAttribute("aria-hidden");
             })
             .wait(500)
+            .eval(
+                () =>
+                    (
+                        window as {
+                            __tabsterTestRequest?: Types.ObservedElementAsyncRequest<boolean>;
+                        }
+                    ).__tabsterTestRequest?.status
+            )
+            .check((status: Types.ObservedElementRequestStatus) => {
+                expect(status).toBe(ObservedElementRequestStatuses.Succeeded);
+            })
             .activeElement((el) => {
                 expect(el?.textContent).toEqual("Button1");
             });
@@ -295,5 +456,43 @@ describe("Focusable", () => {
                 expect(el?.attributes.id).toEqual("test-button-2");
                 expect(el?.textContent).toEqual("CreatedButton");
             });
+    });
+
+    it("should time out waiting for nonexistent element", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button>Button1</button>
+                </div>
+            )
+        )
+            .eval(async () => {
+                const request =
+                    getTabsterTestVariables().observedElement?.requestFocus(
+                        "SomeName",
+                        600 // Set timeout relatively low to not wait forever
+                    );
+
+                const initialStatus = request?.status;
+
+                return request
+                    ? [await request.result, request.status, initialStatus]
+                    : [];
+            })
+            .check(
+                ([res, status, initialStatus]: [
+                    boolean,
+                    Types.ObservedElementRequestStatus,
+                    Types.ObservedElementRequestStatus
+                ]) => {
+                    expect(res).toBe(false);
+                    expect(status).toBe(
+                        ObservedElementRequestStatuses.TimedOut
+                    );
+                    expect(initialStatus).toBe(
+                        ObservedElementRequestStatuses.Waiting
+                    );
+                }
+            );
     });
 });

--- a/tests/ObservedElement.test.tsx
+++ b/tests/ObservedElement.test.tsx
@@ -379,6 +379,13 @@ describe("Focusable", () => {
                     }
                 ).__tabsterTestRequest;
 
+                // Clean up the global variable.
+                delete (
+                    window as {
+                        __tabsterTestRequest?: Types.ObservedElementAsyncRequest<boolean>;
+                    }
+                ).__tabsterTestRequest;
+
                 return request ? [await request.result, request.status] : [];
             })
             .check(


### PR DESCRIPTION
When requestFocus() request resolves with `true` or `false`, in case of `false` it was not possible to tell the difference between timed out request or canceled request (older requests get canceled when a new request is made or when a user has moved focus). Adding status to be able to tell one from another.