### PR TITLE
chore(lint): enforce consistent-type-imports (inline style)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -100,6 +100,13 @@ export default [
                 "error",
                 { allowTernary: true, allowShortCircuit: true },
             ],
+            "@typescript-eslint/consistent-type-imports": [
+                "error",
+                {
+                    prefer: "type-imports",
+                    fixStyle: "inline-type-imports",
+                },
+            ],
         },
     },
 ];

--- a/src/AttributeHelpers.ts
+++ b/src/AttributeHelpers.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 
 export function getTabsterAttribute(

--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -11,7 +11,7 @@ import {
 import { getTabsterOnElement } from "./Instance.js";
 import { RootAPI } from "./Root.js";
 import { Subscribable } from "./State/Subscribable.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { ObservedElementAccessibilities } from "./Consts.js";
 import {
     getElementUId,
@@ -19,7 +19,7 @@ import {
     getPromise,
     getUId,
     getWindowUId,
-    HTMLElementWithUID,
+    type HTMLElementWithUID,
 } from "./Utils.js";
 import { dom } from "./DOMAPI.js";
 

--- a/src/DOMAPI.ts
+++ b/src/DOMAPI.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { DOMAPI } from "./Types.js";
+import { type DOMAPI } from "./Types.js";
 
 const _createMutationObserver = (callback: MutationCallback) =>
     new MutationObserver(callback);

--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -5,11 +5,11 @@
 
 import { getTabsterOnElement } from "./Instance.js";
 import { RootAPI } from "./Root.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { DeloserStrategies, RestoreFocusOrders } from "./Consts.js";
 import {
     DeloserFocusLostEvent,
-    DeloserRestoreFocusEvent,
+    type DeloserRestoreFocusEvent,
     DeloserRestoreFocusEventName,
     TabsterMoveFocusEvent,
 } from "./Events.js";

--- a/src/Deprecated.ts
+++ b/src/Deprecated.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { GroupperMoveFocusAction, MoverKey } from "./Types.js";
+import { type GroupperMoveFocusAction, type MoverKey } from "./Types.js";
 import {
     GroupperMoveFocusEvent,
     MoverMoveFocusEvent,

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types.js";
-import * as EventsTypes from "./EventsTypes.js";
+import type * as Types from "./Types.js";
+import type * as EventsTypes from "./EventsTypes.js";
 
 /**
  * Events sent by Tabster.

--- a/src/EventsTypes.ts
+++ b/src/EventsTypes.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 
 export interface TabsterMoveFocusEventDetail {
     by: "mover" | "groupper" | "modalizer" | "root" | "deloser";

--- a/src/Focusable.ts
+++ b/src/Focusable.ts
@@ -5,7 +5,7 @@
 
 import { getTabsterOnElement } from "./Instance.js";
 import { RootAPI } from "./Root.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { FOCUSABLE_SELECTOR } from "./Consts.js";
 import {
     createElementTreeWalker,

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -8,20 +8,20 @@ import { nativeFocus } from "keyborg";
 import { getTabsterOnElement } from "./Instance.js";
 import { Keys } from "./Keys.js";
 import { RootAPI } from "./Root.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import {
     AsyncFocusSources,
     GroupperMoveFocusActions,
     GroupperTabbabilities,
 } from "./Consts.js";
 import {
-    GroupperMoveFocusEvent,
+    type GroupperMoveFocusEvent,
     GroupperMoveFocusEventName,
     TabsterMoveFocusEvent,
 } from "./Events.js";
 import { FocusedElementState } from "./State/FocusedElement.js";
 import {
-    DummyInput,
+    type DummyInput,
     DummyInputManager,
     DummyInputManagerPriorities,
     getAdjacentElement,

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 
 export function getTabsterOnElement(

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -8,12 +8,12 @@ import { getTabsterOnElement } from "./Instance.js";
 import { RootAPI } from "./Root.js";
 import { FocusedElementState } from "./State/FocusedElement.js";
 import { Keys } from "./Keys.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { ModalizerActiveEvent, ModalizerInactiveEvent } from "./Events.js";
-import { ModalizerEventDetail } from "./EventsTypes.js";
+import { type ModalizerEventDetail } from "./EventsTypes.js";
 import {
     augmentAttribute,
-    DummyInput,
+    type DummyInput,
     DummyInputManager,
     DummyInputManagerPriorities,
     getDummyInputContainer,

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -8,19 +8,19 @@ import { FocusedElementState } from "./State/FocusedElement.js";
 import { getTabsterOnElement } from "./Instance.js";
 import { Keys } from "./Keys.js";
 import { RootAPI } from "./Root.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { Visibilities, MoverDirections, MoverKeys } from "./Consts.js";
 import {
-    MoverMemorizedElementEvent,
+    type MoverMemorizedElementEvent,
     MoverMemorizedElementEventName,
-    MoverMoveFocusEvent,
+    type MoverMoveFocusEvent,
     MoverMoveFocusEventName,
     MoverStateEvent,
     TabsterMoveFocusEvent,
 } from "./Events.js";
 import {
     createElementTreeWalker,
-    DummyInput,
+    type DummyInput,
     DummyInputManager,
     DummyInputManagerPriorities,
     getElementUId,

--- a/src/MutationEvent.ts
+++ b/src/MutationEvent.ts
@@ -4,13 +4,13 @@
  */
 
 import { getTabsterOnElement } from "./Instance.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 import {
     createElementTreeWalker,
     getInstanceContext,
-    HTMLElementWithUID,
-    InstanceContext,
+    type HTMLElementWithUID,
+    type InstanceContext,
     WeakHTMLElement,
 } from "./Utils.js";
 import { dom } from "./DOMAPI.js";

--- a/src/Outline.ts
+++ b/src/Outline.ts
@@ -4,7 +4,7 @@
  */
 
 import { getTabsterOnElement } from "./Instance.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { getBoundingRect } from "./Utils.js";
 
 interface WindowWithOutlineStyle extends Window {

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -5,15 +5,15 @@
 
 import { KEYBORG_FOCUSIN, KEYBORG_FOCUSOUT, nativeFocus } from "keyborg";
 import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance.js";
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 import { RootFocusEvent, RootBlurEvent } from "./Events.js";
 import {
-    DummyInput,
+    type DummyInput,
     DummyInputManager,
     DummyInputManagerPriorities,
     getElementUId,
     TabsterPart,
-    WeakHTMLElement,
+    type WeakHTMLElement,
 } from "./Utils.js";
 import { setTabsterAttribute } from "./AttributeHelpers.js";
 

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -6,14 +6,14 @@
 import {
     KEYBORG_FOCUSIN,
     KEYBORG_FOCUSOUT,
-    KeyborgFocusInEvent,
-    KeyborgFocusOutEvent,
+    type KeyborgFocusInEvent,
+    type KeyborgFocusOutEvent,
     nativeFocus,
 } from "keyborg";
 
 import { Keys } from "../Keys.js";
 import { RootAPI } from "../Root.js";
-import * as Types from "../Types.js";
+import type * as Types from "../Types.js";
 import { AsyncFocusSources } from "../Consts.js";
 import {
     TabsterFocusInEvent,

--- a/src/State/KeyboardNavigation.ts
+++ b/src/State/KeyboardNavigation.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { createKeyborg, disposeKeyborg, Keyborg } from "keyborg";
+import { createKeyborg, disposeKeyborg, type Keyborg } from "keyborg";
 
-import * as Types from "../Types.js";
+import type * as Types from "../Types.js";
 import { Subscribable } from "./Subscribable.js";
 
 export class KeyboardNavigationState

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -4,7 +4,7 @@
  */
 
 import { getTabsterOnElement } from "../Instance.js";
-import * as Types from "../Types.js";
+import type * as Types from "../Types.js";
 import {
     ObservedElementAccessibilities,
     ObservedElementRequestStatuses,

--- a/src/State/Subscribable.ts
+++ b/src/State/Subscribable.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "../Types.js";
+import type * as Types from "../Types.js";
 
 export abstract class Subscribable<
     A,

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -8,8 +8,8 @@ import { FocusedElementState } from "./State/FocusedElement.js";
 import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance.js";
 import { KeyboardNavigationState } from "./State/KeyboardNavigation.js";
 import { observeMutations } from "./MutationEvent.js";
-import { RootAPI, WindowWithTabsterInstance } from "./Root.js";
-import * as Types from "./Types.js";
+import { RootAPI, type WindowWithTabsterInstance } from "./Root.js";
+import type * as Types from "./Types.js";
 import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 import { UncontrolledAPI } from "./Uncontrolled.js";
 import {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -134,7 +134,7 @@ export interface FocusedElementDetail {
     modalizerId?: string;
 }
 
-import { AsyncFocusSources as _AsyncFocusSources } from "./Consts.js";
+import { type AsyncFocusSources as _AsyncFocusSources } from "./Consts.js";
 export type AsyncFocusSources = typeof _AsyncFocusSources;
 
 export type AsyncFocusSource = AsyncFocusSources[keyof AsyncFocusSources];
@@ -258,21 +258,21 @@ export interface ObservedElementChange {
     removedNames?: string[];
 }
 
-import { ObservedElementAccessibilities as _ObservedElementAccessibilities } from "./Consts.js";
+import { type ObservedElementAccessibilities as _ObservedElementAccessibilities } from "./Consts.js";
 export type ObservedElementAccessibilities =
     typeof _ObservedElementAccessibilities;
 
 export type ObservedElementAccessibility =
     ObservedElementAccessibilities[keyof ObservedElementAccessibilities];
 
-import { ObservedElementRequestStatuses as _ObservedElementRequestStatuses } from "./Consts.js";
+import { type ObservedElementRequestStatuses as _ObservedElementRequestStatuses } from "./Consts.js";
 export type ObservedElementRequestStatuses =
     typeof _ObservedElementRequestStatuses;
 
 export type ObservedElementRequestStatus =
     ObservedElementRequestStatuses[keyof ObservedElementRequestStatuses];
 
-import { ObservedElementFailureReasons as _ObservedElementFailureReasons } from "./Consts.js";
+import { type ObservedElementFailureReasons as _ObservedElementFailureReasons } from "./Consts.js";
 export type ObservedElementFailureReasons =
     typeof _ObservedElementFailureReasons;
 
@@ -489,12 +489,12 @@ export interface DeloserElementActions {
     isActive: () => boolean;
 }
 
-import { RestoreFocusOrders as _RestoreFocusOrders } from "./Consts.js";
+import { type RestoreFocusOrders as _RestoreFocusOrders } from "./Consts.js";
 export type RestoreFocusOrders = typeof _RestoreFocusOrders;
 
 export type RestoreFocusOrder = RestoreFocusOrders[keyof RestoreFocusOrders];
 
-import { DeloserStrategies as _DeloserStrategies } from "./Consts.js";
+import { type DeloserStrategies as _DeloserStrategies } from "./Consts.js";
 export type DeloserStrategies = typeof _DeloserStrategies;
 
 export type DeloserStrategy = DeloserStrategies[keyof DeloserStrategies];
@@ -764,7 +764,7 @@ export interface DummyInputManager {
     ) => void;
 }
 
-import { Visibilities as _Visibilities } from "./Consts.js";
+import { type Visibilities as _Visibilities } from "./Consts.js";
 export type Visibilities = typeof _Visibilities;
 
 export type Visibility = Visibilities[keyof Visibilities];
@@ -774,12 +774,12 @@ export interface MoverElementState {
     visibility: Visibility;
 }
 
-import { RestorerTypes as _RestorerTypes } from "./Consts.js";
+import { type RestorerTypes as _RestorerTypes } from "./Consts.js";
 export type RestorerTypes = typeof _RestorerTypes;
 
 export type RestorerType = RestorerTypes[keyof RestorerTypes];
 
-import { MoverDirections as _MoverDirections } from "./Consts.js";
+import { type MoverDirections as _MoverDirections } from "./Consts.js";
 export type MoverDirections = typeof _MoverDirections;
 
 export type MoverDirection = MoverDirections[keyof MoverDirections];
@@ -864,7 +864,7 @@ interface MoverAPIInternal {
     ): Mover;
 }
 
-import { MoverKeys as _MoverKeys } from "./Consts.js";
+import { type MoverKeys as _MoverKeys } from "./Consts.js";
 export type MoverKeys = typeof _MoverKeys;
 
 export type MoverKey = MoverKeys[keyof MoverKeys];
@@ -874,7 +874,7 @@ export interface MoverAPI extends MoverAPIInternal, Disposable {
     moveFocus(fromElement: HTMLElement, key: MoverKey): HTMLElement | null;
 }
 
-import { GroupperTabbabilities as _GroupperTabbabilities } from "./Consts.js";
+import { type GroupperTabbabilities as _GroupperTabbabilities } from "./Consts.js";
 export type GroupperTabbabilities = typeof _GroupperTabbabilities;
 
 export type GroupperTabbability =
@@ -925,7 +925,7 @@ export interface GroupperAPIInternal {
     ): void;
 }
 
-import { GroupperMoveFocusActions as _GroupperMoveFocusActions } from "./Consts.js";
+import { type GroupperMoveFocusActions as _GroupperMoveFocusActions } from "./Consts.js";
 export type GroupperMoveFocusActions = typeof _GroupperMoveFocusActions;
 
 export type GroupperMoveFocusAction =
@@ -995,7 +995,7 @@ export type RootConstructor = (
     props: RootProps
 ) => Root;
 
-import { SysDummyInputsPositions as _SysDummyInputsPositions } from "./Consts.js";
+import { type SysDummyInputsPositions as _SysDummyInputsPositions } from "./Consts.js";
 export type SysDummyInputsPositions = typeof _SysDummyInputsPositions;
 
 export type SysDummyInputsPosition =

--- a/src/Uncontrolled.ts
+++ b/src/Uncontrolled.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types.js";
+import type * as Types from "./Types.js";
 
 /**
  * Allows default or user focus behaviour on the DOM subtree

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -6,15 +6,15 @@
 import { nativeFocus } from "keyborg";
 
 import {
-    DummyInputObserver as DummyInputObserverInterface,
-    GetWindow,
-    RadioButtonGroup,
-    SysProps,
-    TabsterAttributeProps,
-    TabsterCore,
-    TabsterPart as TabsterPartInterface,
-    Visibility,
-    WeakHTMLElement as WeakHTMLElementInterface,
+    type DummyInputObserver as DummyInputObserverInterface,
+    type GetWindow,
+    type RadioButtonGroup,
+    type SysProps,
+    type TabsterAttributeProps,
+    type TabsterCore,
+    type TabsterPart as TabsterPartInterface,
+    type Visibility,
+    type WeakHTMLElement as WeakHTMLElementInterface,
 } from "./Types.js";
 import {
     FOCUSABLE_SELECTOR,


### PR DESCRIPTION
## Summary

- Enable [`@typescript-eslint/consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports/) with `fixStyle: "inline-type-imports"`.
- Autofix the full `src/` tree.

## Why

Type-only imports are erased at compile time, but a value-style import of a symbol used only as a type can still hold the module "alive" for bundlers that don't prove unused-ness (or for consumers that disable tree-shaking). Making the intent explicit removes that dependency on bundler heuristics and keeps imports honest across future refactors.

## Style

Inline over top-level because it keeps mixed value+type imports as a single statement:

```ts
import { RootAPI, type WindowWithTabsterInstance } from "./Root.js";
```

rather than splitting into two imports from the same module.