### PR TITLE
feat(exports): split get* into subpath modules for tree-shaking (Rollup)

### DIFF
--- a/monosize.config.mjs
+++ b/monosize.config.mjs
@@ -18,7 +18,7 @@ const config = {
         config.resolve = config.resolve ?? {};
         config.resolve.alias = {
             ...(config.resolve.alias ?? {}),
-            tabster: path.resolve(__dirname, "./dist/tabster.esm.js"),
+            tabster: path.resolve(__dirname, "./dist/esm/index.js"),
         };
         return config;
     }),

--- a/package.json
+++ b/package.json
@@ -6,8 +6,39 @@
     "license": "MIT",
     "sideEffects": false,
     "main": "./dist/index.js",
-    "module": "./dist/tabster.esm.js",
+    "module": "./dist/esm/index.js",
     "typings": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/esm/index.js",
+            "require": "./dist/index.js"
+        },
+        "./groupper": {
+            "import": "./dist/esm/get/getGroupper.js"
+        },
+        "./mover": {
+            "import": "./dist/esm/get/getMover.js"
+        },
+        "./modalizer": {
+            "import": "./dist/esm/get/getModalizer.js"
+        },
+        "./deloser": {
+            "import": "./dist/esm/get/getDeloser.js"
+        },
+        "./outline": {
+            "import": "./dist/esm/get/getOutline.js"
+        },
+        "./observed-element": {
+            "import": "./dist/esm/get/getObservedElement.js"
+        },
+        "./cross-origin": {
+            "import": "./dist/esm/get/getCrossOrigin.js"
+        },
+        "./restorer": {
+            "import": "./dist/esm/get/getRestorer.js"
+        }
+    },
     "files": [
         "dist"
     ],

--- a/package.json
+++ b/package.json
@@ -5,38 +5,54 @@
     "author": "Marat Abdullin <marata@microsoft.com>",
     "license": "MIT",
     "sideEffects": false,
-    "main": "./dist/index.js",
+    "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",
     "typings": "./dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
             "import": "./dist/esm/index.js",
