### PR TITLE
feat(Modalizer): A method to activate modalizer without moving focus.

### DIFF
--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -692,6 +692,23 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         return false;
     }
 
+    activate(modalizerElementOrContainer: HTMLElement | undefined): boolean {
+        const modalizerToActivate: Types.Modalizer | undefined =
+            modalizerElementOrContainer
+                ? RootAPI.getTabsterContext(
+                      this._tabster,
+                      modalizerElementOrContainer
+                  )?.modalizer
+                : undefined;
+
+        if (!modalizerElementOrContainer || modalizerToActivate) {
+            this.setActive(modalizerToActivate);
+            return true;
+        }
+
+        return false;
+    }
+
     acceptElement(
         element: HTMLElement,
         state: Types.FocusableAcceptElementState

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1014,6 +1014,17 @@ export interface ModalizerAPI extends ModalizerAPIInternal, Disposable {
         noFocusFirst?: boolean,
         noFocusDefault?: boolean
     ): boolean;
+
+    /**
+     * Just activates the modalizer without focusing on any element. Might be useful,
+     * when the modalizer doesn't have focusable elements yet (but you want it active
+     * already).
+     *
+     * @param modalizerElementOrContainer The element that belongs to a Modalizer or the Modalizer container,
+     * or null to active main app (deactivating any active modalizer).
+     * @returns true if the modalizer was activated.
+     */
+    activate(modalizerElementOrContainer: HTMLElement | undefined): boolean;
 }
 
 interface RestorerAPIInternal {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1021,7 +1021,7 @@ export interface ModalizerAPI extends ModalizerAPIInternal, Disposable {
      * already).
      *
      * @param modalizerElementOrContainer The element that belongs to a Modalizer or the Modalizer container,
-     * or null to active main app (deactivating any active modalizer).
+     * or undefined to active main app (deactivating any active modalizer).
      * @returns true if the modalizer was activated.
      */
     activate(modalizerElementOrContainer: HTMLElement | undefined): boolean;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1021,7 +1021,7 @@ export interface ModalizerAPI extends ModalizerAPIInternal, Disposable {
      * already).
      *
      * @param modalizerElementOrContainer The element that belongs to a Modalizer or the Modalizer container,
-     * or undefined to active main app (deactivating any active modalizer).
+     * or undefined to activate main app (deactivating any active modalizer).
      * @returns true if the modalizer was activated.
      */
     activate(modalizerElementOrContainer: HTMLElement | undefined): boolean;

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -2879,7 +2879,7 @@ describe("Modalizer activation on creation", () => {
     });
 });
 
-describe("Modalizer activation history", () => {
+describe("Modalizer activation", () => {
     beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({ modalizer: true });
     });
@@ -2945,6 +2945,85 @@ describe("Modalizer activation history", () => {
             .activeElement((el) => expect(el?.textContent).toBeUndefined())
             .pressTab()
             .wait(300) // Give Modalizer time to restore focus to active modalizer.
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("ModalButton1")
+            );
+    });
+
+    it("should activate modalizer by element from modalizer or modalizer container", async () => {
+        await new BroTest.BroTest(
+            (
+                <div {...getTabsterAttribute({ root: {} })}>
+                    <button id="button-1">Button1</button>
+                    <div
+                        id="modal-1"
+                        aria-label="modal"
+                        {...getTabsterAttribute({
+                            modalizer: { id: "modal-1", isTrapped: true },
+                        })}
+                    >
+                        <button id="modal-button-1">ModalButton1</button>
+                    </div>
+                    <button>Button2</button>
+                </div>
+            )
+        )
+            .focusElement("#button-1")
+            .activeElement((el) => expect(el?.textContent).toEqual("Button1"))
+            .eval(() => {
+                const tabsterTestVariables = getTabsterTestVariables();
+                const element = tabsterTestVariables.dom?.getElementById(
+                    document,
+                    "modal-button-1"
+                );
+
+                if (element) {
+                    // Activate by element from modalizer.
+                    return [tabsterTestVariables.modalizer?.activate(element)];
+                }
+
+                return [];
+            })
+            .check((result: boolean[]) => {
+                expect(result).toEqual([true]);
+            })
+            .pressTab()
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("ModalButton1")
+            )
+            .pressTab()
+            .activeElement((el) =>
+                expect(el?.textContent).toEqual("ModalButton1")
+            )
+            .eval(() => {
+                return [
+                    // Deactivate modalizer.
+                    getTabsterTestVariables().modalizer?.activate(undefined),
+                ];
+            })
+            .check((result: boolean[]) => {
+                expect(result).toEqual([true]);
+            })
+            .pressTab()
+            .activeElement((el) => expect(el?.textContent).toEqual("Button2"))
+            .eval(() => {
+                const tabsterTestVariables = getTabsterTestVariables();
+                const element = tabsterTestVariables.dom?.getElementById(
+                    document,
+                    "modal-1"
+                );
+
+                if (element) {
+                    // Activate by modalizer container.
+                    return [tabsterTestVariables.modalizer?.activate(element)];
+                }
+
+                return [];
+            })
+            .check((result: boolean[]) => {
+                expect(result).toEqual([true]);
+            })
+            .pressTab()
             .activeElement((el) =>
                 expect(el?.textContent).toEqual("ModalButton1")
             );

--- a/tests/Modalizer.test.tsx
+++ b/tests/Modalizer.test.tsx
@@ -3023,7 +3023,7 @@ describe("Modalizer activation", () => {
             .check((result: boolean[]) => {
                 expect(result).toEqual([true]);
             })
-            .pressTab()
+            .pressTab(true)
             .activeElement((el) =>
                 expect(el?.textContent).toEqual("ModalButton1")
             );


### PR DESCRIPTION
In some cases we might want to activate Modalizer without moving focus (for example there are no focusable elements yet, but we already want to activate focus trap and deactivate the rest of the app). This PR adds new method `activate()` to the Modalizer API.