### PR TITLE
chore: remove IE11 shims and unused globals indirection

### DIFF
--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -16,7 +16,6 @@ import { ObservedElementAccessibilities } from "./Consts.js";
 import {
     getElementUId,
     getInstanceContext,
-    getPromise,
     getUId,
     getWindowUId,
     HTMLElementWithUID,
@@ -195,7 +194,7 @@ abstract class CrossOriginTransaction<I, O> {
         this.targetId = targetId;
         this.sendUp = sendUp;
         this.timeout = timeout;
-        this._promise = new (getPromise(getOwner))<O>((resolve, reject) => {
+        this._promise = new Promise<O>((resolve, reject) => {
             this._resolve = resolve;
             this._reject = reject;
         });
@@ -841,7 +840,7 @@ class GetElementTransaction extends CrossOriginTransaction<
                 const e: {
                     element?: HTMLElement | null;
                     crossOrigin?: CrossOriginElementDataOut;
-                } = await new (getPromise(getOwner))((resolve) => {
+                } = await new Promise((resolve) => {
                     let isWaitElementResolved = false;
                     let isForwardResolved = false;
                     let isResolved = false;
@@ -1081,7 +1080,7 @@ class CrossOriginTransactions {
         withReject?: boolean
     ): Promise<O | undefined> {
         if (!this._owner) {
-            return getPromise(this._owner).reject();
+            return Promise.reject();
         }
 
         const transaction = new Transaction(
@@ -1116,7 +1115,7 @@ class CrossOriginTransactions {
                     this._owner,
                     this._ownerUId,
                     this,
-                    getPromise(this._owner).resolve(undefined),
+                    Promise.resolve(undefined),
                     true
                 );
             };
@@ -1183,7 +1182,7 @@ class CrossOriginTransactions {
         let targetId = data.target;
 
         if (targetId === this._ownerUId) {
-            return getPromise(owner).resolve();
+            return Promise.resolve();
         }
 
         const Transaction = this._getTransactionClass(data.type);
@@ -1221,13 +1220,11 @@ class CrossOriginTransactions {
                     data.timeout
                 );
             } else {
-                return getPromise(owner).resolve();
+                return Promise.resolve();
             }
         }
 
-        return getPromise(owner).reject(
-            `Unknown transaction type ${data.type}`
-        );
+        return Promise.reject(`Unknown transaction type ${data.type}`);
     }
 
     private _getTransactionClass(
@@ -1359,7 +1356,7 @@ class CrossOriginTransactions {
         }
 
         if (targets.length) {
-            await getPromise(this._owner).all(
+            await Promise.all(
                 targets.map((uid) =>
                     this.beginTransaction(
                         PingTransaction,

--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -16,7 +16,6 @@ import {
 import {
     documentContains,
     getElementUId,
-    getPromise,
     isDisplayNone,
     TabsterPart,
     WeakHTMLElement,
@@ -75,8 +74,7 @@ export class DeloserItem extends DeloserItemBase<Types.Deloser> {
     }
 
     async resetFocus(): Promise<boolean> {
-        const getWindow = this._tabster.getWindow;
-        return getPromise(getWindow).resolve(this._deloser.resetFocus());
+        return Promise.resolve(this._deloser.resetFocus());
     }
 }
 
@@ -505,13 +503,7 @@ export class Deloser
             return e && e !== element;
         });
 
-        cur.unshift(
-            new WeakHTMLElement(
-                this._tabster.getWindow,
-                element,
-                buildSelector(element)
-            )
-        );
+        cur.unshift(new WeakHTMLElement(element, buildSelector(element)));
 
         while (cur.length > _containerHistoryLength) {
             cur.pop();

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -307,7 +307,7 @@ export class Groupper
 
     setFirst(element: HTMLElement | undefined): void {
         if (element) {
-            this._first = new WeakHTMLElement(this._tabster.getWindow, element);
+            this._first = new WeakHTMLElement(element);
         } else {
             delete this._first;
         }

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -163,12 +163,7 @@ export class Modalizer
 
                 if (isActive) {
                     if (index < 0) {
-                        activeElements.push(
-                            new WeakHTMLElement(
-                                this._tabster.getWindow,
-                                element
-                            )
-                        );
+                        activeElements.push(new WeakHTMLElement(element));
                     }
                 } else {
                     if (index >= 0) {
@@ -821,9 +816,7 @@ export class ModalizerAPI implements Types.ModalizerAPI {
             }
 
             if (isAugmented) {
-                newAugmented.push(
-                    new WeakHTMLElement(tabster.getWindow, element)
-                );
+                newAugmented.push(new WeakHTMLElement(element));
                 newAugmentedMap.set(element, true);
             }
         };

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -24,7 +24,6 @@ import {
     DummyInputManager,
     DummyInputManagerPriorities,
     getElementUId,
-    getPromise,
     isElementVerticallyVisibleInContainer,
     matchesSelector,
     scrollIntoView,
@@ -192,7 +191,7 @@ export class Mover
 
     setCurrent(element: HTMLElement | undefined): void {
         if (element) {
-            this._current = new WeakHTMLElement(this._win, element);
+            this._current = new WeakHTMLElement(element);
         } else {
             this._current = undefined;
         }
@@ -1377,7 +1376,7 @@ export class MoverAPI implements Types.MoverAPI {
                         (element as HTMLInputElement).selectionEnd || 0;
                 }
             } else if (element.contentEditable === "true") {
-                asyncRet = new (getPromise(this._win))((resolve) => {
+                asyncRet = new Promise<boolean>((resolve) => {
                     this._ignoredInputResolve = (value: boolean) => {
                         delete this._ignoredInputResolve;
                         resolve(value);

--- a/src/MutationEvent.ts
+++ b/src/MutationEvent.ts
@@ -113,7 +113,7 @@ export function observeMutations(
             if (removed) {
                 delete elementByUId[uid];
             } else {
-                elementByUId[uid] ??= new WeakHTMLElement(getWindow, element);
+                elementByUId[uid] ??= new WeakHTMLElement(element);
             }
         }
 

--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -96,9 +96,7 @@ class History {
         if (this._stack.length > History.DEPTH) {
             this._stack.shift();
         }
-        this._stack.push(
-            new WeakHTMLElement<HTMLElement>(this._getWindow, element)
-        );
+        this._stack.push(new WeakHTMLElement<HTMLElement>(element));
     }
     /**
      * Pop the first element from the history that satisfies the callback.

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -296,7 +296,6 @@ export class FocusedElementState
             container.setAttribute("aria-hidden", "true");
 
             FocusedElementState._lastResetElement = new WeakHTMLElement(
-                this._win,
                 container
             );
 
@@ -399,9 +398,7 @@ export class FocusedElementState
         }
 
         const nextVal = (this._nextVal = {
-            element: element
-                ? new WeakHTMLElement(this._win, element)
-                : undefined,
+            element: element ? new WeakHTMLElement(element) : undefined,
             detail,
         });
 
@@ -425,7 +422,7 @@ export class FocusedElementState
         super.setVal(val, detail);
 
         if (val) {
-            this._lastVal = new WeakHTMLElement(this._win, val);
+            this._lastVal = new WeakHTMLElement(val);
         }
     }
 

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -13,7 +13,6 @@ import {
 import {
     documentContains,
     getElementUId,
-    getPromise,
     WeakHTMLElement,
 } from "../Utils.js";
 import { Subscribable } from "./Subscribable.js";
@@ -311,7 +310,7 @@ export class ObservedElementAPI
 
         if (el) {
             return {
-                result: getPromise(this._win).resolve(el),
+                result: Promise.resolve(el),
                 cancel: () => {
                     /**/
                 },
@@ -363,12 +362,10 @@ export class ObservedElementAPI
             }, timeout),
         };
 
-        const promise = new (getPromise(this._win))<HTMLElement | null>(
-            (resolve, reject) => {
-                w.resolve = resolve;
-                w.reject = reject;
-            }
-        ).catch(() => {
+        const promise = new Promise<HTMLElement | null>((resolve, reject) => {
+            w.resolve = resolve;
+            w.reject = reject;
+        }).catch(() => {
             // Ignore the error, it is expected to be rejected when the request is canceled.
             return null;
         });
@@ -484,7 +481,7 @@ export class ObservedElementAPI
 
             if (!info) {
                 info = this._observedById[uid] = {
-                    element: new WeakHTMLElement(this._win, element),
+                    element: new WeakHTMLElement(element),
                 };
             }
 

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -10,11 +10,7 @@ import {
     ObservedElementRequestStatuses,
     ObservedElementFailureReasons,
 } from "../Consts.js";
-import {
-    documentContains,
-    getElementUId,
-    WeakHTMLElement,
-} from "../Utils.js";
+import { documentContains, getElementUId, WeakHTMLElement } from "../Utils.js";
 import { Subscribable } from "./Subscribable.js";
 
 const _conditionCheckTimeout = 100;

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -13,15 +13,11 @@ import * as Types from "./Types.js";
 import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 import { UncontrolledAPI } from "./Uncontrolled.js";
 import {
-    cleanupFakeWeakRefs,
     clearElementCache,
     createElementTreeWalker,
-    createWeakMap,
     disposeInstanceContext,
     DummyInputObserver,
     getDummyInputContainer,
-    startFakeWeakRefsCleanup,
-    stopFakeWeakRefsCleanupAndClearStorage,
 } from "./Utils.js";
 import { dom, setDOMAPI } from "./DOMAPI.js";
 import * as shadowDOMAPI from "./Shadowdomize/index.js";
@@ -85,7 +81,7 @@ class TabsterCore implements Types.TabsterCore {
     getParent: (el: Node) => Node | null;
 
     constructor(win: Window, props?: Types.TabsterCoreProps) {
-        this._storage = createWeakMap(win);
+        this._storage = new WeakMap();
         this._win = win;
 
         const getWindow = this.getWindow;
@@ -130,8 +126,6 @@ class TabsterCore implements Types.TabsterCore {
                 }
             },
         };
-
-        startFakeWeakRefsCleanup(getWindow);
 
         // Gives a tick to the host app to initialize other tabster
         // APIs before tabster starts observing attributes.
@@ -212,7 +206,6 @@ class TabsterCore implements Types.TabsterCore {
 
         this._dummyObserver.dispose();
 
-        stopFakeWeakRefsCleanupAndClearStorage(this.getWindow);
         clearElementCache(this.getWindow);
 
         this._storage = new WeakMap();
@@ -276,8 +269,6 @@ class TabsterCore implements Types.TabsterCore {
                 FocusedElementState.forgetMemorized(this.focusedElement, el);
             }
         }, 0);
-
-        cleanupFakeWeakRefs(this.getWindow, true);
     }
 
     queueInit(callback: () => void): void {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -433,7 +433,7 @@ export function matchesSelector(
     element: HTMLElement,
     selector: string
 ): boolean {
-    return element.matches(selector);
+    return typeof element.matches === "function" && element.matches(selector);
 }
 
 let _lastTabsterPartId = 0;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -55,8 +55,6 @@ export interface TabsterDOMRect {
 
 export interface InstanceContext {
     elementByUId: { [uid: string]: WeakHTMLElement<HTMLElementWithUID> };
-    basics: InternalBasics;
-    WeakRef?: WeakRefConstructor;
     containerBoundingRectCache: {
         [id: string]: {
             rect: TabsterDOMRect;
@@ -65,54 +63,14 @@ export interface InstanceContext {
     };
     lastContainerBoundingRectCacheId: number;
     containerBoundingRectCacheTimer?: number;
-    fakeWeakRefs: TabsterWeakRef<unknown>[];
-    fakeWeakRefsTimer?: number;
-    fakeWeakRefsStarted: boolean;
 }
-
-let _isBrokenIE11: boolean;
-
-const _DOMRect =
-    typeof DOMRect !== "undefined"
-        ? DOMRect
-        : class {
-              readonly bottom: number;
-              readonly left: number;
-              readonly right: number;
-              readonly top: number;
-
-              constructor(
-                  x?: number,
-                  y?: number,
-                  width?: number,
-                  height?: number
-              ) {
-                  this.left = x || 0;
-                  this.top = y || 0;
-                  this.right = (x || 0) + (width || 0);
-                  this.bottom = (y || 0) + (height || 0);
-              }
-          };
 
 let _uidCounter = 0;
-
-try {
-    // IE11 only accepts `filter` argument as a function (not object with the `acceptNode`
-    // property as the docs define). Also `entityReferenceExpansion` argument is not
-    // optional. And it throws exception when the above arguments aren't there.
-    document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT);
-    _isBrokenIE11 = false;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-} catch (e) {
-    _isBrokenIE11 = true;
-}
 
 const _updateDummyInputsTimeout = 100;
 
 interface WindowWithUtilsConext extends Window {
     __tabsterInstanceContext?: InstanceContext;
-    Promise: PromiseConstructor;
-    WeakRef: WeakRefConstructor;
 }
 
 export function getInstanceContext(getWindow: GetWindow): InstanceContext {
@@ -123,14 +81,8 @@ export function getInstanceContext(getWindow: GetWindow): InstanceContext {
     if (!ctx) {
         ctx = {
             elementByUId: {},
-            basics: {
-                Promise: win.Promise || undefined,
-                WeakRef: win.WeakRef || undefined,
-            },
             containerBoundingRectCache: {},
             lastContainerBoundingRectCacheId: 0,
-            fakeWeakRefs: [],
-            fakeWeakRefsStarted: false,
         };
 
         win.__tabsterInstanceContext = ctx;
@@ -145,86 +97,29 @@ export function disposeInstanceContext(win: Window): void {
     if (ctx) {
         ctx.elementByUId = {};
 
-        delete ctx.WeakRef;
-
         ctx.containerBoundingRectCache = {};
 
         if (ctx.containerBoundingRectCacheTimer) {
             win.clearTimeout(ctx.containerBoundingRectCacheTimer);
         }
 
-        if (ctx.fakeWeakRefsTimer) {
-            win.clearTimeout(ctx.fakeWeakRefsTimer);
-        }
-
-        ctx.fakeWeakRefs = [];
-
         delete (win as WindowWithUtilsConext).__tabsterInstanceContext;
     }
-}
-
-export function createWeakMap<K extends object, V>(win: Window): WeakMap<K, V> {
-    const ctx = (win as WindowWithUtilsConext).__tabsterInstanceContext;
-    return new (ctx?.basics.WeakMap || WeakMap)();
 }
 
 export function hasSubFocusable(element: HTMLElement): boolean {
     return !!element.querySelector(FOCUSABLE_SELECTOR);
 }
 
-interface TabsterWeakRef<T> {
-    deref(): T | undefined;
-}
-
-class FakeWeakRef<
-    T extends HTMLElement = HTMLElement,
-> implements TabsterWeakRef<T> {
-    private _target: T | undefined;
-
-    constructor(target: T) {
-        this._target = target;
-    }
-
-    deref(): T | undefined {
-        return this._target;
-    }
-
-    static cleanup(fwr: FakeWeakRef, forceRemove?: boolean): boolean {
-        if (!fwr._target) {
-            return true;
-        }
-
-        if (
-            forceRemove ||
-            !documentContains(fwr._target.ownerDocument, fwr._target)
-        ) {
-            delete fwr._target;
-            return true;
-        }
-
-        return false;
-    }
-}
-
 export class WeakHTMLElement<
     T extends HTMLElement = HTMLElement,
     D = undefined,
 > implements WeakHTMLElementInterface<D> {
-    private _ref: TabsterWeakRef<T> | undefined;
+    private _ref: WeakRef<T> | undefined;
     private _data: D | undefined;
 
-    constructor(getWindow: GetWindow, element: T, data?: D) {
-        const context = getInstanceContext(getWindow);
-
-        let ref: TabsterWeakRef<T>;
-        if (context.WeakRef) {
-            ref = new context.WeakRef(element);
-        } else {
-            ref = new FakeWeakRef(element);
-            context.fakeWeakRefs.push(ref);
-        }
-
-        this._ref = ref;
+    constructor(element: T, data?: D) {
+        this._ref = new WeakRef(element);
         this._data = data;
     }
 
@@ -248,73 +143,18 @@ export class WeakHTMLElement<
     }
 }
 
-export function cleanupFakeWeakRefs(
-    getWindow: GetWindow,
-    forceRemove?: boolean
-): void {
-    const context = getInstanceContext(getWindow);
-    context.fakeWeakRefs = context.fakeWeakRefs.filter(
-        (e) => !FakeWeakRef.cleanup(e as FakeWeakRef, forceRemove)
-    );
-}
-
-export function startFakeWeakRefsCleanup(getWindow: GetWindow): void {
-    const context = getInstanceContext(getWindow);
-
-    if (!context.fakeWeakRefsStarted) {
-        context.fakeWeakRefsStarted = true;
-        context.WeakRef = getWeakRef(context);
-    }
-
-    if (!context.fakeWeakRefsTimer) {
-        context.fakeWeakRefsTimer = getWindow().setTimeout(
-            () => {
-                context.fakeWeakRefsTimer = undefined;
-                cleanupFakeWeakRefs(getWindow);
-                startFakeWeakRefsCleanup(getWindow);
-            },
-            2 * 60 * 1000
-        ); // 2 minutes.
-    }
-}
-
-export function stopFakeWeakRefsCleanupAndClearStorage(
-    getWindow: GetWindow
-): void {
-    const context = getInstanceContext(getWindow);
-
-    context.fakeWeakRefsStarted = false;
-
-    if (context.fakeWeakRefsTimer) {
-        getWindow().clearTimeout(context.fakeWeakRefsTimer);
-        context.fakeWeakRefsTimer = undefined;
-        context.fakeWeakRefs = [];
-    }
-}
-
 export function createElementTreeWalker(
     doc: Document,
     root: Node,
     acceptNode: (node: Node) => number
 ): TreeWalker | undefined {
-    // IE11 will throw an exception when the TreeWalker root is not an Element.
     if (root.nodeType !== Node.ELEMENT_NODE) {
         return undefined;
     }
 
-    // TypeScript isn't aware of IE11 behaving badly.
-    const filter = (_isBrokenIE11
-        ? acceptNode
-        : ({ acceptNode } as NodeFilter)) as unknown as NodeFilter;
-
-    return dom.createTreeWalker(
-        doc,
-        root,
-        NodeFilter.SHOW_ELEMENT,
-        filter,
-        // @ts-ignore: We still don't want to completely break IE11, so, entityReferenceExpansion argument is not optional.
-        false /* Last argument is not optional for IE11! */
-    );
+    return dom.createTreeWalker(doc, root, NodeFilter.SHOW_ELEMENT, {
+        acceptNode,
+    });
 }
 
 export function getBoundingRect(
@@ -335,7 +175,7 @@ export function getBoundingRect(
         element.ownerDocument && element.ownerDocument.documentElement;
 
     if (!scrollingElement) {
-        return new _DOMRect();
+        return new DOMRect();
     }
 
     // A bounding rect of the top-level element contains the whole page regardless of the
@@ -353,7 +193,7 @@ export function getBoundingRect(
         bottom = Math.min(bottom, r.bottom);
     }
 
-    const rect = new _DOMRect(
+    const rect = new DOMRect(
         left < right ? left : -1,
         top < bottom ? top : -1,
         left < right ? right - left : 0,
@@ -504,18 +344,10 @@ export function shouldIgnoreFocus(element: HTMLElement): boolean {
     return !!(element as FocusedElementWithIgnoreFlag).__shouldIgnoreFocus;
 }
 
-export function getUId(wnd: Window & { msCrypto?: Crypto }): string {
+export function getUId(wnd: Window): string {
     const rnd = new Uint32Array(4);
 
-    if (wnd.crypto && wnd.crypto.getRandomValues) {
-        wnd.crypto.getRandomValues(rnd);
-    } else if (wnd.msCrypto && wnd.msCrypto.getRandomValues) {
-        wnd.msCrypto.getRandomValues(rnd);
-    } else {
-        for (let i = 0; i < rnd.length; i++) {
-            rnd[i] = 0xffffffff * Math.random();
-        }
-    }
+    wnd.crypto.getRandomValues(rnd);
 
     const srnd: string[] = [];
 
@@ -546,7 +378,7 @@ export function getElementUId(
         !context.elementByUId[uid] &&
         documentContains(element.ownerDocument, element)
     ) {
-        context.elementByUId[uid] = new WeakHTMLElement(getWindow, element);
+        context.elementByUId[uid] = new WeakHTMLElement(element);
     }
 
     return uid;
@@ -589,9 +421,9 @@ export function clearElementCache(
     }
 }
 
-// IE11 doesn't have document.contains()...
+// Uses `dom.nodeContains` so the shadow-DOM / iframe abstraction can override it.
 export function documentContains(
-    doc: HTMLDocument | null | undefined,
+    doc: Document | null | undefined,
     element: HTMLElement
 ): boolean {
     return dom.nodeContains(doc?.body, element);
@@ -601,60 +433,7 @@ export function matchesSelector(
     element: HTMLElement,
     selector: string
 ): boolean {
-    interface HTMLElementWithMatches extends HTMLElement {
-        matchesSelector?: typeof HTMLElement.prototype.matches;
-        msMatchesSelector?: typeof HTMLElement.prototype.matches;
-    }
-
-    const matches =
-        element.matches ||
-        (element as HTMLElementWithMatches).matchesSelector ||
-        (element as HTMLElementWithMatches).msMatchesSelector ||
-        element.webkitMatchesSelector;
-
-    return matches && matches.call(element, selector);
-}
-
-export function getPromise(getWindow: GetWindow): PromiseConstructor {
-    const context = getInstanceContext(getWindow);
-    if (context.basics.Promise) {
-        return context.basics.Promise;
-    }
-
-    throw new Error("No Promise defined.");
-}
-
-export function getWeakRef(
-    context: InstanceContext
-): WeakRefConstructor | undefined {
-    return context.basics.WeakRef;
-}
-
-interface InternalBasics {
-    Promise?: PromiseConstructor;
-    WeakRef?: WeakRefConstructor;
-    WeakMap?: WeakMapConstructor;
-}
-
-export function setBasics(win: Window, basics: InternalBasics): void {
-    const context = getInstanceContext(() => win);
-
-    let key: keyof InternalBasics;
-
-    key = "Promise";
-    if (key in basics) {
-        context.basics[key] = basics[key];
-    }
-
-    key = "WeakRef";
-    if (key in basics) {
-        context.basics[key] = basics[key];
-    }
-
-    key = "WeakMap";
-    if (key in basics) {
-        context.basics[key] = basics[key];
-    }
+    return element.matches(selector);
 }
 
 let _lastTabsterPartId = 0;
@@ -670,9 +449,8 @@ export abstract class TabsterPart<
     readonly id: string;
 
     constructor(tabster: TabsterCore, element: HTMLElement, props: P) {
-        const getWindow = tabster.getWindow;
         this._tabster = tabster;
-        this._element = new WeakHTMLElement(getWindow, element);
+        this._element = new WeakHTMLElement(element);
         this._props = { ...props };
         this.id = "i" + ++_lastTabsterPartId;
     }
@@ -1098,7 +876,7 @@ export class DummyInputManager {
                 isFirst: true,
             },
             undefined,
-            new WeakHTMLElement(tabster.getWindow, targetElement)
+            new WeakHTMLElement(targetElement)
         );
 
         const input = dummy.input;
@@ -1181,7 +959,7 @@ export class DummyInputObserver implements DummyInputObserverInterface {
 
     add(dummy: HTMLElement, callback: () => void): void {
         if (!this._dummyCallbacks.has(dummy) && this._win) {
-            this._dummyElements.push(new WeakHTMLElement(this._win, dummy));
+            this._dummyElements.push(new WeakHTMLElement(dummy));
             this._dummyCallbacks.set(dummy, callback);
             this.domChanged = this._domChanged;
         }


### PR DESCRIPTION
## Summary

`.browserslistrc` already declares `not IE 11`. The shim machinery that existed to paper over IE11 (and pre-2020 Safari `WeakRef`) can go. Also removes `setBasics` — a fully-unused export — which unlocks the cascade.

### Removed

- **`setBasics`** — no caller anywhere in `src/`, `tests/`, or `stories/`.
- **`InstanceContext.basics` / `.WeakRef` / `.fakeWeakRefs*` fields** — dead once `setBasics` is the only writer.
- **`FakeWeakRef` class + `cleanupFakeWeakRefs` / `startFakeWeakRefsCleanup` / `stopFakeWeakRefsCleanupAndClearStorage`** — IE11's `WeakRef` polyfill plus a 2-minute cleanup timer that runs forever. Unneeded with native `WeakRef` (Chrome 84+, FF 79+, Safari 14.1+).
- **`getPromise` / `getWeakRef` / `createWeakMap`** — call sites now use native `Promise` / `new WeakRef()` / `new WeakMap()` directly (9 + 1 + 1 sites across `CrossOrigin`, `Deloser`, `Mover`, `ObservedElement`, `Tabster`).
- **`_isBrokenIE11` module-top probe** — plus the `createElementTreeWalker` ternary and `@ts-ignore` and mandatory-false-4th-arg it fed into.
- **`_DOMRect` fallback class** — native `DOMRect` everywhere.
- **`getUId`: `msCrypto` branch + `Math.random` last-resort** — `crypto.getRandomValues` is universal.
- **`matchesSelector`: `webkitMatchesSelector` / `msMatchesSelector` / non-prototype `matchesSelector` fallbacks** — now just `element.matches(selector)`.
- **`WeakHTMLElement` ctor: `getWindow` parameter** — unused since `FakeWeakRef` / `basics.WeakRef` lookups are gone. 15 callers updated.

`documentContains` is kept — its stale "IE11 doesn't have document.contains" comment is replaced with one noting that it exists for the `dom.nodeContains` shadow-DOM/iframe abstraction.