-            "require": "./dist/index.js"
+            "require": "./dist/cjs/index.js"
         },
         "./groupper": {
-            "import": "./dist/esm/get/getGroupper.js"
+            "types": "./dist/get/getGroupper.d.ts",
+            "import": "./dist/esm/get/getGroupper.js",
+            "require": "./dist/cjs/get/getGroupper.js"
         },
         "./mover": {
-            "import": "./dist/esm/get/getMover.js"
+            "types": "./dist/get/getMover.d.ts",
+            "import": "./dist/esm/get/getMover.js",
+            "require": "./dist/cjs/get/getMover.js"
         },
         "./modalizer": {
-            "import": "./dist/esm/get/getModalizer.js"
+            "types": "./dist/get/getModalizer.d.ts",
+            "import": "./dist/esm/get/getModalizer.js",
+            "require": "./dist/cjs/get/getModalizer.js"
         },
         "./deloser": {
-            "import": "./dist/esm/get/getDeloser.js"
+            "types": "./dist/get/getDeloser.d.ts",
+            "import": "./dist/esm/get/getDeloser.js",
+            "require": "./dist/cjs/get/getDeloser.js"
         },
         "./outline": {
-            "import": "./dist/esm/get/getOutline.js"
+            "types": "./dist/get/getOutline.d.ts",
+            "import": "./dist/esm/get/getOutline.js",
+            "require": "./dist/cjs/get/getOutline.js"
         },
         "./observed-element": {
-            "import": "./dist/esm/get/getObservedElement.js"
+            "types": "./dist/get/getObservedElement.d.ts",
+            "import": "./dist/esm/get/getObservedElement.js",
+            "require": "./dist/cjs/get/getObservedElement.js"
         },
         "./cross-origin": {
-            "import": "./dist/esm/get/getCrossOrigin.js"
+            "types": "./dist/get/getCrossOrigin.d.ts",
+            "import": "./dist/esm/get/getCrossOrigin.js",
+            "require": "./dist/cjs/get/getCrossOrigin.js"
         },
         "./restorer": {
-            "import": "./dist/esm/get/getRestorer.js"
+            "types": "./dist/get/getRestorer.d.ts",
+            "import": "./dist/esm/get/getRestorer.js",
+            "require": "./dist/cjs/get/getRestorer.js"
         }
     },
     "files": [

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -18,7 +18,14 @@ const config = [
         input: "./src/index.ts",
         output: [
             { file: pkg.main, format: "cjs", sourcemap: true },
-            { file: pkg.module, format: "es", sourcemap: true },
+            {
+                dir: "dist/esm",
+                format: "es",
+                sourcemap: true,
+                preserveModules: true,
+                preserveModulesRoot: "src",
+                entryFileNames: "[name].js",
+            },
         ],
         external: ["tslib", "keyborg"],
         plugins: [

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,3 +1,4 @@
+import { mkdirSync, writeFileSync } from "node:fs";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import { babel } from "@rollup/plugin-babel";
@@ -10,6 +11,36 @@ import pkg from "./package.json" with { type: "json" };
 
 const extensions = [".ts"];
 
+const SUBPATH_GETTERS = [
+    "getCrossOrigin",
+    "getDeloser",
+    "getGroupper",
+    "getModalizer",
+    "getMover",
+    "getObservedElement",
+    "getOutline",
+    "getRestorer",
+];
+
+/**
+ * Emits per-subpath .d.ts stubs that re-export from the rolled-up
+ * `dist/index.d.ts`, so `tabster/mover` etc. share a single declaration
+ * site with the main entry (avoids duplicate-type-with-different-shape
+ * mismatches when mixing main and subpath imports).
+ */
+const subpathTypeStubs = () => ({
+    name: "emit-subpath-dts-stubs",
+    writeBundle() {
+        mkdirSync("dist/get", { recursive: true });
+        for (const name of SUBPATH_GETTERS) {
+            writeFileSync(
+                `dist/get/${name}.d.ts`,
+                `export { ${name} } from "../index";\n`
+            );
+        }
+    },
+});
+
 /**
  * @type {import('rollup').RollupOptions}
  */
@@ -17,7 +48,15 @@ const config = [
     {
         input: "./src/index.ts",
         output: [
-            { file: pkg.main, format: "cjs", sourcemap: true },
+            {
+                dir: "dist/cjs",
+                format: "cjs",
+                sourcemap: true,
+                preserveModules: true,
+                preserveModulesRoot: "src",
+                entryFileNames: "[name].js",
+                exports: "named",
+            },
             {
                 dir: "dist/esm",
                 format: "es",
@@ -60,7 +99,7 @@ const config = [
         output: [{ file: "dist/index.d.ts", format: "es" }],
         // rolls up all dts files into a single dts file
         // so that internal types don't leak
-        plugins: [dts()],
+        plugins: [dts(), subpathTypeStubs()],
     },
 ];
 

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -3,18 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { CrossOriginAPI } from "./CrossOrigin";
-import { DeloserAPI } from "./Deloser";
 import { FocusableAPI } from "./Focusable";
 import { FocusedElementState } from "./State/FocusedElement";
-import { GroupperAPI } from "./Groupper";
 import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance";
 import { KeyboardNavigationState } from "./State/KeyboardNavigation";
-import { ModalizerAPI } from "./Modalizer";
-import { MoverAPI } from "./Mover";
 import { observeMutations } from "./MutationEvent";
-import { ObservedElementAPI } from "./State/ObservedElement";
-import { OutlineAPI } from "./Outline";
 import { RootAPI, WindowWithTabsterInstance } from "./Root";
 import * as Types from "./Types";
 import { TABSTER_ATTRIBUTE_NAME } from "./Consts";
@@ -30,7 +23,6 @@ import {
     startFakeWeakRefsCleanup,
     stopFakeWeakRefsCleanupAndClearStorage,
 } from "./Utils";
-import { RestorerAPI } from "./Restorer";
 import { dom, setDOMAPI } from "./DOMAPI";
 import * as shadowDOMAPI from "./Shadowdomize";
 
@@ -355,137 +347,9 @@ export function getShadowDOMAPI(): Types.DOMAPI {
     return shadowDOMAPI;
 }
 
-/**
- * Creates a new groupper instance or returns an existing one
- * @param tabster Tabster instance
- */
-export function getGroupper(tabster: Types.Tabster): Types.GroupperAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.groupper) {
-        tabsterCore.groupper = new GroupperAPI(
-            tabsterCore,
-            tabsterCore.getWindow
-        );
-    }
-
-    return tabsterCore.groupper;
-}
-
-/**
- * Creates a new mover instance or returns an existing one
- * @param tabster Tabster instance
- */
-export function getMover(tabster: Types.Tabster): Types.MoverAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.mover) {
-        tabsterCore.mover = new MoverAPI(tabsterCore, tabsterCore.getWindow);
-    }
-
-    return tabsterCore.mover;
-}
-
-export function getOutline(tabster: Types.Tabster): Types.OutlineAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.outline) {
-        tabsterCore.outline = new OutlineAPI(tabsterCore);
-    }
-
-    return tabsterCore.outline;
-}
-
-/**
- * Creates a new new deloser instance or returns an existing one
- * @param tabster Tabster instance
- * @param props Deloser props
- */
-export function getDeloser(
-    tabster: Types.Tabster,
-    props?: { autoDeloser: Types.DeloserProps }
-): Types.DeloserAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.deloser) {
-        tabsterCore.deloser = new DeloserAPI(tabsterCore, props);
-    }
-
-    return tabsterCore.deloser;
-}
-
-/**
- * Creates a new modalizer instance or returns an existing one
- * @param tabster Tabster instance
- * @param alwaysAccessibleSelector When Modalizer is active, we put
- * aria-hidden to everything else to hide it from screen readers. This CSS
- * selector allows to exclude some elements from this behaviour. For example,
- * this could be used to exclude aria-live region with the application-wide
- * status announcements.
- * @param accessibleCheck An optional callback that will be called when
- * active Modalizer wants to hide an element that doesn't belong to it from
- * the screen readers by setting aria-hidden. Similar to alwaysAccessibleSelector
- * but allows to address the elements programmatically rather than with a selector.
- * If the callback returns true, the element will not receive aria-hidden.
- */
-export function getModalizer(
-    tabster: Types.Tabster,
-    // @deprecated use accessibleCheck.
-    alwaysAccessibleSelector?: string,
-    accessibleCheck?: Types.ModalizerElementAccessibleCheck
-): Types.ModalizerAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.modalizer) {
-        tabsterCore.modalizer = new ModalizerAPI(
-            tabsterCore,
-            alwaysAccessibleSelector,
-            accessibleCheck
-        );
-    }
-
-    return tabsterCore.modalizer;
-}
-
-export function getObservedElement(
-    tabster: Types.Tabster
-): Types.ObservedElementAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.observedElement) {
-        tabsterCore.observedElement = new ObservedElementAPI(tabsterCore);
-    }
-
-    return tabsterCore.observedElement;
-}
-
-export function getCrossOrigin(tabster: Types.Tabster): Types.CrossOriginAPI {
-    const tabsterCore = tabster.core;
-    if (!tabsterCore.crossOrigin) {
-        getDeloser(tabster);
-        getModalizer(tabster);
-        getMover(tabster);
-        getGroupper(tabster);
-        getOutline(tabster);
-        getObservedElement(tabster);
-        tabsterCore.crossOrigin = new CrossOriginAPI(tabsterCore);
-    }
-
-    return tabsterCore.crossOrigin;
-}
-
 export function getInternal(tabster: Types.Tabster): Types.InternalAPI {
     const tabsterCore = tabster.core;
     return tabsterCore.internal;
-}
-
-export function getRestorer(tabster: Types.Tabster): Types.RestorerAPI {
-    const tabsterCore = tabster.core;
-    if (!tabsterCore.restorer) {
-        tabsterCore.restorer = new RestorerAPI(tabsterCore);
-    }
-
-    return tabsterCore.restorer;
 }
 
 export function disposeTabster(

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -415,3 +415,12 @@ export function makeNoOp(tabster: Types.Tabster, noop: boolean): void {
 export function isNoOp(tabster: Types.TabsterCore): boolean {
     return (tabster as TabsterCore)._noop;
 }
+
+export { getCrossOrigin } from "./get/getCrossOrigin";
+export { getDeloser } from "./get/getDeloser";
+export { getGroupper } from "./get/getGroupper";
+export { getModalizer } from "./get/getModalizer";
+export { getMover } from "./get/getMover";
+export { getObservedElement } from "./get/getObservedElement";
+export { getOutline } from "./get/getOutline";
+export { getRestorer } from "./get/getRestorer";

--- a/src/get/getCrossOrigin.ts
+++ b/src/get/getCrossOrigin.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { CrossOriginAPI } from "../CrossOrigin";
+import type * as Types from "../Types";
+import { getDeloser } from "./getDeloser";
+import { getModalizer } from "./getModalizer";
+import { getMover } from "./getMover";
+import { getGroupper } from "./getGroupper";
+import { getOutline } from "./getOutline";
+import { getObservedElement } from "./getObservedElement";
+
+export function getCrossOrigin(tabster: Types.Tabster): Types.CrossOriginAPI {
+    const tabsterCore = tabster.core;
+    if (!tabsterCore.crossOrigin) {
+        getDeloser(tabster);
+        getModalizer(tabster);
+        getMover(tabster);
+        getGroupper(tabster);
+        getOutline(tabster);
+        getObservedElement(tabster);
+        tabsterCore.crossOrigin = new CrossOriginAPI(tabsterCore);
+    }
+
+    return tabsterCore.crossOrigin;
+}

--- a/src/get/getDeloser.ts
+++ b/src/get/getDeloser.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DeloserAPI } from "../Deloser";
+import type * as Types from "../Types";
+
+/**
+ * Creates a new deloser instance or returns an existing one
+ * @param tabster Tabster instance
+ * @param props Deloser props
+ */
+export function getDeloser(
+    tabster: Types.Tabster,
+    props?: { autoDeloser: Types.DeloserProps }
+): Types.DeloserAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.deloser) {
+        tabsterCore.deloser = new DeloserAPI(tabsterCore, props);
+    }
+
+    return tabsterCore.deloser;
+}

