### PR TITLE
chore(deps): bump keyborg to ^3.0.0 to drop unused / legacy code paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "8.8.0",
             "license": "MIT",
             "dependencies": {
-                "keyborg": "^2.14.1",
+                "keyborg": "^3.0.0",
                 "tslib": "^2.8.1"
             },
             "devDependencies": {
@@ -11808,9 +11808,9 @@
             }
         },
         "node_modules/keyborg": {
-            "version": "2.14.1",
-            "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.14.1.tgz",
-            "integrity": "sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-3.0.0.tgz",
+            "integrity": "sha512-reD2drNqyQWG4NIVBvKPkdWcwtgQRScukQFlcH/qINpbVG+n0AUPKwxaixedDomy50gtUQJTGbaOp5y03foxkw==",
             "license": "MIT"
         },
         "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "prepare-pages-deploy": "rimraf ./.pages-deploy && npm run build-docs && npm run build-storybook && copyfiles -u 2 -a \"./docs/build/**/*\" ./.pages-deploy && copyfiles -u 1 -a \"./storybook-static/**/*\" ./.pages-deploy/storybook"
     },
     "dependencies": {
-        "keyborg": "^2.14.1",
+        "keyborg": "^3.0.0",
         "tslib": "^2.8.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary

Bumps `keyborg` to `^3.0.0` to pick up the upstream version.

## Stack context

Stacked on top of #538.