### PR TITLE
chore(bundle-size): add fixtures for Focusable find* methods

### DIFF
--- a/bundle-size/focusableFindAll.fixture.js
+++ b/bundle-size/focusableFindAll.fixture.js
@@ -1,0 +1,23 @@
+import {
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    Types,
+} from "tabster";
+
+/** @param {ReturnType<typeof createTabster>} tabster */
+const useFocusable = (tabster) => tabster.focusable.findAll;
+
+console.log(
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    useFocusable,
+    Types
+);
+
+export default {
+    name: "focusable.findAll",
+};

--- a/bundle-size/focusableFindLast.fixture.js
+++ b/bundle-size/focusableFindLast.fixture.js
@@ -1,0 +1,23 @@
+import {
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    Types,
+} from "tabster";
+
+/** @param {ReturnType<typeof createTabster>} tabster */
+const useFocusable = (tabster) => tabster.focusable.findLast;
+
+console.log(
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    useFocusable,
+    Types
+);
+
+export default {
+    name: "focusable.findLast",
+};

--- a/bundle-size/focusableFindNext.fixture.js
+++ b/bundle-size/focusableFindNext.fixture.js
@@ -1,0 +1,23 @@
+import {
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    Types,
+} from "tabster";
+
+/** @param {ReturnType<typeof createTabster>} tabster */
+const useFocusable = (tabster) => tabster.focusable.findNext;
+
+console.log(
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    useFocusable,
+    Types
+);
+
+export default {
+    name: "focusable.findNext",
+};

--- a/bundle-size/focusableFindPrev.fixture.js
+++ b/bundle-size/focusableFindPrev.fixture.js
@@ -1,0 +1,23 @@
+import {
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    Types,
+} from "tabster";
+
+/** @param {ReturnType<typeof createTabster>} tabster */
+const useFocusable = (tabster) => tabster.focusable.findPrev;
+
+console.log(
+    createTabster,
+    disposeTabster,
+    getTabsterAttribute,
+    setTabsterAttribute,
+    useFocusable,
+    Types
+);
+
+export default {
+    name: "focusable.findPrev",
+};


### PR DESCRIPTION
## Summary

Adds four bundle-size fixtures used by the monosize harness — one per `Focusable` find variant, so each entry point can be measured independently:

- `focusableFindAll.fixture.js`
- `focusableFindLast.fixture.js`
- `focusableFindNext.fixture.js`
- `focusableFindPrev.fixture.js`

Purely additive — only files under `bundle-size/` are added, no shipped code changes.

The matching fixture for `getModalizer` with `controlTab: false` is deferred to the later stack PR that introduces `getRootDummyInputs`, since the fixture needs that export to exist.

## Stack context

First PR in the bundle-size stack. Parent: `master`.