### PR TITLE
chore(ts): enforce explicit .js import extensions via NodeNext

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -10,6 +10,7 @@
         ]
     },
     "moduleNameMapper": {
+        "^(\\.{1,2}/.*)\\.js$": "$1",
         "tabster": "<rootDir>/../src/"
     },
     "testTimeout": 10000,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -30,6 +30,10 @@ const config = [
                         // https://github.com/ezolenko/rollup-plugin-typescript2/issues/268
                         emitDeclarationOnly: false,
                         stripInternal: true,
+                        // rollup-plugin-typescript2 doesn't support NodeNext;
+                        // override to ESNext+Bundler for the bundling pass.
+                        module: "ESNext",
+                        moduleResolution: "Bundler",
                     },
                 },
             }),

--- a/src/AttributeHelpers.ts
+++ b/src/AttributeHelpers.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types";
-import { TABSTER_ATTRIBUTE_NAME } from "./Consts";
+import * as Types from "./Types.js";
+import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 
 export function getTabsterAttribute(
     props: Types.TabsterAttributeProps

--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -7,12 +7,12 @@ import {
     DeloserAPI,
     DeloserHistoryByRootBase,
     DeloserItemBase,
-} from "./Deloser";
-import { getTabsterOnElement } from "./Instance";
-import { RootAPI } from "./Root";
-import { Subscribable } from "./State/Subscribable";
-import * as Types from "./Types";
-import { ObservedElementAccessibilities } from "./Consts";
+} from "./Deloser.js";
+import { getTabsterOnElement } from "./Instance.js";
+import { RootAPI } from "./Root.js";
+import { Subscribable } from "./State/Subscribable.js";
+import * as Types from "./Types.js";
+import { ObservedElementAccessibilities } from "./Consts.js";
 import {
     getElementUId,
     getInstanceContext,
@@ -20,8 +20,8 @@ import {
     getUId,
     getWindowUId,
     HTMLElementWithUID,
-} from "./Utils";
-import { dom } from "./DOMAPI";
+} from "./Utils.js";
+import { dom } from "./DOMAPI.js";
 
 const _transactionTimeout = 1500;
 const _pingTimeout = 3000;

--- a/src/DOMAPI.ts
+++ b/src/DOMAPI.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { DOMAPI } from "./Types";
+import { DOMAPI } from "./Types.js";
 
 const _createMutationObserver = (callback: MutationCallback) =>
     new MutationObserver(callback);

--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -3,16 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { getTabsterOnElement } from "./Instance";
-import { RootAPI } from "./Root";
-import * as Types from "./Types";
-import { DeloserStrategies, RestoreFocusOrders } from "./Consts";
+import { getTabsterOnElement } from "./Instance.js";
+import { RootAPI } from "./Root.js";
+import * as Types from "./Types.js";
+import { DeloserStrategies, RestoreFocusOrders } from "./Consts.js";
 import {
     DeloserFocusLostEvent,
     DeloserRestoreFocusEvent,
     DeloserRestoreFocusEventName,
     TabsterMoveFocusEvent,
-} from "./Events";
+} from "./Events.js";
 import {
     documentContains,
     getElementUId,
@@ -20,8 +20,8 @@ import {
     isDisplayNone,
     TabsterPart,
     WeakHTMLElement,
-} from "./Utils";
-import { dom } from "./DOMAPI";
+} from "./Utils.js";
+import { dom } from "./DOMAPI.js";
 
 const _containerHistoryLength = 10;
 

