### PR TITLE
refactor: split get* subsystem helpers into src/get/*.ts

### DIFF
--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -3,18 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { CrossOriginAPI } from "./CrossOrigin.js";
-import { DeloserAPI } from "./Deloser.js";
 import { FocusableAPI } from "./Focusable.js";
 import { FocusedElementState } from "./State/FocusedElement.js";
-import { GroupperAPI } from "./Groupper.js";
 import { getTabsterOnElement, updateTabsterByAttribute } from "./Instance.js";
 import { KeyboardNavigationState } from "./State/KeyboardNavigation.js";
-import { ModalizerAPI } from "./Modalizer.js";
-import { MoverAPI } from "./Mover.js";
 import { observeMutations } from "./MutationEvent.js";
-import { ObservedElementAPI } from "./State/ObservedElement.js";
-import { OutlineAPI } from "./Outline.js";
 import { RootAPI, WindowWithTabsterInstance } from "./Root.js";
 import * as Types from "./Types.js";
 import { TABSTER_ATTRIBUTE_NAME } from "./Consts.js";
@@ -30,7 +23,6 @@ import {
     startFakeWeakRefsCleanup,
     stopFakeWeakRefsCleanupAndClearStorage,
 } from "./Utils.js";
-import { RestorerAPI } from "./Restorer.js";
 import { dom, setDOMAPI } from "./DOMAPI.js";
 import * as shadowDOMAPI from "./Shadowdomize/index.js";
 
@@ -355,137 +347,9 @@ export function getShadowDOMAPI(): Types.DOMAPI {
     return shadowDOMAPI;
 }
 
-/**
- * Creates a new groupper instance or returns an existing one
- * @param tabster Tabster instance
- */
-export function getGroupper(tabster: Types.Tabster): Types.GroupperAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.groupper) {
-        tabsterCore.groupper = new GroupperAPI(
-            tabsterCore,
-            tabsterCore.getWindow
-        );
-    }
-
-    return tabsterCore.groupper;
-}
-
-/**
- * Creates a new mover instance or returns an existing one
- * @param tabster Tabster instance
- */
-export function getMover(tabster: Types.Tabster): Types.MoverAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.mover) {
-        tabsterCore.mover = new MoverAPI(tabsterCore, tabsterCore.getWindow);
-    }
-
-    return tabsterCore.mover;
-}
-
-export function getOutline(tabster: Types.Tabster): Types.OutlineAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.outline) {
-        tabsterCore.outline = new OutlineAPI(tabsterCore);
-    }
-
-    return tabsterCore.outline;
-}
-
-/**
- * Creates a new new deloser instance or returns an existing one
- * @param tabster Tabster instance
- * @param props Deloser props
- */
-export function getDeloser(
-    tabster: Types.Tabster,
-    props?: { autoDeloser: Types.DeloserProps }
-): Types.DeloserAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.deloser) {
-        tabsterCore.deloser = new DeloserAPI(tabsterCore, props);
-    }
-
-    return tabsterCore.deloser;
-}
-
-/**
- * Creates a new modalizer instance or returns an existing one
- * @param tabster Tabster instance
- * @param alwaysAccessibleSelector When Modalizer is active, we put
- * aria-hidden to everything else to hide it from screen readers. This CSS
- * selector allows to exclude some elements from this behaviour. For example,
- * this could be used to exclude aria-live region with the application-wide
- * status announcements.
- * @param accessibleCheck An optional callback that will be called when
- * active Modalizer wants to hide an element that doesn't belong to it from
- * the screen readers by setting aria-hidden. Similar to alwaysAccessibleSelector
- * but allows to address the elements programmatically rather than with a selector.
- * If the callback returns true, the element will not receive aria-hidden.
- */
-export function getModalizer(
-    tabster: Types.Tabster,
-    // @deprecated use accessibleCheck.
-    alwaysAccessibleSelector?: string,
-    accessibleCheck?: Types.ModalizerElementAccessibleCheck
-): Types.ModalizerAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.modalizer) {
-        tabsterCore.modalizer = new ModalizerAPI(
-            tabsterCore,
-            alwaysAccessibleSelector,
-            accessibleCheck
-        );
-    }
-
-    return tabsterCore.modalizer;
-}
-
-export function getObservedElement(
-    tabster: Types.Tabster
-): Types.ObservedElementAPI {
-    const tabsterCore = tabster.core;
-
-    if (!tabsterCore.observedElement) {
-        tabsterCore.observedElement = new ObservedElementAPI(tabsterCore);
-    }
-
-    return tabsterCore.observedElement;
-}
-
-export function getCrossOrigin(tabster: Types.Tabster): Types.CrossOriginAPI {
-    const tabsterCore = tabster.core;
-    if (!tabsterCore.crossOrigin) {
-        getDeloser(tabster);
-        getModalizer(tabster);
-        getMover(tabster);
-        getGroupper(tabster);
-        getOutline(tabster);
-        getObservedElement(tabster);
-        tabsterCore.crossOrigin = new CrossOriginAPI(tabsterCore);
-    }
-
-    return tabsterCore.crossOrigin;
-}
-
 export function getInternal(tabster: Types.Tabster): Types.InternalAPI {
     const tabsterCore = tabster.core;
     return tabsterCore.internal;
-}
-
-export function getRestorer(tabster: Types.Tabster): Types.RestorerAPI {
-    const tabsterCore = tabster.core;
-    if (!tabsterCore.restorer) {
-        tabsterCore.restorer = new RestorerAPI(tabsterCore);
-    }
-
-    return tabsterCore.restorer;
 }
 
 export function disposeTabster(
@@ -551,3 +415,12 @@ export function makeNoOp(tabster: Types.Tabster, noop: boolean): void {
 export function isNoOp(tabster: Types.TabsterCore): boolean {
     return (tabster as TabsterCore)._noop;
 }
+
+export { getCrossOrigin } from "./get/getCrossOrigin.js";
+export { getDeloser } from "./get/getDeloser.js";
+export { getGroupper } from "./get/getGroupper.js";
+export { getModalizer } from "./get/getModalizer.js";
+export { getMover } from "./get/getMover.js";
+export { getObservedElement } from "./get/getObservedElement.js";
+export { getOutline } from "./get/getOutline.js";
+export { getRestorer } from "./get/getRestorer.js";

--- a/src/get/getCrossOrigin.ts
+++ b/src/get/getCrossOrigin.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { CrossOriginAPI } from "../CrossOrigin.js";
+import type * as Types from "../Types.js";
+import { getDeloser } from "./getDeloser.js";
+import { getModalizer } from "./getModalizer.js";
+import { getMover } from "./getMover.js";
+import { getGroupper } from "./getGroupper.js";
+import { getOutline } from "./getOutline.js";
+import { getObservedElement } from "./getObservedElement.js";
+
+export function getCrossOrigin(tabster: Types.Tabster): Types.CrossOriginAPI {
+    const tabsterCore = tabster.core;
+    if (!tabsterCore.crossOrigin) {
+        getDeloser(tabster);
+        getModalizer(tabster);
+        getMover(tabster);
+        getGroupper(tabster);
+        getOutline(tabster);
+        getObservedElement(tabster);
+        tabsterCore.crossOrigin = new CrossOriginAPI(tabsterCore);
+    }
+
+    return tabsterCore.crossOrigin;
+}

--- a/src/get/getDeloser.ts
+++ b/src/get/getDeloser.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DeloserAPI } from "../Deloser.js";
+import type * as Types from "../Types.js";
+
+/**
+ * Creates a new deloser instance or returns an existing one
+ * @param tabster Tabster instance
+ * @param props Deloser props
+ */
+export function getDeloser(
+    tabster: Types.Tabster,
+    props?: { autoDeloser: Types.DeloserProps }
+): Types.DeloserAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.deloser) {
+        tabsterCore.deloser = new DeloserAPI(tabsterCore, props);
+    }
+
+    return tabsterCore.deloser;
+}

