### PR TITLE
refactor: delegate attribute updates to each subsystem API

### DIFF
--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -797,14 +797,14 @@ export class DeloserAPI implements Types.DeloserAPI {
 
     applyAttribute(
         element: HTMLElement,
-        storage: Types.TabsterOnElement,
+        existingDeloser: Types.Deloser | undefined,
         newProps: Types.DeloserProps
-    ): void {
-        if (storage.deloser) {
-            storage.deloser.setProps(newProps);
-        } else {
-            storage.deloser = this.createDeloser(element, newProps);
+    ): Types.Deloser {
+        if (existingDeloser) {
+            existingDeloser.setProps(newProps);
+            return existingDeloser;
         }
+        return this.createDeloser(element, newProps);
     }
 
     getActions(element: HTMLElement): Types.DeloserElementActions | undefined {

--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -795,6 +795,18 @@ export class DeloserAPI implements Types.DeloserAPI {
         return deloser;
     }
 
+    applyAttribute(
+        element: HTMLElement,
+        storage: Types.TabsterOnElement,
+        newProps: Types.DeloserProps
+    ): void {
+        if (storage.deloser) {
+            storage.deloser.setProps(newProps);
+        } else {
+            storage.deloser = this.createDeloser(element, newProps);
+        }
+    }
+
     getActions(element: HTMLElement): Types.DeloserElementActions | undefined {
         for (
             let e: HTMLElement | null = element;

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -528,6 +528,19 @@ export class GroupperAPI implements Types.GroupperAPI {
         return newGroupper;
     }
 
+    applyAttribute(
+        element: HTMLElement,
+        storage: Types.TabsterOnElement,
+        newProps: Types.GroupperProps,
+        sys: Types.SysProps | undefined
+    ): void {
+        if (storage.groupper) {
+            storage.groupper.setProps(newProps);
+        } else {
+            storage.groupper = this.createGroupper(element, newProps, sys);
+        }
+    }
+
     forgetCurrentGrouppers(): void {
         this._current = {};
     }

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -530,15 +530,15 @@ export class GroupperAPI implements Types.GroupperAPI {
 
     applyAttribute(
         element: HTMLElement,
-        storage: Types.TabsterOnElement,
+        existingGroupper: Types.Groupper | undefined,
         newProps: Types.GroupperProps,
         sys: Types.SysProps | undefined
-    ): void {
-        if (storage.groupper) {
-            storage.groupper.setProps(newProps);
-        } else {
-            storage.groupper = this.createGroupper(element, newProps, sys);
+    ): Types.Groupper {
+        if (existingGroupper) {
+            existingGroupper.setProps(newProps);
+            return existingGroupper;
         }
+        return this.createGroupper(element, newProps, sys);
     }
 
     forgetCurrentGrouppers(): void {

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -125,9 +125,9 @@ export function updateTabsterByAttribute(
         switch (key) {
             case "deloser":
                 if (tabster.deloser) {
-                    tabster.deloser.applyAttribute(
+                    tabsterOnElement.deloser = tabster.deloser.applyAttribute(
                         element,
-                        tabsterOnElement,
+                        tabsterOnElement.deloser,
                         newTabsterProps.deloser as Types.DeloserProps
                     );
                 } else if (__DEV__) {
@@ -154,13 +154,14 @@ export function updateTabsterByAttribute(
 
             case "modalizer":
                 if (tabster.modalizer) {
-                    tabster.modalizer.applyAttribute(
-                        element,
-                        tabsterOnElement,
-                        newTabsterProps.modalizer as Types.ModalizerProps,
-                        oldTabsterProps?.modalizer,
-                        sys
-                    );
+                    tabsterOnElement.modalizer =
+                        tabster.modalizer.applyAttribute(
+                            element,
+                            tabsterOnElement.modalizer,
+                            newTabsterProps.modalizer as Types.ModalizerProps,
+                            oldTabsterProps?.modalizer,
+                            sys
+                        );
                 } else if (__DEV__) {
                     console.error(
                         "Modalizer API used before initialization, please call `getModalizer()`"
@@ -171,11 +172,12 @@ export function updateTabsterByAttribute(
             case "restorer":
                 if (tabster.restorer) {
                     if (newTabsterProps.restorer) {
-                        tabster.restorer.applyAttribute(
-                            element,
-                            tabsterOnElement,
-                            newTabsterProps.restorer
-                        );
+                        tabsterOnElement.restorer =
+                            tabster.restorer.applyAttribute(
+                                element,
+                                tabsterOnElement.restorer,
+                                newTabsterProps.restorer
+                            );
                     }
                 } else if (__DEV__) {
                     console.error(
@@ -190,9 +192,9 @@ export function updateTabsterByAttribute(
 
             case "groupper":
                 if (tabster.groupper) {
-                    tabster.groupper.applyAttribute(
+                    tabsterOnElement.groupper = tabster.groupper.applyAttribute(
                         element,
-                        tabsterOnElement,
+                        tabsterOnElement.groupper,
                         newTabsterProps.groupper as Types.GroupperProps,
                         sys
                     );
@@ -205,9 +207,9 @@ export function updateTabsterByAttribute(
 
             case "mover":
                 if (tabster.mover) {
-                    tabster.mover.applyAttribute(
+                    tabsterOnElement.mover = tabster.mover.applyAttribute(
                         element,
-                        tabsterOnElement,
+                        tabsterOnElement.mover,
                         newTabsterProps.mover as Types.MoverProps,
                         sys
                     );

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -124,22 +124,16 @@ export function updateTabsterByAttribute(
 
         switch (key) {
             case "deloser":
-                if (tabsterOnElement.deloser) {
-                    tabsterOnElement.deloser.setProps(
+                if (tabster.deloser) {
+                    tabster.deloser.applyAttribute(
+                        element,
+                        tabsterOnElement,
                         newTabsterProps.deloser as Types.DeloserProps
                     );
-                } else {
-                    if (tabster.deloser) {
-                        tabsterOnElement.deloser =
-                            tabster.deloser.createDeloser(
-                                element,
-                                newTabsterProps.deloser as Types.DeloserProps
-                            );
-                    } else if (__DEV__) {
-                        console.error(
-                            "Deloser API used before initialization, please call `getDeloser()`"
-                        );
-                    }
+                } else if (__DEV__) {
+                    console.error(
+                        "Deloser API used before initialization, please call `getDeloser()`"
+                    );
                 }
                 break;
 
@@ -159,69 +153,35 @@ export function updateTabsterByAttribute(
                 break;
 
             case "modalizer":
-                {
-                    let newModalizerProps: Types.ModalizerProps | undefined;
-                    const modalizerAPI = tabster.modalizer;
-
-                    if (tabsterOnElement.modalizer) {
-                        const props =
-                            newTabsterProps.modalizer as Types.ModalizerProps;
-                        const newModalizerId = props.id;
-                        if (
-                            newModalizerId &&
-                            oldTabsterProps?.modalizer?.id !== newModalizerId
-                        ) {
-                            // Modalizer id is changed, given the modalizers have complex logic and could be
-                            // composite, it is easier to recreate the Modalizer instance than to implement
-                            // the id update.
-                            tabsterOnElement.modalizer.dispose();
-                            newModalizerProps = props;
-                        } else {
-                            tabsterOnElement.modalizer.setProps(props);
-                        }
-                    } else {
-                        if (modalizerAPI) {
-                            newModalizerProps = newTabsterProps.modalizer;
-                        } else if (__DEV__) {
-                            console.error(
-                                "Modalizer API used before initialization, please call `getModalizer()`"
-                            );
-                        }
-                    }
-
-                    if (modalizerAPI && newModalizerProps) {
-                        tabsterOnElement.modalizer =
-                            modalizerAPI.createModalizer(
-                                element,
-                                newModalizerProps,
-                                sys
-                            );
-                    }
+                if (tabster.modalizer) {
+                    tabster.modalizer.applyAttribute(
+                        element,
+                        tabsterOnElement,
+                        newTabsterProps.modalizer as Types.ModalizerProps,
+                        oldTabsterProps?.modalizer,
+                        sys
+                    );
+                } else if (__DEV__) {
+                    console.error(
+                        "Modalizer API used before initialization, please call `getModalizer()`"
+                    );
                 }
-
                 break;
 
             case "restorer":
-                if (tabsterOnElement.restorer) {
-                    tabsterOnElement.restorer.setProps(
-                        newTabsterProps.restorer as Types.RestorerProps
-                    );
-                } else {
-                    if (tabster.restorer) {
-                        if (newTabsterProps.restorer) {
-                            tabsterOnElement.restorer =
-                                tabster.restorer.createRestorer(
-                                    element,
-                                    newTabsterProps.restorer
-                                );
-                        }
-                    } else if (__DEV__) {
-                        console.error(
-                            "Restorer API used before initialization, please call `getRestorer()`"
+                if (tabster.restorer) {
+                    if (newTabsterProps.restorer) {
+                        tabster.restorer.applyAttribute(
+                            element,
+                            tabsterOnElement,
+                            newTabsterProps.restorer
                         );
                     }
+                } else if (__DEV__) {
+                    console.error(
+                        "Restorer API used before initialization, please call `getRestorer()`"
+                    );
                 }
-
                 break;
 
             case "focusable":
@@ -229,43 +189,32 @@ export function updateTabsterByAttribute(
                 break;
 
             case "groupper":
-                if (tabsterOnElement.groupper) {
-                    tabsterOnElement.groupper.setProps(
-                        newTabsterProps.groupper as Types.GroupperProps
+                if (tabster.groupper) {
+                    tabster.groupper.applyAttribute(
+                        element,
+                        tabsterOnElement,
+                        newTabsterProps.groupper as Types.GroupperProps,
+                        sys
                     );
-                } else {
-                    if (tabster.groupper) {
-                        tabsterOnElement.groupper =
-                            tabster.groupper.createGroupper(
-                                element,
-                                newTabsterProps.groupper as Types.GroupperProps,
-                                sys
-                            );
-                    } else if (__DEV__) {
-                        console.error(
-                            "Groupper API used before initialization, please call `getGroupper()`"
-                        );
-                    }
+                } else if (__DEV__) {
+                    console.error(
+                        "Groupper API used before initialization, please call `getGroupper()`"
+                    );
                 }
                 break;
 
             case "mover":
-                if (tabsterOnElement.mover) {
-                    tabsterOnElement.mover.setProps(
-                        newTabsterProps.mover as Types.MoverProps
+                if (tabster.mover) {
+                    tabster.mover.applyAttribute(
+                        element,
+                        tabsterOnElement,
+                        newTabsterProps.mover as Types.MoverProps,
+                        sys
                     );
-                } else {
-                    if (tabster.mover) {
-                        tabsterOnElement.mover = tabster.mover.createMover(
-                            element,
-                            newTabsterProps.mover as Types.MoverProps,
-                            sys
-                        );
-                    } else if (__DEV__) {
-                        console.error(
-                            "Mover API used before initialization, please call `getMover()`"
-                        );
-                    }
+                } else if (__DEV__) {
+                    console.error(
+                        "Mover API used before initialization, please call `getMover()`"
+                    );
                 }
                 break;
 

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -447,6 +447,39 @@ export class ModalizerAPI implements Types.ModalizerAPI {
         return modalizer;
     }
 
+    applyAttribute(
+        element: HTMLElement,
+        storage: Types.TabsterOnElement,
+        newProps: Types.ModalizerProps,
+        oldProps: Types.ModalizerProps | undefined,
+        sys: Types.SysProps | undefined
+    ): void {
+        let propsToCreate: Types.ModalizerProps | undefined;
+
+        if (storage.modalizer) {
+            const newId = newProps.id;
+            if (newId && oldProps?.id !== newId) {
+                // Modalizer id is changed, given the modalizers have complex logic and could be
+                // composite, it is easier to recreate the Modalizer instance than to implement
+                // the id update.
+                storage.modalizer.dispose();
+                propsToCreate = newProps;
+            } else {
+                storage.modalizer.setProps(newProps);
+            }
+        } else {
+            propsToCreate = newProps;
+        }
+
+        if (propsToCreate) {
+            storage.modalizer = this.createModalizer(
+                element,
+                propsToCreate,
+                sys
+            );
+        }
+    }
+
     private _onModalizerDispose = (modalizer: Modalizer) => {
         const id = modalizer.id;
         const userId = modalizer.userId;

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -449,35 +449,24 @@ export class ModalizerAPI implements Types.ModalizerAPI {
 
     applyAttribute(
         element: HTMLElement,
-        storage: Types.TabsterOnElement,
+        existingModalizer: Types.Modalizer | undefined,
         newProps: Types.ModalizerProps,
         oldProps: Types.ModalizerProps | undefined,
         sys: Types.SysProps | undefined
-    ): void {
-        let propsToCreate: Types.ModalizerProps | undefined;
-
-        if (storage.modalizer) {
+    ): Types.Modalizer {
+        if (existingModalizer) {
             const newId = newProps.id;
             if (newId && oldProps?.id !== newId) {
                 // Modalizer id is changed, given the modalizers have complex logic and could be
                 // composite, it is easier to recreate the Modalizer instance than to implement
                 // the id update.
-                storage.modalizer.dispose();
-                propsToCreate = newProps;
-            } else {
-                storage.modalizer.setProps(newProps);
+                existingModalizer.dispose();
+                return this.createModalizer(element, newProps, sys);
             }
-        } else {
-            propsToCreate = newProps;
+            existingModalizer.setProps(newProps);
+            return existingModalizer;
         }
-
-        if (propsToCreate) {
-            storage.modalizer = this.createModalizer(
-                element,
-                propsToCreate,
-                sys
-            );
-        }
+        return this.createModalizer(element, newProps, sys);
     }
 
     private _onModalizerDispose = (modalizer: Modalizer) => {

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -760,15 +760,15 @@ export class MoverAPI implements Types.MoverAPI {
 
     applyAttribute(
         element: HTMLElement,
-        storage: Types.TabsterOnElement,
+        existingMover: Types.Mover | undefined,
         newProps: Types.MoverProps,
         sys: Types.SysProps | undefined
-    ): void {
-        if (storage.mover) {
-            storage.mover.setProps(newProps);
-        } else {
-            storage.mover = this.createMover(element, newProps, sys);
+    ): Types.Mover {
+        if (existingMover) {
+            existingMover.setProps(newProps);
+            return existingMover;
         }
+        return this.createMover(element, newProps, sys);
     }
 
     private _onMoverDispose = (mover: Mover) => {

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -758,6 +758,19 @@ export class MoverAPI implements Types.MoverAPI {
         return newMover;
     }
 
+    applyAttribute(
+        element: HTMLElement,
+        storage: Types.TabsterOnElement,
+        newProps: Types.MoverProps,
+        sys: Types.SysProps | undefined
+    ): void {
+        if (storage.mover) {
+            storage.mover.setProps(newProps);
+        } else {
+            storage.mover = this.createMover(element, newProps, sys);
+        }
+    }
+
     private _onMoverDispose = (mover: Mover) => {
         delete this._movers[mover.id];
     };

--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -12,7 +12,6 @@ import type {
     RestorerAPI as RestorerAPIType,
     RestorerProps,
     TabsterCore,
-    TabsterOnElement,
 } from "./Types.js";
 import { RestorerTypes, AsyncFocusSources } from "./Consts.js";
 import {
@@ -249,13 +248,13 @@ export class RestorerAPI implements RestorerAPIType {
 
     applyAttribute(
         element: HTMLElement,
-        storage: TabsterOnElement,
+        existingRestorer: RestorerInterface | undefined,
         newProps: RestorerProps
-    ): void {
-        if (storage.restorer) {
-            storage.restorer.setProps(newProps);
-        } else {
-            storage.restorer = this.createRestorer(element, newProps);
+    ): RestorerInterface {
+        if (existingRestorer) {
+            existingRestorer.setProps(newProps);
+            return existingRestorer;
         }
+        return this.createRestorer(element, newProps);
     }
 }

--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -12,6 +12,7 @@ import type {
     RestorerAPI as RestorerAPIType,
     RestorerProps,
     TabsterCore,
+    TabsterOnElement,
 } from "./Types.js";
 import { RestorerTypes, AsyncFocusSources } from "./Consts.js";
 import {
@@ -244,5 +245,17 @@ export class RestorerAPI implements RestorerAPIType {
         }
 
         return restorer;
+    }
+
+    applyAttribute(
+        element: HTMLElement,
+        storage: TabsterOnElement,
+        newProps: RestorerProps
+    ): void {
+        if (storage.restorer) {
+            storage.restorer.setProps(newProps);
+        } else {
+            storage.restorer = this.createRestorer(element, newProps);
+        }
     }
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -533,9 +533,9 @@ interface DeloserInterfaceInternal {
     /** @internal */
     applyAttribute(
         element: HTMLElement,
-        storage: TabsterOnElement,
+        existing: Deloser | undefined,
         newProps: DeloserProps
-    ): void;
+    ): Deloser;
 }
 
 export interface DeloserAPI extends DeloserInterfaceInternal, Disposable {
@@ -871,10 +871,10 @@ interface MoverAPIInternal {
     /** @internal */
     applyAttribute(
         element: HTMLElement,
-        storage: TabsterOnElement,
+        existing: Mover | undefined,
         newProps: MoverProps,
         sys: SysProps | undefined
-    ): void;
+    ): Mover;
 }
 
 import { type MoverKeys as _MoverKeys } from "./Consts.js";
@@ -939,10 +939,10 @@ export interface GroupperAPIInternal {
     /** @internal */
     applyAttribute(
         element: HTMLElement,
-        storage: TabsterOnElement,
+        existing: Groupper | undefined,
         newProps: GroupperProps,
         sys: SysProps | undefined
-    ): void;
+    ): Groupper;
 }
 
 import { type GroupperMoveFocusActions as _GroupperMoveFocusActions } from "./Consts.js";
@@ -1113,11 +1113,11 @@ interface ModalizerAPIInternal extends TabsterPartWithAcceptElement {
     /** @internal */
     applyAttribute(
         element: HTMLElement,
-        storage: TabsterOnElement,
+        existing: Modalizer | undefined,
         newProps: ModalizerProps,
         oldProps: ModalizerProps | undefined,
         sys: SysProps | undefined
-    ): void;
+    ): Modalizer;
     /**
      * Sets active modalizers.
      * When active, everything outside of the modalizers with the specific user
@@ -1165,9 +1165,9 @@ interface RestorerAPIInternal {
     /** @internal */
     applyAttribute(
         element: HTMLElement,
-        storage: TabsterOnElement,
+        existing: Restorer | undefined,
         newProps: RestorerProps
-    ): void;
+    ): Restorer;
 }
 
 export interface RestorerAPI extends RestorerAPIInternal, Disposable {}

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -530,6 +530,12 @@ export type DeloserConstructor = (
 interface DeloserInterfaceInternal {
     /** @internal */
     createDeloser(element: HTMLElement, props: DeloserProps): Deloser;
+    /** @internal */
+    applyAttribute(
+        element: HTMLElement,
+        storage: TabsterOnElement,
+        newProps: DeloserProps
+    ): void;
 }
 
 export interface DeloserAPI extends DeloserInterfaceInternal, Disposable {
@@ -862,6 +868,13 @@ interface MoverAPIInternal {
         props: MoverProps,
         sys: SysProps | undefined
     ): Mover;
+    /** @internal */
+    applyAttribute(
+        element: HTMLElement,
+        storage: TabsterOnElement,
+        newProps: MoverProps,
+        sys: SysProps | undefined
+    ): void;
 }
 
 import { type MoverKeys as _MoverKeys } from "./Consts.js";
@@ -922,6 +935,13 @@ export interface GroupperAPIInternal {
         element: HTMLElement,
         event: KeyboardEvent,
         fromModalizer?: boolean
+    ): void;
+    /** @internal */
+    applyAttribute(
+        element: HTMLElement,
+        storage: TabsterOnElement,
+        newProps: GroupperProps,
+        sys: SysProps | undefined
     ): void;
 }
 
@@ -1090,6 +1110,14 @@ interface ModalizerAPIInternal extends TabsterPartWithAcceptElement {
         props: ModalizerProps,
         sys: SysProps | undefined
     ): Modalizer;
+    /** @internal */
+    applyAttribute(
+        element: HTMLElement,
+        storage: TabsterOnElement,
+        newProps: ModalizerProps,
+        oldProps: ModalizerProps | undefined,
+        sys: SysProps | undefined
+    ): void;
     /**
      * Sets active modalizers.
      * When active, everything outside of the modalizers with the specific user
@@ -1134,6 +1162,12 @@ export interface ModalizerAPI extends ModalizerAPIInternal, Disposable {
 interface RestorerAPIInternal {
     /** @internal */
     createRestorer(element: HTMLElement, props: RestorerProps): Restorer;
+    /** @internal */
+    applyAttribute(
+        element: HTMLElement,
+        storage: TabsterOnElement,
+        newProps: RestorerProps
+    ): void;
 }
 
 export interface RestorerAPI extends RestorerAPIInternal, Disposable {}


### PR DESCRIPTION
## Problem

`Instance.ts`'s `updateTabsterByAttribute()` held a ~1.3 kB minified switch that handled `data-tabster` attribute changes for every subsystem.

In a single-subsystem bundle the 5 dead branches for the unused subsystems shipped regardless, guarded only by runtime \`if (tabster.modalizer) …\` checks — which terser cannot statically prove unreachable.

## Fix

Move the heavy branch bodies (`create` / `setProps` / id-change recreation) onto each subsystem's API:

- `DeloserAPI.applyAttribute`
- `GroupperAPI.applyAttribute`
- `MoverAPI.applyAttribute`
- `ModalizerAPI.applyAttribute` — retains the id-change recreation path
- `RestorerAPI.applyAttribute`

\`Instance.ts\` branches become one-liners:

```ts
case "groupper":
    if (tabster.groupper) {
        tabster.groupper.applyAttribute(element, tabsterOnElement, props, sys);
    } else if (__DEV__) {
        console.error(\"Groupper API used before initialization, please call \\\`getGroupper()\\\`\");
    }
    break;
```

**Crucial effect:** each subsystem's `applyAttribute` body is now imported only when its module is imported — i.e. only when \`getX()\` is called. In a \`getGroupper\`-only bundle, Deloser / Mover / Modalizer / Restorer ship nothing for attribute handling; previously they shipped their create/setProps branches inside \`Instance.ts\`.

## Not changed

- **\`root\`** — always present, no tree-shaking benefit, kept inline.
- **\`observed\` / \`outline\`** — conditional but tiny (1-3 lines), kept inline.
- **\`focusable\` / \`uncontrolled\` / \`sys\`** — plain property assignments, kept inline.
- **The delete switch** (cleanup when a key disappears from the attribute) is already compact via case fall-through; a \`removeAttribute\` method would *add* bytes. Left alone.