### PR TITLE
fix: unhandled promise rejection in ObservedElementAPI

### DIFF
--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -228,7 +228,10 @@ export class ObservedElementAPI
                 w.resolve = resolve;
                 w.reject = reject;
             }
-        );
+        ).catch(() => {
+            // Ignore the error, it is expected to be rejected when the request is canceled.
+            return null;
+        });
 
         const request: Types.ObservedElementAsyncRequest<HTMLElement | null> = {
             result: promise,


### PR DESCRIPTION
### Before

Tests are failing:

<img width="718" alt="image" src="https://github.com/user-attachments/assets/cafd0123-9b65-4297-9bb6-b52396e0353a" />

See for context https://github.com/microsoft/fluentui/pull/34291.

### After

Tests are passing:

<img width="569" alt="image" src="https://github.com/user-attachments/assets/abe79622-d1b5-4fda-b283-4f5c26d4b4b6" />