--- a/src/get/getGroupper.ts
+++ b/src/get/getGroupper.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { GroupperAPI } from "../Groupper.js";
+import type * as Types from "../Types.js";
+
+/**
+ * Creates a new groupper instance or returns an existing one
+ * @param tabster Tabster instance
+ */
+export function getGroupper(tabster: Types.Tabster): Types.GroupperAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.groupper) {
+        tabsterCore.groupper = new GroupperAPI(
+            tabsterCore,
+            tabsterCore.getWindow
+        );
+    }
+
+    return tabsterCore.groupper;
+}

--- a/src/get/getModalizer.ts
+++ b/src/get/getModalizer.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ModalizerAPI } from "../Modalizer.js";
+import type * as Types from "../Types.js";
+
+/**
+ * Creates a new modalizer instance or returns an existing one
+ * @param tabster Tabster instance
+ * @param alwaysAccessibleSelector When Modalizer is active, we put aria-hidden to
+ * everything else to hide it from screen readers. This CSS selector allows to
+ * exclude some elements from this behaviour.
+ * @param accessibleCheck An optional callback used to exclude elements from
+ * receiving aria-hidden when a Modalizer is active.
+ */
+export function getModalizer(
+    tabster: Types.Tabster,
+    // @deprecated use accessibleCheck.
+    alwaysAccessibleSelector?: string,
+    accessibleCheck?: Types.ModalizerElementAccessibleCheck
+): Types.ModalizerAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.modalizer) {
+        tabsterCore.modalizer = new ModalizerAPI(
+            tabsterCore,
+            alwaysAccessibleSelector,
+            accessibleCheck
+        );
+    }
+
+    return tabsterCore.modalizer;
+}