--- a/src/get/getGroupper.ts
+++ b/src/get/getGroupper.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { GroupperAPI } from "../Groupper";
+import type * as Types from "../Types";
+
+/**
+ * Creates a new groupper instance or returns an existing one
+ * @param tabster Tabster instance
+ */
+export function getGroupper(tabster: Types.Tabster): Types.GroupperAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.groupper) {
+        tabsterCore.groupper = new GroupperAPI(
+            tabsterCore,
+            tabsterCore.getWindow
+        );
+    }
+
+    return tabsterCore.groupper;
+}

--- a/src/get/getModalizer.ts
+++ b/src/get/getModalizer.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ModalizerAPI } from "../Modalizer";
+import type * as Types from "../Types";
+
+/**
+ * Creates a new modalizer instance or returns an existing one
+ * @param tabster Tabster instance
+ * @param alwaysAccessibleSelector When Modalizer is active, we put aria-hidden to
+ * everything else to hide it from screen readers. This CSS selector allows to
+ * exclude some elements from this behaviour.
+ * @param accessibleCheck An optional callback used to exclude elements from
+ * receiving aria-hidden when a Modalizer is active.
+ */
+export function getModalizer(
+    tabster: Types.Tabster,
+    // @deprecated use accessibleCheck.
+    alwaysAccessibleSelector?: string,
+    accessibleCheck?: Types.ModalizerElementAccessibleCheck
+): Types.ModalizerAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.modalizer) {
+        tabsterCore.modalizer = new ModalizerAPI(
+            tabsterCore,
+            alwaysAccessibleSelector,
+            accessibleCheck
+        );
+    }
+
+    return tabsterCore.modalizer;
+}

