### PR TITLE
chore(bundle-size): rename fixtures for clarity + fill coverage

### DIFF
--- a/bundle-size/allExports.fixture.js
+++ b/bundle-size/allExports.fixture.js
@@ -11,6 +11,7 @@ import {
     getModalizer,
     getObservedElement,
     getOutline,
+    getRestorer,
     getInternal,
     overrideBasics,
     makeNoOp,
@@ -31,6 +32,7 @@ console.log(
     getModalizer,
     getObservedElement,
     getOutline,
+    getRestorer,
     getInternal,
     overrideBasics,
     makeNoOp,
@@ -39,5 +41,5 @@ console.log(
 );
 
 export default {
-    name: "All Tabster",
+    name: "all exports",
 };

--- a/bundle-size/createTabster.fixture.js
+++ b/bundle-size/createTabster.fixture.js
@@ -1,0 +1,19 @@
+import {
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    Types,
+} from "tabster";
+
+console.log(
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    Types
+);
+
+export default {
+    name: "createTabster (core)",
+};

--- a/bundle-size/getCrossOrigin.fixture.js
+++ b/bundle-size/getCrossOrigin.fixture.js
@@ -3,7 +3,7 @@ import {
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getModalizer,
+    getCrossOrigin,
     Types,
 } from "tabster";
 
@@ -12,10 +12,10 @@ console.log(
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getModalizer,
+    getCrossOrigin,
     Types
 );
 
 export default {
-    name: "Modalizer only",
+    name: "getCrossOrigin",
 };

--- a/bundle-size/getDeloser.fixture.js
+++ b/bundle-size/getDeloser.fixture.js
@@ -3,7 +3,7 @@ import {
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getRestorer,
+    getDeloser,
     Types,
 } from "tabster";
 
@@ -12,10 +12,10 @@ console.log(
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getRestorer,
+    getDeloser,
     Types
 );
 
 export default {
-    name: "Restorer only",
+    name: "getDeloser",
 };

--- a/bundle-size/getGroupper.fixture.js
+++ b/bundle-size/getGroupper.fixture.js
@@ -1,0 +1,21 @@
+import {
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    getGroupper,
+    Types,
+} from "tabster";
+
+console.log(
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    getGroupper,
+    Types
+);
+
+export default {
+    name: "getGroupper",
+};

--- a/bundle-size/getModalizer.fixture.js
+++ b/bundle-size/getModalizer.fixture.js
@@ -3,7 +3,7 @@ import {
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getGroupper,
+    getModalizer,
     Types,
 } from "tabster";
 
@@ -12,10 +12,10 @@ console.log(
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getGroupper,
+    getModalizer,
     Types
 );
 
 export default {
-    name: "Groupper only",
+    name: "getModalizer",
 };

--- a/bundle-size/getMover.fixture.js
+++ b/bundle-size/getMover.fixture.js
@@ -3,10 +3,7 @@ import {
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getGroupper,
     getMover,
-    getDeloser,
-    getModalizer,
     Types,
 } from "tabster";
 
@@ -15,13 +12,10 @@ console.log(
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getGroupper,
     getMover,
-    getDeloser,
-    getModalizer,
     Types
 );
 
 export default {
-    name: "Partners import",
+    name: "getMover",
 };

--- a/bundle-size/getObservedElement.fixture.js
+++ b/bundle-size/getObservedElement.fixture.js
@@ -1,0 +1,21 @@
+import {
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    getObservedElement,
+    Types,
+} from "tabster";
+
+console.log(
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    getObservedElement,
+    Types
+);
+
+export default {
+    name: "getObservedElement",
+};

--- a/bundle-size/getOutline.fixture.js
+++ b/bundle-size/getOutline.fixture.js
@@ -3,7 +3,7 @@ import {
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getMover,
+    getOutline,
     Types,
 } from "tabster";
 
@@ -12,10 +12,10 @@ console.log(
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getMover,
+    getOutline,
     Types
 );
 
 export default {
-    name: "Mover only",
+    name: "getOutline",
 };

--- a/bundle-size/getRestorer.fixture.js
+++ b/bundle-size/getRestorer.fixture.js
@@ -3,7 +3,7 @@ import {
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getDeloser,
+    getRestorer,
     Types,
 } from "tabster";
 
@@ -12,10 +12,10 @@ console.log(
     disposeTabster,
     getTabsterAttribute,
     setTabsterAttribute,
-    getDeloser,
+    getRestorer,
     Types
 );
 
 export default {
-    name: "Deloser only",
+    name: "getRestorer",
 };


### PR DESCRIPTION
## Motivation

`bundle-size/*.fixture.js` has two small issues that make the report harder to read than it should be:

- Fixture file names are ambiguous. `Tabster.fixture.js` could mean "the Tabster core only" or "every Tabster export"; in the current file it's the latter.
- Not every `get*` export is represented. There are no fixtures for `getCrossOrigin`, `getOutline`, or `getObservedElement`, so those subsystems' sizes aren't tracked at all.
- There's also a `Partners.fixture.js` that measures an arbitrary mix of 4 getters — there's no principled reason for that particular combination, and the individual fixtures plus an "all exports" ceiling already cover the useful cases.

## Changes

- Rename each single-getter fixture to match the import it measures:
  `Deloser.fixture.js` → `getDeloser.fixture.js` (same for Groupper, Modalizer, Mover, Restorer). The fixture `name` is updated to match (`"Deloser only"` → `"getDeloser"`) so the reporter labels line up with the file and with the actual symbol being measured.
- Rename `Tabster.fixture.js` → `allExports.fixture.js` (name `"All Tabster"` → `"all exports"`). Also add `getRestorer` to its import list — it was the one getter missing from the "everything" fixture.
- Remove `Partners.fixture.js`.
- Add three new single-getter fixtures so every public `get*` is represented:
  - `getCrossOrigin.fixture.js`
  - `getOutline.fixture.js`
  - `getObservedElement.fixture.js`
- Add a core-only baseline fixture, `createTabster.fixture.js`. It imports the same companions every single-getter fixture uses (`createTabster`, `disposeTabster`, `getTabsterAttribute`, `setTabsterAttribute`, `Types`) but no `get*`. The delta between this row and any `get<X>` row is then the marginal cost of pulling in that subsystem.

## Results on this branch

```
┌──────────────────────┬───────────────┬───────────┐
│ Fixture              │ Minified size │ GZIP size │
├──────────────────────┼───────────────┼───────────┤
│ all exports          │ 126.467 kB    │ 33.184 kB │
│ createTabster (core) │ 50.313 kB     │ 14.011 kB │
│ getCrossOrigin       │ 122.843 kB    │ 32.255 kB │
│ getDeloser           │ 59.995 kB     │ 16.387 kB │
│ getGroupper          │ 57.893 kB     │ 15.748 kB │
│ getModalizer         │ 60.038 kB     │ 16.547 kB │
│ getMover             │ 65.946 kB     │ 18.192 kB │
│ getObservedElement   │ 56.376 kB     │ 15.708 kB │
│ getOutline           │ 59.395 kB     │ 16.354 kB │
│ getRestorer          │ 52.891 kB     │ 14.556 kB │
└──────────────────────┴───────────────┴───────────┘
```

A couple of things the new coverage makes visible:

- `createTabster` alone is 50 kB — the always-shipped floor.
- `getCrossOrigin` is nearly the whole library (122 kB). It instantiates every other subsystem, so importing it transitively pulls in Deloser, Modalizer, Mover, Groupper, Outline, ObservedElement. That fact was previously untracked.
- `getRestorer` is cheapest (≈ 2.6 kB marginal); `getMover` is the most expensive single subsystem at ≈ 15.6 kB marginal.

No source changes — only fixtures.