--- a/src/get/getMover.ts
+++ b/src/get/getMover.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { MoverAPI } from "../Mover.js";
+import type * as Types from "../Types.js";
+
+/**
+ * Creates a new mover instance or returns an existing one
+ * @param tabster Tabster instance
+ */
+export function getMover(tabster: Types.Tabster): Types.MoverAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.mover) {
+        tabsterCore.mover = new MoverAPI(tabsterCore, tabsterCore.getWindow);
+    }
+
+    return tabsterCore.mover;
+}

--- a/src/get/getObservedElement.ts
+++ b/src/get/getObservedElement.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ObservedElementAPI } from "../State/ObservedElement.js";
+import type * as Types from "../Types.js";
+
+export function getObservedElement(
+    tabster: Types.Tabster
+): Types.ObservedElementAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.observedElement) {
+        tabsterCore.observedElement = new ObservedElementAPI(tabsterCore);
+    }
+
+    return tabsterCore.observedElement;
+}

--- a/src/get/getOutline.ts
+++ b/src/get/getOutline.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { OutlineAPI } from "../Outline.js";
+import type * as Types from "../Types.js";
+
+export function getOutline(tabster: Types.Tabster): Types.OutlineAPI {
+    const tabsterCore = tabster.core;
+
+    if (!tabsterCore.outline) {
+        tabsterCore.outline = new OutlineAPI(tabsterCore);
+    }
+
+    return tabsterCore.outline;
+}

--- a/src/get/getRestorer.ts
+++ b/src/get/getRestorer.ts
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { RestorerAPI } from "../Restorer.js";
+import type * as Types from "../Types.js";
+
+export function getRestorer(tabster: Types.Tabster): Types.RestorerAPI {
+    const tabsterCore = tabster.core;
+    if (!tabsterCore.restorer) {
+        tabsterCore.restorer = new RestorerAPI(tabsterCore);
+    }
+
+    return tabsterCore.restorer;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,21 +7,22 @@ export {
     createTabster,
     disposeTabster,
     forceCleanup,
-    getCrossOrigin,
-    getDeloser,
     getDummyInputContainer,
-    getGroupper,
     getInternal,
-    getModalizer,
-    getMover,
-    getObservedElement,
-    getOutline,
-    getRestorer,
-    getShadowDOMAPI,
     getTabster,
+    getShadowDOMAPI,
     isNoOp,
     makeNoOp,
 } from "./Tabster.js";
+
+export { getCrossOrigin } from "./get/getCrossOrigin.js";
+export { getDeloser } from "./get/getDeloser.js";
+export { getGroupper } from "./get/getGroupper.js";
+export { getModalizer } from "./get/getModalizer.js";
+export { getMover } from "./get/getMover.js";
+export { getObservedElement } from "./get/getObservedElement.js";
+export { getOutline } from "./get/getOutline.js";
+export { getRestorer } from "./get/getRestorer.js";
 
 export * from "./AttributeHelpers.js";
 


### PR DESCRIPTION
## Summary

Splits the per-subsystem `get*` helpers out of `Tabster.ts` into one file per subsystem under `src/get/`. The public API is unchanged — `import { getMover } from 'tabster'` keeps working — but bundlers can now drop subsystems a consumer doesn't reference, since `Tabster.ts` no longer statically imports every subsystem class.

## Why

`CrossOrigin.js` alone is ~33 KB and ships to every Fluent consumer even though no Fluent package calls `getCrossOrigin`. The static imports at the top of `Tabster.ts` defeat tree-shaking (**module splitting**) for the whole subsystem set.

## Scope

- New: `src/get/{getCrossOrigin,getDeloser,getGroupper,getModalizer,getMover,getObservedElement,getOutline,getRestorer}.ts`
- `src/Tabster.ts`: drops the eight subsystem class imports and the `getX` function definitions
- `src/index.ts`: re-exports each `getX` from its new location

No `package.json` change. No build-pipeline change. Pure source reorg.