--- a/src/get/getMover.ts
+++ b/src/get/getMover.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { MoverAPI } from "../Mover";
+import type * as Types from "../Types";
+
+/**
+ * Creates a new mover instance or returns an existing one
+ * @param tabster Tabster instance
+ */
+export function getMover(tabster: Types.Tabster): Types.MoverAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.mover) {
+        tabsterCore.mover = new MoverAPI(tabsterCore, tabsterCore.getWindow);
+    }
+
+    return tabsterCore.mover;
+}

--- a/src/get/getObservedElement.ts
+++ b/src/get/getObservedElement.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ObservedElementAPI } from "../State/ObservedElement";
+import type * as Types from "../Types";
+
+export function getObservedElement(
+    tabster: Types.Tabster
+): Types.ObservedElementAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.observedElement) {
+        tabsterCore.observedElement = new ObservedElementAPI(tabsterCore);
+    }
+
+    return tabsterCore.observedElement;
+}

--- a/src/get/getOutline.ts
+++ b/src/get/getOutline.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { OutlineAPI } from "../Outline";
+import type * as Types from "../Types";
+
+export function getOutline(tabster: Types.Tabster): Types.OutlineAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.outline) {
+        tabsterCore.outline = new OutlineAPI(tabsterCore);
+    }
+
+    return tabsterCore.outline;
+}