--- a/src/Deprecated.ts
+++ b/src/Deprecated.ts
@@ -3,12 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { GroupperMoveFocusAction, MoverKey } from "./Types";
+import { GroupperMoveFocusAction, MoverKey } from "./Types.js";
 import {
     GroupperMoveFocusEvent,
     MoverMoveFocusEvent,
     MoverMemorizedElementEvent,
-} from "./Events";
+} from "./Events.js";
 
 /** @deprecated This function is obsolete, use native element.dispatchEvent(new GroupperMoveFocusEvent(...)). */
 export function dispatchGroupperMoveFocusEvent(

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types";
-import * as EventsTypes from "./EventsTypes";
+import * as Types from "./Types.js";
+import * as EventsTypes from "./EventsTypes.js";
 
 /**
  * Events sent by Tabster.

--- a/src/EventsTypes.ts
+++ b/src/EventsTypes.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types";
+import * as Types from "./Types.js";
 
 export interface TabsterMoveFocusEventDetail {
     by: "mover" | "groupper" | "modalizer" | "root" | "deloser";

--- a/src/Focusable.ts
+++ b/src/Focusable.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { getTabsterOnElement } from "./Instance";
-import { RootAPI } from "./Root";
-import * as Types from "./Types";
-import { FOCUSABLE_SELECTOR } from "./Consts";
+import { getTabsterOnElement } from "./Instance.js";
+import { RootAPI } from "./Root.js";
+import * as Types from "./Types.js";
+import { FOCUSABLE_SELECTOR } from "./Consts.js";
 import {
     createElementTreeWalker,
     getDummyInputContainer,
@@ -16,8 +16,8 @@ import {
     isRadio,
     matchesSelector,
     shouldIgnoreFocus,
-} from "./Utils";
-import { dom } from "./DOMAPI";
+} from "./Utils.js";
+import { dom } from "./DOMAPI.js";
 
 export class FocusableAPI implements Types.FocusableAPI {
     private _tabster: Types.TabsterCore;

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -5,21 +5,21 @@
 
 import { nativeFocus } from "keyborg";
 
-import { getTabsterOnElement } from "./Instance";
-import { Keys } from "./Keys";
-import { RootAPI } from "./Root";
-import * as Types from "./Types";
+import { getTabsterOnElement } from "./Instance.js";
+import { Keys } from "./Keys.js";
+import { RootAPI } from "./Root.js";
+import * as Types from "./Types.js";
 import {
     AsyncFocusSources,
     GroupperMoveFocusActions,
     GroupperTabbabilities,
-} from "./Consts";
+} from "./Consts.js";
 import {
     GroupperMoveFocusEvent,
     GroupperMoveFocusEventName,
     TabsterMoveFocusEvent,
-} from "./Events";
-import { FocusedElementState } from "./State/FocusedElement";
+} from "./Events.js";
+import { FocusedElementState } from "./State/FocusedElement.js";
 import {
     DummyInput,
     DummyInputManager,
@@ -28,8 +28,8 @@ import {
     getDummyInputContainer,
     TabsterPart,
     WeakHTMLElement,
-} from "./Utils";
-import { dom } from "./DOMAPI";
+} from "./Utils.js";
+import { dom } from "./DOMAPI.js";
 
 class GroupperDummyManager extends DummyInputManager {
     constructor(

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types";
-import { TABSTER_ATTRIBUTE_NAME } from "./Consts";
+import * as Types from "./Types.js";
+import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 
 export function getTabsterOnElement(
     tabster: Types.TabsterCore,

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -4,13 +4,13 @@
  */
 
 import { nativeFocus } from "keyborg";
-import { getTabsterOnElement } from "./Instance";
-import { RootAPI } from "./Root";
-import { FocusedElementState } from "./State/FocusedElement";
-import { Keys } from "./Keys";
-import * as Types from "./Types";
-import { ModalizerActiveEvent, ModalizerInactiveEvent } from "./Events";
-import { ModalizerEventDetail } from "./EventsTypes";
+import { getTabsterOnElement } from "./Instance.js";
+import { RootAPI } from "./Root.js";
+import { FocusedElementState } from "./State/FocusedElement.js";
+import { Keys } from "./Keys.js";
+import * as Types from "./Types.js";
+import { ModalizerActiveEvent, ModalizerInactiveEvent } from "./Events.js";
+import { ModalizerEventDetail } from "./EventsTypes.js";
 import {
     augmentAttribute,
     DummyInput,
@@ -19,8 +19,8 @@ import {
     getDummyInputContainer,
     TabsterPart,
     WeakHTMLElement,
-} from "./Utils";
-import { dom } from "./DOMAPI";
+} from "./Utils.js";
+import { dom } from "./DOMAPI.js";
 
 let _wasFocusedCounter = 0;
 

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -4,12 +4,12 @@
  */
 
 import { nativeFocus } from "keyborg";
-import { FocusedElementState } from "./State/FocusedElement";
-import { getTabsterOnElement } from "./Instance";
-import { Keys } from "./Keys";
-import { RootAPI } from "./Root";
-import * as Types from "./Types";
-import { Visibilities, MoverDirections, MoverKeys } from "./Consts";
+import { FocusedElementState } from "./State/FocusedElement.js";
+import { getTabsterOnElement } from "./Instance.js";
+import { Keys } from "./Keys.js";
+import { RootAPI } from "./Root.js";
+import * as Types from "./Types.js";
+import { Visibilities, MoverDirections, MoverKeys } from "./Consts.js";
 import {
     MoverMemorizedElementEvent,
     MoverMemorizedElementEventName,
@@ -17,7 +17,7 @@ import {
     MoverMoveFocusEventName,
     MoverStateEvent,
     TabsterMoveFocusEvent,
-} from "./Events";
+} from "./Events.js";
 import {
     createElementTreeWalker,
     DummyInput,
@@ -31,8 +31,8 @@ import {
     TabsterPart,
     WeakHTMLElement,
     getDummyInputContainer,
-} from "./Utils";
-import { dom } from "./DOMAPI";
+} from "./Utils.js";
+import { dom } from "./DOMAPI.js";
 
 const _inputSelector = ["input", "textarea", "*[contenteditable]"].join(", ");
 

--- a/src/MutationEvent.ts
+++ b/src/MutationEvent.ts
@@ -3,17 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { getTabsterOnElement } from "./Instance";
-import * as Types from "./Types";
-import { TABSTER_ATTRIBUTE_NAME } from "./Consts";
+import { getTabsterOnElement } from "./Instance.js";
+import * as Types from "./Types.js";
+import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 import {
     createElementTreeWalker,
     getInstanceContext,
     HTMLElementWithUID,
     InstanceContext,
     WeakHTMLElement,
-} from "./Utils";
-import { dom } from "./DOMAPI";
+} from "./Utils.js";
+import { dom } from "./DOMAPI.js";
 
 export function observeMutations(
     doc: Document,

--- a/src/Outline.ts
+++ b/src/Outline.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { getTabsterOnElement } from "./Instance";
-import * as Types from "./Types";
-import { getBoundingRect } from "./Utils";
+import { getTabsterOnElement } from "./Instance.js";
+import * as Types from "./Types.js";
+import { getBoundingRect } from "./Utils.js";
 
 interface WindowWithOutlineStyle extends Window {
     __tabsterOutline?: {

--- a/src/Restorer.ts
+++ b/src/Restorer.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { getTabsterOnElement } from "./Instance";
+import { getTabsterOnElement } from "./Instance.js";
 import type {
     FocusedElementState,
     GetWindow,
@@ -12,14 +12,14 @@ import type {
     RestorerAPI as RestorerAPIType,
     RestorerProps,
     TabsterCore,
-} from "./Types";
-import { RestorerTypes, AsyncFocusSources } from "./Consts";
+} from "./Types.js";
+import { RestorerTypes, AsyncFocusSources } from "./Consts.js";
 import {
     RestorerRestoreFocusEvent,
     RestorerRestoreFocusEventName,
-} from "./Events";
-import { TabsterPart, WeakHTMLElement } from "./Utils";
-import { dom } from "./DOMAPI";
+} from "./Events.js";
+import { TabsterPart, WeakHTMLElement } from "./Utils.js";
+import { dom } from "./DOMAPI.js";
 
 class Restorer extends TabsterPart<RestorerProps> implements RestorerInterface {
     private _hasFocus = false;

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -4,9 +4,9 @@
  */
 
 import { KEYBORG_FOCUSIN, KEYBORG_FOCUSOUT, nativeFocus } from "keyborg";
-import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance";
-import * as Types from "./Types";
-import { RootFocusEvent, RootBlurEvent } from "./Events";
+import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance.js";
+import * as Types from "./Types.js";
+import { RootFocusEvent, RootBlurEvent } from "./Events.js";
 import {
     DummyInput,
     DummyInputManager,
@@ -14,8 +14,8 @@ import {
     getElementUId,
     TabsterPart,
     WeakHTMLElement,
-} from "./Utils";
-import { setTabsterAttribute } from "./AttributeHelpers";
+} from "./Utils.js";
+import { setTabsterAttribute } from "./AttributeHelpers.js";
 
 export interface WindowWithTabsterInstance extends Window {
     __tabsterInstance?: Types.TabsterCore;

--- a/src/Shadowdomize/ShadowMutationObserver.ts
+++ b/src/Shadowdomize/ShadowMutationObserver.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { nodeContains } from "./DOMFunctions";
+import { nodeContains } from "./DOMFunctions.js";
 
 interface OverridenAttachShadow {
     __origAttachShadow?: typeof Element.prototype.attachShadow;

--- a/src/Shadowdomize/ShadowTreeWalker.ts
+++ b/src/Shadowdomize/ShadowTreeWalker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { getLastElementChild, nodeContains } from "./DOMFunctions";
+import { getLastElementChild, nodeContains } from "./DOMFunctions.js";
 
 function getLastChild(container: HTMLElement): HTMLElement | undefined {
     let lastChild: HTMLElement | null = null;

--- a/src/Shadowdomize/index.ts
+++ b/src/Shadowdomize/index.ts
@@ -6,8 +6,8 @@
 // TODO: The functions below do not consider Shadow DOM slots yet. We will be adding
 // support for slots as the need arises.
 
-export { createShadowTreeWalker as createTreeWalker } from "./ShadowTreeWalker";
-export { createShadowMutationObserver as createMutationObserver } from "./ShadowMutationObserver";
+export { createShadowTreeWalker as createTreeWalker } from "./ShadowTreeWalker.js";
+export { createShadowMutationObserver as createMutationObserver } from "./ShadowMutationObserver.js";
 export {
     appendChild,
     getActiveElement,
@@ -25,9 +25,9 @@ export {
     getElementsByName,
     insertBefore,
     nodeContains,
-} from "./DOMFunctions";
+} from "./DOMFunctions.js";
 export {
     getElementById,
     querySelector,
     querySelectorAll,
-} from "./querySelector";
+} from "./querySelector.js";

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -11,25 +11,25 @@ import {
     nativeFocus,
 } from "keyborg";
 
-import { Keys } from "../Keys";
-import { RootAPI } from "../Root";
-import * as Types from "../Types";
-import { AsyncFocusSources } from "../Consts";
+import { Keys } from "../Keys.js";
+import { RootAPI } from "../Root.js";
+import * as Types from "../Types.js";
+import { AsyncFocusSources } from "../Consts.js";
 import {
     TabsterFocusInEvent,
     TabsterFocusOutEvent,
     TabsterMoveFocusEvent,
-} from "../Events";
+} from "../Events.js";
 import {
     documentContains,
     DummyInputManager,
     getLastChild,
     shouldIgnoreFocus,
     WeakHTMLElement,
-} from "../Utils";
-import { getTabsterOnElement } from "../Instance";
-import { dom } from "../DOMAPI";
-import { Subscribable } from "./Subscribable";
+} from "../Utils.js";
+import { getTabsterOnElement } from "../Instance.js";
+import { dom } from "../DOMAPI.js";
+import { Subscribable } from "./Subscribable.js";
 
 function getUncontrolledCompletelyContainer(
     tabster: Types.TabsterCore,

--- a/src/State/KeyboardNavigation.ts
+++ b/src/State/KeyboardNavigation.ts
@@ -5,8 +5,8 @@
 
 import { createKeyborg, disposeKeyborg, Keyborg } from "keyborg";
 
-import * as Types from "../Types";
-import { Subscribable } from "./Subscribable";
+import * as Types from "../Types.js";
+import { Subscribable } from "./Subscribable.js";
 
 export class KeyboardNavigationState
     extends Subscribable<boolean>

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -3,20 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { getTabsterOnElement } from "../Instance";
-import * as Types from "../Types";
+import { getTabsterOnElement } from "../Instance.js";
+import * as Types from "../Types.js";
 import {
     ObservedElementAccessibilities,
     ObservedElementRequestStatuses,
     ObservedElementFailureReasons,
-} from "../Consts";
+} from "../Consts.js";
 import {
     documentContains,
     getElementUId,
     getPromise,
     WeakHTMLElement,
-} from "../Utils";
-import { Subscribable } from "./Subscribable";
+} from "../Utils.js";
+import { Subscribable } from "./Subscribable.js";
 
 const _conditionCheckTimeout = 100;
 

--- a/src/State/Subscribable.ts
+++ b/src/State/Subscribable.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "../Types";
+import * as Types from "../Types.js";
 
 export abstract class Subscribable<
     A,

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -3,22 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { CrossOriginAPI } from "./CrossOrigin";
-import { DeloserAPI } from "./Deloser";
-import { FocusableAPI } from "./Focusable";
-import { FocusedElementState } from "./State/FocusedElement";
-import { GroupperAPI } from "./Groupper";
-import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance";
-import { KeyboardNavigationState } from "./State/KeyboardNavigation";
-import { ModalizerAPI } from "./Modalizer";
-import { MoverAPI } from "./Mover";
-import { observeMutations } from "./MutationEvent";
-import { ObservedElementAPI } from "./State/ObservedElement";
-import { OutlineAPI } from "./Outline";
-import { RootAPI, WindowWithTabsterInstance } from "./Root";
-import * as Types from "./Types";
-import { TABSTER_ATTRIBUTE_NAME } from "./Consts";
-import { UncontrolledAPI } from "./Uncontrolled";
+import { CrossOriginAPI } from "./CrossOrigin.js";
+import { DeloserAPI } from "./Deloser.js";
+import { FocusableAPI } from "./Focusable.js";
+import { FocusedElementState } from "./State/FocusedElement.js";
+import { GroupperAPI } from "./Groupper.js";
+import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance.js";
+import { KeyboardNavigationState } from "./State/KeyboardNavigation.js";
+import { ModalizerAPI } from "./Modalizer.js";
+import { MoverAPI } from "./Mover.js";
+import { observeMutations } from "./MutationEvent.js";
+import { ObservedElementAPI } from "./State/ObservedElement.js";
+import { OutlineAPI } from "./Outline.js";
+import { RootAPI, WindowWithTabsterInstance } from "./Root.js";
+import * as Types from "./Types.js";
+import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
+import { UncontrolledAPI } from "./Uncontrolled.js";
 import {
     cleanupFakeWeakRefs,
     clearElementCache,
@@ -29,10 +29,10 @@ import {
     getDummyInputContainer,
     startFakeWeakRefsCleanup,
     stopFakeWeakRefsCleanupAndClearStorage,
-} from "./Utils";
-import { RestorerAPI } from "./Restorer";
-import { dom, setDOMAPI } from "./DOMAPI";
-import * as shadowDOMAPI from "./Shadowdomize";
+} from "./Utils.js";
+import { RestorerAPI } from "./Restorer.js";
+import { dom, setDOMAPI } from "./DOMAPI.js";
+import * as shadowDOMAPI from "./Shadowdomize/index.js";
 
 export { getDummyInputContainer };
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { TABSTER_ATTRIBUTE_NAME } from "./Consts";
+import type { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
 
 export interface HTMLElementWithTabsterFlags extends HTMLElement {
     __tabsterElementFlags?: {
@@ -134,7 +134,7 @@ export interface FocusedElementDetail {
     modalizerId?: string;
 }
 
-import { AsyncFocusSources as _AsyncFocusSources } from "./Consts";
+import { AsyncFocusSources as _AsyncFocusSources } from "./Consts.js";
 export type AsyncFocusSources = typeof _AsyncFocusSources;
 
 export type AsyncFocusSource = AsyncFocusSources[keyof AsyncFocusSources];
@@ -258,21 +258,21 @@ export interface ObservedElementChange {
     removedNames?: string[];
 }
 
-import { ObservedElementAccessibilities as _ObservedElementAccessibilities } from "./Consts";
+import { ObservedElementAccessibilities as _ObservedElementAccessibilities } from "./Consts.js";
 export type ObservedElementAccessibilities =
     typeof _ObservedElementAccessibilities;
 
 export type ObservedElementAccessibility =
     ObservedElementAccessibilities[keyof ObservedElementAccessibilities];
 
-import { ObservedElementRequestStatuses as _ObservedElementRequestStatuses } from "./Consts";
+import { ObservedElementRequestStatuses as _ObservedElementRequestStatuses } from "./Consts.js";
 export type ObservedElementRequestStatuses =
     typeof _ObservedElementRequestStatuses;
 
 export type ObservedElementRequestStatus =
     ObservedElementRequestStatuses[keyof ObservedElementRequestStatuses];
 
-import { ObservedElementFailureReasons as _ObservedElementFailureReasons } from "./Consts";
+import { ObservedElementFailureReasons as _ObservedElementFailureReasons } from "./Consts.js";
 export type ObservedElementFailureReasons =
     typeof _ObservedElementFailureReasons;
 
@@ -489,12 +489,12 @@ export interface DeloserElementActions {
     isActive: () => boolean;
 }
 
-import { RestoreFocusOrders as _RestoreFocusOrders } from "./Consts";
+import { RestoreFocusOrders as _RestoreFocusOrders } from "./Consts.js";
 export type RestoreFocusOrders = typeof _RestoreFocusOrders;
 
 export type RestoreFocusOrder = RestoreFocusOrders[keyof RestoreFocusOrders];
 
-import { DeloserStrategies as _DeloserStrategies } from "./Consts";
+import { DeloserStrategies as _DeloserStrategies } from "./Consts.js";
 export type DeloserStrategies = typeof _DeloserStrategies;
 
 export type DeloserStrategy = DeloserStrategies[keyof DeloserStrategies];
@@ -764,7 +764,7 @@ export interface DummyInputManager {
     ) => void;
 }
 
-import { Visibilities as _Visibilities } from "./Consts";
+import { Visibilities as _Visibilities } from "./Consts.js";
 export type Visibilities = typeof _Visibilities;
 
 export type Visibility = Visibilities[keyof Visibilities];
@@ -774,12 +774,12 @@ export interface MoverElementState {
     visibility: Visibility;
 }
 
-import { RestorerTypes as _RestorerTypes } from "./Consts";
+import { RestorerTypes as _RestorerTypes } from "./Consts.js";
 export type RestorerTypes = typeof _RestorerTypes;
 
 export type RestorerType = RestorerTypes[keyof RestorerTypes];
 
-import { MoverDirections as _MoverDirections } from "./Consts";
+import { MoverDirections as _MoverDirections } from "./Consts.js";
 export type MoverDirections = typeof _MoverDirections;
 
 export type MoverDirection = MoverDirections[keyof MoverDirections];
@@ -864,7 +864,7 @@ interface MoverAPIInternal {
     ): Mover;
 }
 
-import { MoverKeys as _MoverKeys } from "./Consts";
+import { MoverKeys as _MoverKeys } from "./Consts.js";
 export type MoverKeys = typeof _MoverKeys;
 
 export type MoverKey = MoverKeys[keyof MoverKeys];
@@ -874,7 +874,7 @@ export interface MoverAPI extends MoverAPIInternal, Disposable {
     moveFocus(fromElement: HTMLElement, key: MoverKey): HTMLElement | null;
 }
 
-import { GroupperTabbabilities as _GroupperTabbabilities } from "./Consts";
+import { GroupperTabbabilities as _GroupperTabbabilities } from "./Consts.js";
 export type GroupperTabbabilities = typeof _GroupperTabbabilities;
 
 export type GroupperTabbability =
@@ -925,7 +925,7 @@ export interface GroupperAPIInternal {
     ): void;
 }
 
-import { GroupperMoveFocusActions as _GroupperMoveFocusActions } from "./Consts";
+import { GroupperMoveFocusActions as _GroupperMoveFocusActions } from "./Consts.js";
 export type GroupperMoveFocusActions = typeof _GroupperMoveFocusActions;
 
 export type GroupperMoveFocusAction =
@@ -995,7 +995,7 @@ export type RootConstructor = (
     props: RootProps
 ) => Root;
 
-import { SysDummyInputsPositions as _SysDummyInputsPositions } from "./Consts";
+import { SysDummyInputsPositions as _SysDummyInputsPositions } from "./Consts.js";
 export type SysDummyInputsPositions = typeof _SysDummyInputsPositions;
 
 export type SysDummyInputsPosition =

--- a/src/Uncontrolled.ts
+++ b/src/Uncontrolled.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Types from "./Types";
+import * as Types from "./Types.js";
 
 /**
  * Allows default or user focus behaviour on the DOM subtree

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -15,16 +15,16 @@ import {
     TabsterPart as TabsterPartInterface,
     Visibility,
     WeakHTMLElement as WeakHTMLElementInterface,
-} from "./Types";
+} from "./Types.js";
 import {
     FOCUSABLE_SELECTOR,
     SysDummyInputsPositions,
     TABSTER_ATTRIBUTE_NAME,
     TABSTER_DUMMY_INPUT_ATTRIBUTE_NAME,
     Visibilities,
-} from "./Consts";
-import { TabsterMoveFocusEvent } from "./Events";
-import { dom } from "./DOMAPI";
+} from "./Consts.js";
+import { TabsterMoveFocusEvent } from "./Events.js";
+import { dom } from "./DOMAPI.js";
 
 interface HTMLElementWithBoundingRectCacheId extends HTMLElement {
     __tabsterCacheId?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,16 +21,16 @@ export {
     getTabster,
     isNoOp,
     makeNoOp,
-} from "./Tabster";
+} from "./Tabster.js";
 
-export * from "./AttributeHelpers";
+export * from "./AttributeHelpers.js";
 
-export * as Types from "./Types";
+export * as Types from "./Types.js";
 
-export * from "./Events";
+export * from "./Events.js";
 
-export * as EventsTypes from "./EventsTypes";
+export * as EventsTypes from "./EventsTypes.js";
 
-export * from "./Consts";
+export * from "./Consts.js";
 
-export * from "./Deprecated";
+export * from "./Deprecated.js";

--- a/src/tsconfig.lib.json
+++ b/src/tsconfig.lib.json
@@ -2,6 +2,8 @@
     "extends": "../tsconfig.json",
     "compilerOptions": {
         "target": "ES2019",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
         "outDir": "../dist",
         "declarationDir": "../dist/dts",
         "sourceMap": true


### PR DESCRIPTION
## Summary
Switches \`src/tsconfig.lib.json\` to \`module: NodeNext\` + \`moduleResolution: NodeNext\` so TypeScript enforces explicit extensions on relative imports. Adds \`.js\` suffix to every relative import across \`src/\`.

## Changes
- **\`src/tsconfig.lib.json\`** — adds \`module: NodeNext\`, \`moduleResolution: NodeNext\`.
- **All \`src/**/*.ts\` files** — \`from "./X"\` → \`from "./X.js"\`. Barrel imports get \`/index.js\` (the only one is \`./Shadowdomize\` in \`Tabster.ts\`).
- **\`rollup.config.mjs\`** — \`rollup-plugin-typescript2\` does not support NodeNext, so the bundling pass overrides \`module: ESNext\` + \`moduleResolution: Bundler\` via \`tsconfigOverride\`. The source tsconfig stays strict.
- **\`jest.config.json\`** — adds \`moduleNameMapper\` rule \`"^(\\\\.{1,2}/.*)\\\\.js$": "$1"\` so Jest can resolve \`.js\` imports back to source \`.ts\` files in tests.

## Why
Once enforced by TSC, missing extensions become a type error rather than something that only breaks at runtime under stricter resolvers (Node ESM, NodeNext consumers, future build pipelines). No public API change.

## Not changed
- No build-system migration. The existing Rollup pipeline still produces \`dist/index.js\`, \`dist/tabster.esm.js\`, and \`dist/index.d.ts\` unchanged.
- No \`"type": "module"\` flip on \`package.json\`. Babel/Jest puppeteer config files keep their \`.js\` extensions.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run type-check\` passes (lib + tests + stories)
- [x] \`npm run build-bundle\` produces valid \`dist/\` output
- [x] \`npm run format:check\` clean (only gitignored \`.claude/settings.local.json\` flagged)
- [ ] Full puppeteer test matrix — runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)