### PR TITLE
fix: handle inert in FocusableAPI

### DIFF
--- a/src/Consts.ts
+++ b/src/Consts.ts
@@ -6,6 +6,8 @@
 export const TABSTER_ATTRIBUTE_NAME = "data-tabster" as const;
 export const TABSTER_DUMMY_INPUT_ATTRIBUTE_NAME = "data-tabster-dummy" as const;
 
+export const INERT_SELECTOR = `[inert], [inert] *`;
+
 export const FOCUSABLE_SELECTOR = `:is(${[
     "a[href]",
     "button",
@@ -17,7 +19,7 @@ export const FOCUSABLE_SELECTOR = `:is(${[
     "details > summary",
     "audio[controls]",
     "video[controls]",
-].join(", ")}):not(:disabled)`;
+].join(", ")}):not(:disabled, ${INERT_SELECTOR})`;
 
 export const AsyncFocusSources = {
     EscapeGroupper: 1,

--- a/src/Focusable.ts
+++ b/src/Focusable.ts
@@ -6,7 +6,7 @@
 import { getTabsterOnElement } from "./Instance";
 import { RootAPI } from "./Root";
 import * as Types from "./Types";
-import { FOCUSABLE_SELECTOR } from "./Consts";
+import { INERT_SELECTOR, FOCUSABLE_SELECTOR } from "./Consts";
 import {
     createElementTreeWalker,
     getDummyInputContainer,
@@ -81,6 +81,10 @@ export class FocusableAPI implements Types.FocusableAPI {
                 return false;
             }
 
+            if (this._isInert(e)) {
+                return false;
+            }
+
             const ignoreDisabled =
                 tabsterOnElement?.focusable?.ignoreAriaDisabled;
 
@@ -94,6 +98,14 @@ export class FocusableAPI implements Types.FocusableAPI {
 
     private _isDisabled(el: HTMLElement): boolean {
         return el.hasAttribute("disabled");
+    }
+
+    private _isInert(el: HTMLElement): boolean {
+        if (matchesSelector(el, INERT_SELECTOR)) {
+            return true;
+        }
+
+        return false;
     }
 
     private _isHidden(el: HTMLElement): boolean {


### PR DESCRIPTION
- FOCUSABLE_SELECTOR now only matches if the element and all of its parents are not inert
- isFocusable returns false if element or its parents are inert
- isAccesible returns false if the element or its parents are inert

closes https://github.com/microsoft/tabster/issues/369