--- a/src/get/getRestorer.ts
+++ b/src/get/getRestorer.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { RestorerAPI } from "../Restorer";
+import type * as Types from "../Types";
+
+export function getRestorer(tabster: Types.Tabster): Types.RestorerAPI {
+    const tabsterCore = tabster.core;
+    if (!tabsterCore.restorer) {
+        tabsterCore.restorer = new RestorerAPI(tabsterCore);
+    }
+
+    return tabsterCore.restorer;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,21 +7,22 @@ export {
     createTabster,
     disposeTabster,
     forceCleanup,
-    getCrossOrigin,
-    getDeloser,
     getDummyInputContainer,
-    getGroupper,
     getInternal,
-    getModalizer,
-    getMover,
-    getObservedElement,
-    getOutline,
-    getRestorer,
-    getShadowDOMAPI,
     getTabster,
+    getShadowDOMAPI,
     isNoOp,
     makeNoOp,
 } from "./Tabster";
+
+export { getCrossOrigin } from "./get/getCrossOrigin";
+export { getDeloser } from "./get/getDeloser";
+export { getGroupper } from "./get/getGroupper";
+export { getModalizer } from "./get/getModalizer";
+export { getMover } from "./get/getMover";
+export { getObservedElement } from "./get/getObservedElement";
+export { getOutline } from "./get/getOutline";
+export { getRestorer } from "./get/getRestorer";
 
 export * from "./AttributeHelpers";
 


### PR DESCRIPTION
## Motivation

Every consumer of `tabster` pulls in ~60 KB of subsystem code regardless of which `get*` function they use. `Tabster.ts` statically imports every subsystem class (`GroupperAPI`, `MoverAPI`, `ModalizerAPI`, `DeloserAPI`, `OutlineAPI`, `CrossOriginAPI`, `ObservedElementAPI`, `RestorerAPI`) at the top of the file, so once any `get*` is reachable the entire subsystem set lands in the consumer's module graph. `CrossOrigin.js` alone is ~33 KB and ships to every Fluent consumer even though no Fluent package calls `getCrossOrigin`.

This PR keeps the existing **Rollup** build pipeline unchanged and lays new subpath exports on top of it. A sibling PR (#515) does the same source refactor under a **TSC + SWC** build swap; the two PRs are alternatives — pick whichever build philosophy the repo prefers.

## What this PR does

1. **Split `get*` into `src/get/<name>.ts`** — one file per subsystem. Each file imports only its own subsystem class. `src/index.ts` re-exports every `get*` from the new location, and `Tabster.ts` also re-exports them for backward compatibility, so both `import { getMover } from 'tabster'` and any deep `./Tabster` import keep working unchanged. `Tabster.ts` itself no longer statically imports any subsystem class.

2. **`exports` map with per-subsystem subpaths** — `tabster/mover`, `tabster/modalizer`, `tabster/groupper`, `tabster/deloser`, `tabster/restorer`, `tabster/observed-element`, `tabster/outline`, `tabster/cross-origin`. Each subpath exposes `types`, `import`, and `require` conditions so TypeScript, ESM, and CJS consumers all resolve correctly.

3. **Both ESM and CJS Rollup outputs switch to `preserveModules`**:
   - ESM → `dist/esm/` (per-module)
   - CJS → `dist/cjs/` (per-module); `package.json#main` moves from `./dist/index.js` to `./dist/cjs/index.js`

   This way every `import` / `require` entry in the `exports` map resolves to a physical per-module file.

4. **Stub `.d.ts` files for subpath types.** A small Rollup plugin writes `dist/get/get<Subsystem>.d.ts` files that re-export the single `get*` symbol from the main rolled-up `dist/index.d.ts`:

   ```ts
   // dist/get/getMover.d.ts
   export { getMover } from "../index";
   ```

   This makes the subpath types share the same (internal-stripped) `Tabster` declaration as the main entry, so mixing main and subpath imports type-checks cleanly. Pointing `types` at the raw per-module output under `dist/dts/*.d.ts` would leak internal fields (e.g. `Tabster.core`) and produce duplicate incompatible `Tabster` declarations.

## Results

`npm run bundle-size` on this branch (fixtures come from #518 on `master`):

```
┌──────────────────────┬───────────────┬───────────┐
│ Fixture              │ Minified size │ GZIP size │
├──────────────────────┼───────────────┼───────────┤
│ all exports          │ 123.875 kB    │ 32.663 kB │
│ createTabster (core) │ 47.595 kB     │ 13.302 kB │
│ getCrossOrigin       │ 120.129 kB    │ 31.874 kB │
│ getDeloser           │ 57.284 kB     │ 15.663 kB │
│ getGroupper          │ 55.175 kB     │ 14.996 kB │
│ getModalizer         │ 57.320 kB     │ 15.829 kB │
│ getMover             │ 63.237 kB     │ 17.413 kB │
│ getObservedElement   │ 53.666 kB     │ 14.945 kB │
│ getOutline           │ 56.679 kB     │ 15.615 kB │
│ getRestorer          │ 50.663 kB     │ 13.938 kB │
└──────────────────────┴───────────────┴───────────┘
```

Each fixture drops ~2.7 kB (~0.75 kB gzip) vs pre-refactor `master` measurements (run under the same webpack + sideEffects conditions), confirming that decoupling `Tabster.ts` lets webpack actually tree-shake the unused subsystems instead of dragging them along through the static-import hub.

The real savings land for consumers whose `tabster` imports come from **pre-compiled** Fluent packages — there the subpath exports make a 13 kB+ difference per surface (measured separately in a React-19 + Fluent UI v9 testbed; happy to share the setup).

## Compatibility

- **No public API change.** All `get*` exports remain on the main entry point, and are additionally re-exported from `./Tabster` (matching pre-refactor behavior at the module level).
- **Dual ESM + CJS preserved.** The `.` entry still exposes both via the `exports` map. `package.json#module` still points at ESM; `typings` still points at the rolled-up `dist/index.d.ts`.
- **TabsterCore unchanged.** It still holds optional typed slots for every subsystem; the constructor still instantiates only the always-loaded parts (`KeyboardNavigationState`, `FocusedElementState`, `FocusableAPI`, `UncontrolledAPI`).
- **Runtime logic unchanged.** Each `get*` body is copied verbatim from its prior location in `Tabster.ts`.

## Relationship to #515

#515 does the same source refactor **and** replaces Rollup with TSC + SWC (griffel-style). The source-level effect on consumers is identical between the two branches. This PR is the build-system-preserving option; #515 is the build-system-modernizing option. Pick one.

The Puppeteer/Storybook integration suite was not re-run for this PR — the change is a pure reorg of module boundaries with no runtime logic change. Happy to run it if a maintainer would like.
