### PR TITLE
chore(build): bump target to ES2022

### DIFF
--- a/scripts/build-bundle.mjs
+++ b/scripts/build-bundle.mjs
@@ -65,7 +65,7 @@ async function buildCjs() {
             module: { type: "commonjs", strict: true },
             jsc: {
                 parser: { syntax: "ecmascript" },
-                target: "es2019",
+                target: "es2022",
             },
             sourceMaps: true,
         });

--- a/src/tsconfig.lib.json
+++ b/src/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-        "target": "ES2019",
+        "target": "ES2022",
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "outDir": "../dist/type-check",


### PR DESCRIPTION
## Summary

Bumps the TypeScript and SWC `target` from ES2019 to ES2022.

## Why

ES2022 is broadly supported across all browsers in Tabster's matrix. Bumping the target lets TSC + SWC emit native class fields, `??=`/`||=`/`&&=` logical assignment, and other syntax that today gets downleveled to ES2019.

## Changes

- `src/tsconfig.lib.json` — `target: ES2022`
- `scripts/build-bundle.mjs` — SWC `target: es2022`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
