### PR TITLE
refactor(bundle-size): use free-function helpers for timers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,7 +112,7 @@ export default [
     },
     {
         // Library source must go through the free-function helpers in
-        // `Utils.ts` instead of calling the raw DOM event APIs directly —
+        // `Utils.ts` instead of calling the raw DOM/window APIs directly —
         // helper names mangle to single chars after minification, native
         // property names like `addEventListener` are preserved verbatim.
         files: ["src/**/*.ts"],
@@ -135,6 +135,16 @@ export default [
                     selector:
                         "CallExpression[callee.property.name='dispatchEvent']",
                     message: "Use `dispatchEvent` from './Utils.js'.",
+                },
+                {
+                    selector:
+                        "CallExpression[callee.property.name='setTimeout']",
+                    message: "Use `setTimer` from './Utils.js'.",
+                },
+                {
+                    selector:
+                        "CallExpression[callee.property.name='clearTimeout']",
+                    message: "Use `clearTimer` from './Utils.js'.",
                 },
             ],
         },

--- a/src/CrossOrigin.ts
+++ b/src/CrossOrigin.ts
@@ -15,12 +15,16 @@ import type * as Types from "./Types.js";
 import { ObservedElementAccessibilities } from "./Consts.js";
 import {
     addListener,
+    clearTimer,
     getElementUId,
     getInstanceContext,
     getUId,
     getWindowUId,
     type HTMLElementWithUID,
+    isTimerActive,
     removeListener,
+    setTimer,
+    type Timer,
 } from "./Utils.js";
 import { dom } from "./DOMAPI.js";
 
@@ -952,7 +956,7 @@ class PingTransaction extends CrossOriginTransaction<undefined, true> {
 
 interface CrossOriginTransactionWrapper<I, O> {
     transaction: CrossOriginTransaction<I, O>;
-    timer?: number;
+    timer?: Timer;
 }
 
 class CrossOriginTransactions {
@@ -964,7 +968,7 @@ class CrossOriginTransactions {
         [id: string]: CrossOriginTransactionWrapper<any, any>;
     } = {};
     private _tabster: Types.TabsterCore;
-    private _pingTimer: number | undefined;
+    private _pingTimer?: Timer;
     private _isDefaultSendUp = false;
     private _deadPromise: Promise<true | undefined> | undefined;
     isSetUp = false;
@@ -1045,10 +1049,7 @@ class CrossOriginTransactions {
     async dispose(): Promise<void> {
         const owner = this._owner();
 
-        if (this._pingTimer) {
-            owner.clearTimeout(this._pingTimer);
-            this._pingTimer = undefined;
-        }
+        clearTimer(this._pingTimer, owner);
 
         removeListener(owner, "message", this._onBrowserMessage);
         removeListener(owner, "pagehide", this._onPageHide);
@@ -1060,11 +1061,7 @@ class CrossOriginTransactions {
         for (const id of Object.keys(this._transactions)) {
             const t = this._transactions[id];
 
-            if (t.timer) {
-                owner.clearTimeout(t.timer);
-                delete t.timer;
-            }
-
+            clearTimer(t.timer, owner);
             t.transaction.end();
         }
 
@@ -1147,14 +1144,16 @@ class CrossOriginTransactions {
 
         const wrapper: CrossOriginTransactionWrapper<I, O> = {
             transaction,
-            timer: owner.setTimeout(
-                () => {
-                    delete wrapper.timer;
-                    transaction.end("Cross origin transaction timed out.");
-                },
-                _transactionTimeout + (timeout || 0)
-            ),
         };
+
+        wrapper.timer = setTimer(
+            wrapper.timer,
+            owner,
+            () => {
+                transaction.end("Cross origin transaction timed out.");
+            },
+            _transactionTimeout + (timeout || 0)
+        );
 
         this._transactions[transaction.id] = wrapper;
 
@@ -1163,9 +1162,7 @@ class CrossOriginTransactions {
         ret.catch(() => {
             /**/
         }).finally(() => {
-            if (wrapper.timer) {
-                owner.clearTimeout(wrapper.timer);
-            }
+            clearTimer(wrapper.timer, owner);
             delete this._transactions[transaction.id];
         });
 
@@ -1343,7 +1340,7 @@ class CrossOriginTransactions {
     }
 
     private async _ping(): Promise<void> {
-        if (this._pingTimer) {
+        if (isTimerActive(this._pingTimer)) {
             return;
         }
 
@@ -1409,10 +1406,14 @@ class CrossOriginTransactions {
             }
         }
 
-        this._pingTimer = this._owner().setTimeout(() => {
-            this._pingTimer = undefined;
-            this._ping();
-        }, _pingTimeout);
+        this._pingTimer = setTimer(
+            this._pingTimer,
+            this._owner(),
+            () => {
+                this._ping();
+            },
+            _pingTimeout
+        );
     }
 
     private _onBrowserMessage = (e: MessageEvent) => {
@@ -1642,7 +1643,7 @@ export class CrossOriginAPI implements Types.CrossOriginAPI {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
     private _transactions: CrossOriginTransactions;
-    private _blurTimer: number | undefined;
+    private _blurTimer?: Timer;
     private _ctx: CrossOriginInstanceContext;
 
     focusedElement: Types.CrossOriginFocusedElementState;
@@ -1756,10 +1757,7 @@ export class CrossOriginAPI implements Types.CrossOriginAPI {
 
         const ownerUId = getWindowUId(win);
 
-        if (this._blurTimer) {
-            win.clearTimeout(this._blurTimer);
-            this._blurTimer = undefined;
-        }
+        clearTimer(this._blurTimer, win);
 
         if (element) {
             this._transactions.beginTransaction(StateTransaction, {
@@ -1773,26 +1771,35 @@ export class CrossOriginAPI implements Types.CrossOriginAPI {
                 state: CrossOriginStates.Focused,
             });
         } else {
-            this._blurTimer = win.setTimeout(() => {
-                this._blurTimer = undefined;
-
-                if (this._ctx.focusOwner && this._ctx.focusOwner === ownerUId) {
-                    this._transactions
-                        .beginTransaction(GetElementTransaction, undefined)
-                        .then((value) => {
-                            if (!value && this._ctx.focusOwner === ownerUId) {
-                                this._transactions.beginTransaction(
-                                    StateTransaction,
-                                    {
-                                        ownerUId,
-                                        state: CrossOriginStates.Blurred,
-                                        force: false,
-                                    }
-                                );
-                            }
-                        });
-                }
-            }, 0);
+            this._blurTimer = setTimer(
+                this._blurTimer,
+                win,
+                () => {
+                    if (
+                        this._ctx.focusOwner &&
+                        this._ctx.focusOwner === ownerUId
+                    ) {
+                        this._transactions
+                            .beginTransaction(GetElementTransaction, undefined)
+                            .then((value) => {
+                                if (
+                                    !value &&
+                                    this._ctx.focusOwner === ownerUId
+                                ) {
+                                    this._transactions.beginTransaction(
+                                        StateTransaction,
+                                        {
+                                            ownerUId,
+                                            state: CrossOriginStates.Blurred,
+                                            force: false,
+                                        }
+                                    );
+                                }
+                            });
+                    }
+                },
+                0
+            );
         }
     };
 

--- a/src/Deloser.ts
+++ b/src/Deloser.ts
@@ -15,12 +15,15 @@ import {
 } from "./Events.js";
 import {
     addListener,
+    clearTimer,
     dispatchEvent,
     documentContains,
     getElementUId,
     isDisplayNone,
     removeListener,
+    setTimer,
     TabsterPart,
+    type Timer,
     WeakHTMLElement,
 } from "./Utils.js";
 import { dom } from "./DOMAPI.js";
@@ -710,7 +713,7 @@ export class DeloserAPI implements Types.DeloserAPI {
     private _inDeloser = false;
     private _curDeloser: Types.Deloser | undefined;
     private _history: DeloserHistory;
-    private _restoreFocusTimer: number | undefined;
+    private _restoreFocusTimer?: Timer;
     private _isRestoringFocus = false;
     private _isPaused = false;
     private _autoDeloser: Types.DeloserProps | undefined;
@@ -751,10 +754,7 @@ export class DeloserAPI implements Types.DeloserAPI {
     dispose(): void {
         const win = this._win();
 
-        if (this._restoreFocusTimer) {
-            win.clearTimeout(this._restoreFocusTimer);
-            this._restoreFocusTimer = undefined;
-        }
+        clearTimer(this._restoreFocusTimer, win);
 
         if (this._autoDeloserInstance) {
             this._autoDeloserInstance.dispose();
@@ -821,10 +821,7 @@ export class DeloserAPI implements Types.DeloserAPI {
     pause(): void {
         this._isPaused = true;
 
-        if (this._restoreFocusTimer) {
-            this._win().clearTimeout(this._restoreFocusTimer);
-            this._restoreFocusTimer = undefined;
-        }
+        clearTimer(this._restoreFocusTimer, this._win());
     }
 
     resume(restore?: boolean): void {
@@ -856,10 +853,7 @@ export class DeloserAPI implements Types.DeloserAPI {
     };
 
     private _onFocus = (e: HTMLElement | undefined): void => {
-        if (this._restoreFocusTimer) {
-            this._win().clearTimeout(this._restoreFocusTimer);
-            this._restoreFocusTimer = undefined;
-        }
+        clearTimer(this._restoreFocusTimer, this._win());
 
         if (!e) {
             this._scheduleRestoreFocus();
@@ -904,7 +898,8 @@ export class DeloserAPI implements Types.DeloserAPI {
         }
 
         const restoreFocus = async () => {
-            this._restoreFocusTimer = undefined;
+            clearTimer(this._restoreFocusTimer, this._win());
+
             const lastFocused =
                 this._tabster.focusedElement.getLastFocusedElement();
 
@@ -975,7 +970,12 @@ export class DeloserAPI implements Types.DeloserAPI {
         if (force) {
             restoreFocus();
         } else {
-            this._restoreFocusTimer = this._win().setTimeout(restoreFocus, 100);
+            this._restoreFocusTimer = setTimer(
+                this._restoreFocusTimer,
+                this._win(),
+                restoreFocus,
+                100
+            );
         }
     }
 

--- a/src/DummyInput.ts
+++ b/src/DummyInput.ts
@@ -19,10 +19,14 @@ import { TabsterMoveFocusEvent } from "./Events.js";
 import { dom } from "./DOMAPI.js";
 import {
     addListener,
+    clearTimer,
     dispatchEvent,
     hasSubFocusable,
+    isTimerActive,
     makeFocusIgnored,
     removeListener,
+    setTimer,
+    type Timer,
     WeakHTMLElement,
 } from "./Utils.js";
 
@@ -55,7 +59,7 @@ export type DummyInputFocusCallback = (
 export class DummyInput {
     private _isPhantom: DummyInputProps["isPhantom"];
     private _fixedTarget?: WeakHTMLElement;
-    private _disposeTimer: number | undefined;
+    private _disposeTimer?: Timer;
     private _clearDisposeTimeout: (() => void) | undefined;
 
     input: HTMLElement | undefined;
@@ -105,17 +109,17 @@ export class DummyInput {
             element;
 
         if (this._isPhantom) {
-            this._disposeTimer = win.setTimeout(() => {
-                delete this._disposeTimer;
-                this.dispose();
-            }, 0);
+            this._disposeTimer = setTimer(
+                this._disposeTimer,
+                win,
+                () => {
+                    this.dispose();
+                },
+                0
+            );
 
             this._clearDisposeTimeout = () => {
-                if (this._disposeTimer) {
-                    win.clearTimeout(this._disposeTimer);
-                    delete this._disposeTimer;
-                }
-
+                clearTimer(this._disposeTimer, win);
                 delete this._clearDisposeTimeout;
             };
         }
@@ -511,10 +515,10 @@ export class DummyInputObserver implements DummyInputObserverInterface {
             >
         ) => () => void
     > = new Set();
-    private _updateTimer?: number;
+    private _updateTimer?: Timer;
     private _lastUpdateQueueTime = 0;
     private _changedParents: WeakSet<Node> = new WeakSet();
-    private _updateDummyInputsTimer?: number;
+    private _updateDummyInputsTimer?: Timer;
     private _dummyElements: WeakHTMLElement<HTMLElement>[] = [];
     private _dummyCallbacks: WeakMap<HTMLElement, () => void> = new WeakMap();
     domChanged?(parent: HTMLElement): void;
@@ -547,14 +551,9 @@ export class DummyInputObserver implements DummyInputObserverInterface {
     dispose(): void {
         const win = this._win?.();
 
-        if (this._updateTimer) {
-            win?.clearTimeout(this._updateTimer);
-            delete this._updateTimer;
-        }
-
-        if (this._updateDummyInputsTimer) {
-            win?.clearTimeout(this._updateDummyInputsTimer);
-            delete this._updateDummyInputsTimer;
+        if (win) {
+            clearTimer(this._updateTimer, win);
+            clearTimer(this._updateDummyInputsTimer, win);
         }
 
         this._changedParents = new WeakSet();
@@ -573,34 +572,42 @@ export class DummyInputObserver implements DummyInputObserverInterface {
 
         this._changedParents.add(parent);
 
-        if (this._updateDummyInputsTimer) {
+        if (isTimerActive(this._updateDummyInputsTimer)) {
             return;
         }
 
-        this._updateDummyInputsTimer = this._win?.().setTimeout(() => {
-            delete this._updateDummyInputsTimer;
+        const win = this._win?.();
+        if (!win) {
+            return;
+        }
 
-            for (const ref of this._dummyElements) {
-                const dummyElement = ref.get();
+        this._updateDummyInputsTimer = setTimer(
+            this._updateDummyInputsTimer,
+            win,
+            () => {
+                for (const ref of this._dummyElements) {
+                    const dummyElement = ref.get();
 
-                if (dummyElement) {
-                    const callback = this._dummyCallbacks.get(dummyElement);
+                    if (dummyElement) {
+                        const callback = this._dummyCallbacks.get(dummyElement);
 
-                    if (callback) {
-                        const dummyParent = dom.getParentNode(dummyElement);
+                        if (callback) {
+                            const dummyParent = dom.getParentNode(dummyElement);
 
-                        if (
-                            !dummyParent ||
-                            this._changedParents.has(dummyParent)
-                        ) {
-                            callback();
+                            if (
+                                !dummyParent ||
+                                this._changedParents.has(dummyParent)
+                            ) {
+                                callback();
+                            }
                         }
                     }
                 }
-            }
 
-            this._changedParents = new WeakSet();
-        }, _updateDummyInputsTimeout);
+                this._changedParents = new WeakSet();
+            },
+            _updateDummyInputsTimeout
+        );
     };
 
     updatePositions(
@@ -625,49 +632,57 @@ export class DummyInputObserver implements DummyInputObserverInterface {
     }
 
     private _scheduledUpdatePositions(): void {
-        if (this._updateTimer) {
+        if (isTimerActive(this._updateTimer)) {
             return;
         }
 
-        this._updateTimer = this._win?.().setTimeout(() => {
-            delete this._updateTimer;
+        const win = this._win?.();
+        if (!win) {
+            return;
+        }
 
-            // updatePositions() might be called quite a lot during the scrolling.
-            // So, instead of clearing the timeout and scheduling a new one, we
-            // check if enough time has passed since the last updatePositions() call
-            // and only schedule a new one if not.
-            // At maximum, we will update dummy inputs positions
-            // _updateDummyInputsTimeout * 2 after the last updatePositions() call.
-            if (
-                this._lastUpdateQueueTime + _updateDummyInputsTimeout <=
-                Date.now()
-            ) {
-                // A cache for current bulk of updates to reduce getComputedStyle() calls.
-                const scrollTopLeftCache = new Map<
-                    HTMLElement,
-                    { scrollTop: number; scrollLeft: number } | null
-                >();
+        this._updateTimer = setTimer(
+            this._updateTimer,
+            win,
+            () => {
+                // updatePositions() might be called quite a lot during the scrolling.
+                // So, instead of clearing the timeout and scheduling a new one, we
+                // check if enough time has passed since the last updatePositions() call
+                // and only schedule a new one if not.
+                // At maximum, we will update dummy inputs positions
+                // _updateDummyInputsTimeout * 2 after the last updatePositions() call.
+                if (
+                    this._lastUpdateQueueTime + _updateDummyInputsTimeout <=
+                    Date.now()
+                ) {
+                    // A cache for current bulk of updates to reduce getComputedStyle() calls.
+                    const scrollTopLeftCache = new Map<
+                        HTMLElement,
+                        { scrollTop: number; scrollLeft: number } | null
+                    >();
 
-                const setTopLeftCallbacks: (() => void)[] = [];
+                    const setTopLeftCallbacks: (() => void)[] = [];
 
-                for (const compute of this._updateQueue) {
-                    setTopLeftCallbacks.push(compute(scrollTopLeftCache));
+                    for (const compute of this._updateQueue) {
+                        setTopLeftCallbacks.push(compute(scrollTopLeftCache));
+                    }
+
+                    this._updateQueue.clear();
+
+                    // We're splitting the computation of offsets and setting them to avoid extra
+                    // reflows.
+                    for (const setTopLeft of setTopLeftCallbacks) {
+                        setTopLeft();
+                    }
+
+                    // Explicitly clear to not hold references till the next garbage collection.
+                    scrollTopLeftCache.clear();
+                } else {
+                    this._scheduledUpdatePositions();
                 }
-
-                this._updateQueue.clear();
-
-                // We're splitting the computation of offsets and setting them to avoid extra
-                // reflows.
-                for (const setTopLeft of setTopLeftCallbacks) {
-                    setTopLeft();
-                }
-
-                // Explicitly clear to not hold references till the next garbage collection.
-                scrollTopLeftCache.clear();
-            } else {
-                this._scheduledUpdatePositions();
-            }
-        }, _updateDummyInputsTimeout);
+            },
+            _updateDummyInputsTimeout
+        );
     }
 }
 
@@ -676,7 +691,7 @@ export class DummyInputObserver implements DummyInputObserverInterface {
  */
 class DummyInputManagerCore {
     private _tabster: TabsterCore;
-    private _addTimer: number | undefined;
+    private _addTimer?: Timer;
     private _getWindow: GetWindow;
     private _wrappers: DummyInputWrapper[] = [];
     private _element: WeakHTMLElement | undefined;
@@ -801,10 +816,7 @@ class DummyInputManagerCore {
 
             const win = this._getWindow();
 
-            if (this._addTimer) {
-                win.clearTimeout(this._addTimer);
-                delete this._addTimer;
-            }
+            clearTimer(this._addTimer, win);
 
             const dummyElement = this._firstDummy?.input;
             dummyElement && this._tabster._dummyObserver.remove(dummyElement);
@@ -998,24 +1010,33 @@ class DummyInputManagerCore {
      * Called each time the children under the element is mutated
      */
     private _addDummyInputs = () => {
-        if (this._addTimer) {
+        if (isTimerActive(this._addTimer)) {
             return;
         }
 
-        this._addTimer = this._getWindow().setTimeout(() => {
-            delete this._addTimer;
+        this._addTimer = setTimer(
+            this._addTimer,
+            this._getWindow(),
+            () => {
+                this._ensurePosition();
 
-            this._ensurePosition();
+                if (__DEV__) {
+                    this._firstDummy &&
+                        setDummyInputDebugValue(
+                            this._firstDummy,
+                            this._wrappers
+                        );
+                    this._lastDummy &&
+                        setDummyInputDebugValue(
+                            this._lastDummy,
+                            this._wrappers
+                        );
+                }
 
-            if (__DEV__) {
-                this._firstDummy &&
-                    setDummyInputDebugValue(this._firstDummy, this._wrappers);
-                this._lastDummy &&
-                    setDummyInputDebugValue(this._lastDummy, this._wrappers);
-            }
-
-            this._addTransformOffsets();
-        }, 0);
+                this._addTransformOffsets();
+            },
+            0
+        );
     };
 
     private _ensurePosition(): void {

--- a/src/Groupper.ts
+++ b/src/Groupper.ts
@@ -28,10 +28,14 @@ import {
 } from "./DummyInput.js";
 import {
     addListener,
+    clearTimer,
     dispatchEvent,
     getAdjacentElement,
+    isTimerActive,
     removeListener,
+    setTimer,
     TabsterPart,
+    type Timer,
     WeakHTMLElement,
 } from "./Utils.js";
 import { dom } from "./DOMAPI.js";
@@ -433,7 +437,7 @@ function validateGroupperProps(props: Types.GroupperProps): void {
 
 export class GroupperAPI implements Types.GroupperAPI {
     private _tabster: Types.TabsterCore;
-    private _updateTimer: number | undefined;
+    private _updateTimer?: Timer;
     private _win: Types.GetWindow;
     private _current: Record<string, Types.Groupper> = {};
     private _grouppers: Record<string, Types.Groupper> = {};
@@ -472,10 +476,7 @@ export class GroupperAPI implements Types.GroupperAPI {
 
         this._current = {};
 
-        if (this._updateTimer) {
-            win.clearTimeout(this._updateTimer);
-            delete this._updateTimer;
-        }
+        clearTimer(this._updateTimer, win);
 
         this._tabster.focusedElement.unsubscribe(this._onFocus);
 
@@ -518,18 +519,22 @@ export class GroupperAPI implements Types.GroupperAPI {
         if (
             focusedElement &&
             dom.nodeContains(element, focusedElement) &&
-            !this._updateTimer
+            !isTimerActive(this._updateTimer)
         ) {
-            this._updateTimer = this._win().setTimeout(() => {
-                delete this._updateTimer;
-                // Making sure the focused element hasn't changed.
-                if (
-                    focusedElement ===
-                    tabster.focusedElement.getFocusedElement()
-                ) {
-                    this._updateCurrent(focusedElement);
-                }
-            }, 0);
+            this._updateTimer = setTimer(
+                this._updateTimer,
+                this._win(),
+                () => {
+                    // Making sure the focused element hasn't changed.
+                    if (
+                        focusedElement ===
+                        tabster.focusedElement.getFocusedElement()
+                    ) {
+                        this._updateCurrent(focusedElement);
+                    }
+                },
+                0
+            );
         }
 
         return newGroupper;
@@ -562,10 +567,7 @@ export class GroupperAPI implements Types.GroupperAPI {
     };
 
     private _updateCurrent(element: HTMLElement): void {
-        if (this._updateTimer) {
-            this._win().clearTimeout(this._updateTimer);
-            delete this._updateTimer;
-        }
+        clearTimer(this._updateTimer, this._win());
 
         const tabster = this._tabster;
         const newIds: Record<string, true> = {};

--- a/src/Modalizer.ts
+++ b/src/Modalizer.ts
@@ -20,9 +20,13 @@ import {
 import {
     addListener,
     augmentAttribute,
+    clearTimer,
     dispatchEvent,
+    isTimerActive,
     removeListener,
+    setTimer,
     TabsterPart,
+    type Timer,
     WeakHTMLElement,
 } from "./Utils.js";
 import { dom } from "./DOMAPI.js";
@@ -338,12 +342,12 @@ function validateModalizerProps(props: Types.ModalizerProps): void {
 export class ModalizerAPI implements Types.ModalizerAPI {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
-    private _restoreModalizerFocusTimer: number | undefined;
+    private _restoreModalizerFocusTimer?: Timer;
     private _modalizers: Record<string, Types.Modalizer>;
     private _parts: Record<string, Record<string, Types.Modalizer>>;
     private _augMap: WeakMap<HTMLElement, true>;
     private _aug: WeakHTMLElement<HTMLElement>[];
-    private _hiddenUpdateTimer: number | undefined;
+    private _hiddenUpdateTimer?: Timer;
     private _alwaysAccessibleSelector: string | undefined;
     private _accessibleCheck: Types.ModalizerElementAccessibleCheck | undefined;
     private _activationHistory: (string | undefined)[];
@@ -394,8 +398,8 @@ export class ModalizerAPI implements Types.ModalizerAPI {
             }
         });
 
-        win.clearTimeout(this._restoreModalizerFocusTimer);
-        win.clearTimeout(this._hiddenUpdateTimer);
+        clearTimer(this._restoreModalizerFocusTimer, win);
+        clearTimer(this._hiddenUpdateTimer, win);
 
         this._parts = {};
         delete this.activeId;
@@ -587,14 +591,18 @@ export class ModalizerAPI implements Types.ModalizerAPI {
     }
 
     hiddenUpdate(): void {
-        if (this._hiddenUpdateTimer) {
+        if (isTimerActive(this._hiddenUpdateTimer)) {
             return;
         }
 
-        this._hiddenUpdateTimer = this._win().setTimeout(() => {
-            delete this._hiddenUpdateTimer;
-            this._hiddenUpdate();
-        }, 250);
+        this._hiddenUpdateTimer = setTimer(
+            this._hiddenUpdateTimer,
+            this._win(),
+            () => {
+                this._hiddenUpdate();
+            },
+            250
+        );
     }
 
     setActive(modalizer: Types.Modalizer | undefined): void {
@@ -984,11 +992,11 @@ export class ModalizerAPI implements Types.ModalizerAPI {
             this.setActive(modalizer);
         } else {
             // Focused outside of the active modalizer, try pull focus back to current modalizer
-            const win = this._win();
-            win.clearTimeout(this._restoreModalizerFocusTimer);
             // TODO some rendering frameworks (i.e. React) might async rerender the DOM so we need to wait for a duration
             // Figure out a better way of doing this rather than a 100ms timeout
-            this._restoreModalizerFocusTimer = win.setTimeout(
+            this._restoreModalizerFocusTimer = setTimer(
+                this._restoreModalizerFocusTimer,
+                this._win(),
                 () => this._restoreModalizerFocus(focusedElement),
                 100
             );

--- a/src/Mover.ts
+++ b/src/Mover.ts
@@ -26,14 +26,18 @@ import {
 } from "./DummyInput.js";
 import {
     addListener,
+    clearTimer,
     createElementTreeWalker,
     dispatchEvent,
     getElementUId,
     isElementVerticallyVisibleInContainer,
+    isTimerActive,
     matchesSelector,
     removeListener,
     scrollIntoView,
+    setTimer,
     TabsterPart,
+    type Timer,
     WeakHTMLElement,
 } from "./Utils.js";
 import { dom } from "./DOMAPI.js";
@@ -112,7 +116,7 @@ export class Mover
 {
     private _unobserve: (() => void) | undefined;
     private _intersectionObserver: IntersectionObserver | undefined;
-    private _setCurrentTimer: number | undefined;
+    private _setCurrentTimer?: Timer;
     private _current: WeakHTMLElement | undefined;
     private _prevCurrent: WeakHTMLElement | undefined;
     private _visible: Record<string, Types.Visibility> = {};
@@ -121,7 +125,7 @@ export class Mover
     private _onDispose: (mover: Mover) => void;
     private _allElements: WeakMap<HTMLElement, Mover> | undefined;
     private _updateQueue: MoverUpdateQueueItem[] | undefined;
-    private _updateTimer: number | undefined;
+    private _updateTimer?: Timer;
 
     visibilityTolerance: number;
     dummyManager: MoverDummyManager | undefined;
@@ -180,15 +184,8 @@ export class Mover
 
         const win = this._win();
 
-        if (this._setCurrentTimer) {
-            win.clearTimeout(this._setCurrentTimer);
-            delete this._setCurrentTimer;
-        }
-
-        if (this._updateTimer) {
-            win.clearTimeout(this._updateTimer);
-            delete this._updateTimer;
-        }
+        clearTimer(this._setCurrentTimer, win);
+        clearTimer(this._updateTimer, win);
 
         this.dummyManager?.dispose();
         delete this.dummyManager;
@@ -203,39 +200,45 @@ export class Mover
 
         if (
             (this._props.trackState || this._props.visibilityAware) &&
-            !this._setCurrentTimer
+            !isTimerActive(this._setCurrentTimer)
         ) {
-            this._setCurrentTimer = this._win().setTimeout(() => {
-                delete this._setCurrentTimer;
+            this._setCurrentTimer = setTimer(
+                this._setCurrentTimer,
+                this._win(),
+                () => {
+                    const changed: (WeakHTMLElement | undefined)[] = [];
 
-                const changed: (WeakHTMLElement | undefined)[] = [];
+                    if (this._current !== this._prevCurrent) {
+                        changed.push(this._current);
+                        changed.push(this._prevCurrent);
+                        this._prevCurrent = this._current;
+                    }
 
-                if (this._current !== this._prevCurrent) {
-                    changed.push(this._current);
-                    changed.push(this._prevCurrent);
-                    this._prevCurrent = this._current;
-                }
+                    for (const weak of changed) {
+                        const el = weak?.get();
 
-                for (const weak of changed) {
-                    const el = weak?.get();
+                        if (el && this._allElements?.get(el) === this) {
+                            const props = this._props;
 
-                    if (el && this._allElements?.get(el) === this) {
-                        const props = this._props;
+                            if (
+                                el &&
+                                (props.visibilityAware !== undefined ||
+                                    props.trackState)
+                            ) {
+                                const state = this.getState(el);
 
-                        if (
-                            el &&
-                            (props.visibilityAware !== undefined ||
-                                props.trackState)
-                        ) {
-                            const state = this.getState(el);
-
-                            if (state) {
-                                dispatchEvent(el, new MoverStateEvent(state));
+                                if (state) {
+                                    dispatchEvent(
+                                        el,
+                                        new MoverStateEvent(state)
+                                    );
+                                }
                             }
                         }
                     }
-                }
-            });
+                },
+                0
+            );
         }
     }
 
@@ -561,26 +564,29 @@ export class Mover
         };
 
         const requestUpdate = () => {
-            if (!this._updateTimer && updateQueue.length) {
-                this._updateTimer = win.setTimeout(() => {
-                    delete this._updateTimer;
-
-                    for (const { element, type } of updateQueue) {
-                        switch (type) {
-                            case _moverUpdateAttr:
-                                updateElement(element);
-                                break;
-                            case _moverUpdateAdd:
-                                addNewElements(element);
-                                break;
-                            case _moverUpdateRemove:
-                                removeWalk(element);
-                                break;
+            if (!isTimerActive(this._updateTimer) && updateQueue.length) {
+                this._updateTimer = setTimer(
+                    this._updateTimer,
+                    win,
+                    () => {
+                        for (const { element, type } of updateQueue) {
+                            switch (type) {
+                                case _moverUpdateAttr:
+                                    updateElement(element);
+                                    break;
+                                case _moverUpdateAdd:
+                                    addNewElements(element);
+                                    break;
+                                case _moverUpdateRemove:
+                                    removeWalk(element);
+                                    break;
+                            }
                         }
-                    }
 
-                    updateQueue = this._updateQueue = [];
-                }, 0);
+                        updateQueue = this._updateQueue = [];
+                    },
+                    0
+                );
             }
         };
 
@@ -690,7 +696,7 @@ export class MoverAPI implements Types.MoverAPI {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
     private _movers: Record<string, Mover>;
-    private _ignoredInputTimer: number | undefined;
+    private _ignoredInputTimer?: Timer;
     private _ignoredInputResolve: ((value: boolean) => void) | undefined;
 
     constructor(tabster: Types.TabsterCore, getWindow: Types.GetWindow) {
@@ -722,10 +728,7 @@ export class MoverAPI implements Types.MoverAPI {
 
         this._ignoredInputResolve?.(false);
 
-        if (this._ignoredInputTimer) {
-            win.clearTimeout(this._ignoredInputTimer);
-            delete this._ignoredInputTimer;
-        }
+        clearTimer(this._ignoredInputTimer, win);
 
         removeListener(win, "keydown", this._onKeyDown, true);
         removeListener(win, MoverMoveFocusEventName, this._onMoveFocus);
@@ -1230,10 +1233,7 @@ export class MoverAPI implements Types.MoverAPI {
     }
 
     private _onKeyDown = async (event: KeyboardEvent): Promise<void> => {
-        if (this._ignoredInputTimer) {
-            this._win().clearTimeout(this._ignoredInputTimer);
-            delete this._ignoredInputTimer;
-        }
+        clearTimer(this._ignoredInputTimer, this._win());
 
         this._ignoredInputResolve?.(false);
 
@@ -1392,10 +1392,6 @@ export class MoverAPI implements Types.MoverAPI {
 
                     const win = this._win();
 
-                    if (this._ignoredInputTimer) {
-                        win.clearTimeout(this._ignoredInputTimer);
-                    }
-
                     const {
                         anchorNode: prevAnchorNode,
                         focusNode: prevFocusNode,
@@ -1404,85 +1400,90 @@ export class MoverAPI implements Types.MoverAPI {
                     } = dom.getSelection(element) || {};
 
                     // Get selection gives incorrect value if we call it syncronously onKeyDown.
-                    this._ignoredInputTimer = win.setTimeout(() => {
-                        delete this._ignoredInputTimer;
+                    this._ignoredInputTimer = setTimer(
+                        this._ignoredInputTimer,
+                        win,
+                        () => {
+                            const {
+                                anchorNode,
+                                focusNode,
+                                anchorOffset,
+                                focusOffset,
+                            } = dom.getSelection(element) || {};
 
-                        const {
-                            anchorNode,
-                            focusNode,
-                            anchorOffset,
-                            focusOffset,
-                        } = dom.getSelection(element) || {};
-
-                        if (
-                            anchorNode !== prevAnchorNode ||
-                            focusNode !== prevFocusNode ||
-                            anchorOffset !== prevAnchorOffset ||
-                            focusOffset !== prevFocusOffset
-                        ) {
-                            this._ignoredInputResolve?.(false);
-                            return;
-                        }
-
-                        selectionStart = anchorOffset || 0;
-                        selectionEnd = focusOffset || 0;
-                        textLength = element.textContent?.length || 0;
-
-                        if (anchorNode && focusNode) {
                             if (
-                                dom.nodeContains(element, anchorNode) &&
-                                dom.nodeContains(element, focusNode)
+                                anchorNode !== prevAnchorNode ||
+                                focusNode !== prevFocusNode ||
+                                anchorOffset !== prevAnchorOffset ||
+                                focusOffset !== prevFocusOffset
                             ) {
-                                if (anchorNode !== element) {
-                                    let anchorFound = false;
+                                this._ignoredInputResolve?.(false);
+                                return;
+                            }
 
-                                    const addOffsets = (
-                                        node: ChildNode
-                                    ): boolean => {
-                                        if (node === anchorNode) {
-                                            anchorFound = true;
-                                        } else if (node === focusNode) {
-                                            return true;
-                                        }
+                            selectionStart = anchorOffset || 0;
+                            selectionEnd = focusOffset || 0;
+                            textLength = element.textContent?.length || 0;
 
-                                        const nodeText = node.textContent;
+                            if (anchorNode && focusNode) {
+                                if (
+                                    dom.nodeContains(element, anchorNode) &&
+                                    dom.nodeContains(element, focusNode)
+                                ) {
+                                    if (anchorNode !== element) {
+                                        let anchorFound = false;
 
-                                        if (
-                                            nodeText &&
-                                            !dom.getFirstChild(node)
-                                        ) {
-                                            const len = nodeText.length;
+                                        const addOffsets = (
+                                            node: ChildNode
+                                        ): boolean => {
+                                            if (node === anchorNode) {
+                                                anchorFound = true;
+                                            } else if (node === focusNode) {
+                                                return true;
+                                            }
 
-                                            if (anchorFound) {
-                                                if (focusNode !== anchorNode) {
+                                            const nodeText = node.textContent;
+
+                                            if (
+                                                nodeText &&
+                                                !dom.getFirstChild(node)
+                                            ) {
+                                                const len = nodeText.length;
+
+                                                if (anchorFound) {
+                                                    if (
+                                                        focusNode !== anchorNode
+                                                    ) {
+                                                        selectionEnd += len;
+                                                    }
+                                                } else {
+                                                    selectionStart += len;
                                                     selectionEnd += len;
                                                 }
-                                            } else {
-                                                selectionStart += len;
-                                                selectionEnd += len;
                                             }
-                                        }
 
-                                        let stop = false;
+                                            let stop = false;
 
-                                        for (
-                                            let e = dom.getFirstChild(node);
-                                            e && !stop;
-                                            e = e.nextSibling
-                                        ) {
-                                            stop = addOffsets(e);
-                                        }
+                                            for (
+                                                let e = dom.getFirstChild(node);
+                                                e && !stop;
+                                                e = e.nextSibling
+                                            ) {
+                                                stop = addOffsets(e);
+                                            }
 
-                                        return stop;
-                                    };
+                                            return stop;
+                                        };
 
-                                    addOffsets(element);
+                                        addOffsets(element);
+                                    }
                                 }
                             }
-                        }
 
-                        this._ignoredInputResolve?.(true);
-                    }, 0);
+                            this._ignoredInputResolve?.(true);
+                        },
+                        0
+                    );
                 });
             }
 

--- a/src/Outline.ts
+++ b/src/Outline.ts
@@ -5,7 +5,14 @@
 
 import { getTabsterOnElement } from "./Instance.js";
 import type * as Types from "./Types.js";
-import { addListener, getBoundingRect, removeListener } from "./Utils.js";
+import {
+    addListener,
+    clearTimer,
+    getBoundingRect,
+    removeListener,
+    setTimer,
+    type Timer,
+} from "./Utils.js";
 
 interface WindowWithOutlineStyle extends Window {
     __tabsterOutline?: {
@@ -59,7 +66,7 @@ class OutlinePosition {
 export class OutlineAPI implements Types.OutlineAPI {
     private _tabster: Types.TabsterCore;
     private _win: Types.GetWindow;
-    private _updateTimer: number | undefined;
+    private _updateTimer?: Timer;
     private _outlinedElement: HTMLElement | undefined;
     private _curPos: OutlinePosition | undefined;
     private _isVisible = false;
@@ -130,10 +137,7 @@ export class OutlineAPI implements Types.OutlineAPI {
     dispose(): void {
         const win = this._win();
 
-        if (this._updateTimer) {
-            win.clearTimeout(this._updateTimer);
-            this._updateTimer = undefined;
-        }
+        clearTimer(this._updateTimer, win);
 
         this._tabster.keyboardNavigation.unsubscribe(
             this._onKeyboardNavigationStateChanged
@@ -220,10 +224,7 @@ export class OutlineAPI implements Types.OutlineAPI {
     private _updateElement(e: HTMLElement | undefined): boolean {
         this._outlinedElement = undefined;
 
-        if (this._updateTimer) {
-            this._win().clearTimeout(this._updateTimer);
-            this._updateTimer = undefined;
-        }
+        clearTimer(this._updateTimer, this._win());
 
         this._curPos = undefined;
 
@@ -293,19 +294,20 @@ export class OutlineAPI implements Types.OutlineAPI {
     private _updateOutline(): void {
         this._setOutlinePosition();
 
-        if (this._updateTimer) {
-            this._win().clearTimeout(this._updateTimer);
-            this._updateTimer = undefined;
-        }
+        clearTimer(this._updateTimer, this._win());
 
         if (!this._outlinedElement) {
             return;
         }
 
-        this._updateTimer = this._win().setTimeout(() => {
-            this._updateTimer = undefined;
-            this._updateOutline();
-        }, 30);
+        this._updateTimer = setTimer(
+            this._updateTimer,
+            this._win(),
+            () => {
+                this._updateOutline();
+            },
+            30
+        );
     }
 
     private _setVisibility(visible: boolean): void {

--- a/src/Root.ts
+++ b/src/Root.ts
@@ -14,10 +14,13 @@ import {
 } from "./DummyInput.js";
 import {
     addListener,
+    clearTimer,
     dispatchEvent,
     getElementUId,
     removeListener,
+    setTimer,
     TabsterPart,
+    type Timer,
     type WeakHTMLElement,
 } from "./Utils.js";
 import { setTabsterAttribute } from "./AttributeHelpers.js";
@@ -111,7 +114,7 @@ export class Root
     private _dummyManager?: RootDummyManager;
     private _sys?: Types.SysProps;
     private _isFocused = false;
-    private _setFocusedTimer: number | undefined;
+    private _setFocusedTimer?: Timer;
     private _onDispose: (root: Root) => void;
 
     constructor(
@@ -163,10 +166,7 @@ export class Root
         removeListener(doc, KEYBORG_FOCUSIN, this._onFocusIn);
         removeListener(doc, KEYBORG_FOCUSOUT, this._onFocusOut);
 
-        if (this._setFocusedTimer) {
-            win.clearTimeout(this._setFocusedTimer);
-            delete this._setFocusedTimer;
-        }
+        clearTimer(this._setFocusedTimer, win);
 
         this._dummyManager?.dispose();
         this._remove();
@@ -193,10 +193,8 @@ export class Root
     }
 
     private _setFocused = (hasFocused: boolean): void => {
-        if (this._setFocusedTimer) {
-            this._tabster.getWindow().clearTimeout(this._setFocusedTimer);
-            delete this._setFocusedTimer;
-        }
+        const win = this._tabster.getWindow();
+        clearTimer(this._setFocusedTimer, win);
 
         if (this._isFocused === hasFocused) {
             return;
@@ -210,15 +208,16 @@ export class Root
                 this._dummyManager?.setTabbable(false);
                 dispatchEvent(element, new RootFocusEvent({ element }));
             } else {
-                this._setFocusedTimer = this._tabster
-                    .getWindow()
-                    .setTimeout(() => {
-                        delete this._setFocusedTimer;
-
+                this._setFocusedTimer = setTimer(
+                    this._setFocusedTimer,
+                    win,
+                    () => {
                         this._isFocused = false;
                         this._dummyManager?.setTabbable(true);
                         dispatchEvent(element, new RootBlurEvent({ element }));
-                    }, 0);
+                    },
+                    0
+                );
             }
         }
     };

--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -23,11 +23,14 @@ import {
 import { DummyInputManager } from "../DummyInput.js";
 import {
     addListener,
+    clearTimer,
     dispatchEvent,
     documentContains,
     getLastChild,
     removeListener,
+    setTimer,
     shouldIgnoreFocus,
+    type Timer,
     WeakHTMLElement,
 } from "../Utils.js";
 import { getTabsterOnElement } from "../Instance.js";
@@ -72,7 +75,7 @@ const AsyncFocusIntentPriorityBySource = {
 interface AsyncFocus {
     source: Types.AsyncFocusSource;
     callback: () => void;
-    timeout: number;
+    timeout?: Timer;
 }
 
 export class FocusedElementState
@@ -80,7 +83,7 @@ export class FocusedElementState
     implements Types.FocusedElementState
 {
     private static _lastResetElement: WeakHTMLElement | undefined;
-    private static _isTabbingTimer: number | undefined;
+    private static _isTabbingTimer?: Timer;
     static isTabbing = false;
 
     private _tabster: Types.TabsterCore;
@@ -154,7 +157,7 @@ export class FocusedElementState
 
         const asyncFocus = this._asyncFocus;
         if (asyncFocus) {
-            win.clearTimeout(asyncFocus.timeout);
+            clearTimer(asyncFocus.timeout, win);
             delete this._asyncFocus;
         }
 
@@ -339,24 +342,32 @@ export class FocusedElementState
             }
 
             // New intent has higher priority.
-            win.clearTimeout(currentAsyncFocus.timeout);
+            clearTimer(currentAsyncFocus.timeout, win);
         }
 
-        this._asyncFocus = {
+        const asyncFocus: AsyncFocus = {
             source,
             callback,
-            timeout: win.setTimeout(() => {
+            timeout: undefined,
+        };
+        this._asyncFocus = asyncFocus;
+
+        asyncFocus.timeout = setTimer(
+            asyncFocus.timeout,
+            win,
+            () => {
                 this._asyncFocus = undefined;
                 callback();
-            }, delay),
-        };
+            },
+            delay
+        );
     }
 
     cancelAsyncFocus(source: Types.AsyncFocusSource): void {
         const asyncFocus = this._asyncFocus;
 
         if (asyncFocus?.source === source) {
-            this._tabster.getWindow().clearTimeout(asyncFocus.timeout);
+            clearTimer(asyncFocus.timeout, this._tabster.getWindow());
             this._asyncFocus = undefined;
         }
     }
@@ -469,18 +480,17 @@ export class FocusedElementState
 
         let next: Types.NextTabbable | null = null;
 
-        const isTabbingTimer = FocusedElementState._isTabbingTimer;
         const win = tabster.getWindow();
 
-        if (isTabbingTimer) {
-            win.clearTimeout(isTabbingTimer);
-        }
-
         FocusedElementState.isTabbing = true;
-        FocusedElementState._isTabbingTimer = win.setTimeout(() => {
-            delete FocusedElementState._isTabbingTimer;
-            FocusedElementState.isTabbing = false;
-        }, 0);
+        FocusedElementState._isTabbingTimer = setTimer(
+            FocusedElementState._isTabbingTimer,
+            win,
+            () => {
+                FocusedElementState.isTabbing = false;
+            },
+            0
+        );
 
         const modalizer = ctx.modalizer;
         const groupper = ctx.groupper;

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -10,7 +10,15 @@ import {
     ObservedElementRequestStatuses,
     ObservedElementFailureReasons,
 } from "../Consts.js";
-import { documentContains, getElementUId, WeakHTMLElement } from "../Utils.js";
+import {
+    clearTimer,
+    documentContains,
+    getElementUId,
+    isTimerActive,
+    setTimer,
+    type Timer,
+    WeakHTMLElement,
+} from "../Utils.js";
 import { Subscribable } from "./Subscribable.js";
 
 const _conditionCheckTimeout = 100;
@@ -21,8 +29,8 @@ interface ObservedElementInfo {
 }
 
 interface ObservedWaiting {
-    timer?: number;
-    conditionTimer?: number;
+    timer?: Timer;
+    conditionTimer?: Timer;
     request?: Types.ObservedElementAsyncRequest<HTMLElement | null>;
     resolve?: (value: HTMLElement | null) => void;
     reject?: () => void;
@@ -99,13 +107,8 @@ export class ObservedElementAPI
         if (w) {
             const win = this._win();
 
-            if (w.timer) {
-                win.clearTimeout(w.timer);
-            }
-
-            if (w.conditionTimer) {
-                win.clearTimeout(w.conditionTimer);
-            }
+            clearTimer(w.timer, win);
+            clearTimer(w.conditionTimer, win);
 
             if (!shouldResolve && w.reject) {
                 w.reject();
@@ -334,11 +337,13 @@ export class ObservedElementAPI
             return w.request;
         }
 
-        w = this._waiting[key] = {
-            timer: this._win().setTimeout(() => {
-                if (w.conditionTimer) {
-                    this._win().clearTimeout(w.conditionTimer);
-                }
+        w = this._waiting[key] = {};
+
+        w.timer = setTimer(
+            w.timer,
+            this._win(),
+            () => {
+                clearTimer(w.conditionTimer, this._win());
 
                 delete this._waiting[key];
 
@@ -355,8 +360,9 @@ export class ObservedElementAPI
                 if (w.resolve) {
                     w.resolve(null);
                 }
-            }, timeout),
-        };
+            },
+            timeout
+        );
 
         const promise = new Promise<HTMLElement | null>((resolve, reject) => {
             w.resolve = resolve;
@@ -576,9 +582,7 @@ export class ObservedElementAPI
                 return;
             }
 
-            if (waiting.timer) {
-                win.clearTimeout(waiting.timer);
-            }
+            clearTimer(waiting.timer, win);
 
             delete this._waiting[key];
 
@@ -613,7 +617,7 @@ export class ObservedElementAPI
 
         if (
             waitingAccessibleElement &&
-            !waitingAccessibleElement.conditionTimer
+            !isTimerActive(waitingAccessibleElement.conditionTimer)
         ) {
             const resolveAccessible = () => {
                 const element = this.getElement(observedName);
@@ -630,7 +634,9 @@ export class ObservedElementAPI
                         ObservedElementAccessibilities.Accessible
                     );
                 } else {
-                    waitingAccessibleElement.conditionTimer = win.setTimeout(
+                    waitingAccessibleElement.conditionTimer = setTimer(
+                        waitingAccessibleElement.conditionTimer,
+                        win,
                         resolveAccessible,
                         _conditionCheckTimeout
                     );
@@ -642,7 +648,7 @@ export class ObservedElementAPI
 
         if (
             waitingFocusableElement &&
-            !waitingFocusableElement.conditionTimer
+            !isTimerActive(waitingFocusableElement.conditionTimer)
         ) {
             const resolveFocusable = () => {
                 const element = this.getElement(observedName);
@@ -659,7 +665,9 @@ export class ObservedElementAPI
                         ObservedElementAccessibilities.Focusable
                     );
                 } else {
-                    waitingFocusableElement.conditionTimer = win.setTimeout(
+                    waitingFocusableElement.conditionTimer = setTimer(
+                        waitingFocusableElement.conditionTimer,
+                        win,
                         resolveFocusable,
                         _conditionCheckTimeout
                     );

--- a/src/Tabster.ts
+++ b/src/Tabster.ts
@@ -15,8 +15,12 @@ import { UncontrolledAPI } from "./Uncontrolled.js";
 import { DummyInputObserver } from "./DummyInput.js";
 import {
     clearElementCache,
+    clearTimer,
     createElementTreeWalker,
     disposeInstanceContext,
+    isTimerActive,
+    setTimer,
+    type Timer,
 } from "./Utils.js";
 import { dom, setDOMAPI } from "./DOMAPI.js";
 import * as shadowDOMAPI from "./Shadowdomize/index.js";
@@ -46,10 +50,10 @@ class TabsterCore implements Types.TabsterCore {
     private _storage: WeakMap<HTMLElement, Types.TabsterElementStorage>;
     private _unobserve: (() => void) | undefined;
     private _win: WindowWithTabsterInstance | undefined;
-    private _forgetMemorizedTimer: number | undefined;
+    private _forgetMemorizedTimer?: Timer;
     private _forgetMemorizedElements: HTMLElement[] = [];
     private _wrappers: Set<Tabster> = new Set<Tabster>();
-    private _initTimer: number | undefined;
+    private _initTimer?: Timer;
     private _initQueue: (() => void)[] = [];
 
     _version: string = __VERSION__;
@@ -182,16 +186,13 @@ class TabsterCore implements Types.TabsterCore {
 
         const win = this._win;
 
-        win?.clearTimeout(this._initTimer);
-        delete this._initTimer;
-        this._initQueue = [];
-
-        this._forgetMemorizedElements = [];
-
-        if (win && this._forgetMemorizedTimer) {
-            win.clearTimeout(this._forgetMemorizedTimer);
-            delete this._forgetMemorizedTimer;
+        if (win) {
+            clearTimer(this._initTimer, win);
+            clearTimer(this._forgetMemorizedTimer, win);
         }
+
+        this._initQueue = [];
+        this._forgetMemorizedElements = [];
 
         this.outline?.dispose();
         this.crossOrigin?.dispose();
@@ -260,23 +261,29 @@ class TabsterCore implements Types.TabsterCore {
 
         this._forgetMemorizedElements.push(this._win.document.body);
 
-        if (this._forgetMemorizedTimer) {
+        if (isTimerActive(this._forgetMemorizedTimer)) {
             return;
         }
 
-        this._forgetMemorizedTimer = this._win.setTimeout(() => {
-            delete this._forgetMemorizedTimer;
-
-            for (
-                let el: HTMLElement | undefined =
-                    this._forgetMemorizedElements.shift();
-                el;
-                el = this._forgetMemorizedElements.shift()
-            ) {
-                clearElementCache(this.getWindow, el);
-                FocusedElementState.forgetMemorized(this.focusedElement, el);
-            }
-        }, 0);
+        this._forgetMemorizedTimer = setTimer(
+            this._forgetMemorizedTimer,
+            this._win,
+            () => {
+                for (
+                    let el: HTMLElement | undefined =
+                        this._forgetMemorizedElements.shift();
+                    el;
+                    el = this._forgetMemorizedElements.shift()
+                ) {
+                    clearElementCache(this.getWindow, el);
+                    FocusedElementState.forgetMemorized(
+                        this.focusedElement,
+                        el
+                    );
+                }
+            },
+            0
+        );
     }
 
     queueInit(callback: () => void): void {
@@ -286,11 +293,15 @@ class TabsterCore implements Types.TabsterCore {
 
         this._initQueue.push(callback);
 
-        if (!this._initTimer) {
-            this._initTimer = this._win?.setTimeout(() => {
-                delete this._initTimer;
-                this.drainInitQueue();
-            }, 0);
+        if (!isTimerActive(this._initTimer)) {
+            this._initTimer = setTimer(
+                this._initTimer,
+                this._win,
+                () => {
+                    this.drainInitQueue();
+                },
+                0
+            );
         }
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -51,7 +51,7 @@ export interface InstanceContext {
         };
     };
     lastContainerBoundingRectCacheId: number;
-    containerBoundingRectCacheTimer?: number;
+    containerBoundingRectCacheTimer?: Timer;
 }
 
 let _uidCounter = 0;
@@ -75,9 +75,7 @@ export function disposeInstanceContext(win: Window): void {
     if (ctx) {
         ctx.elementByUId = {};
         ctx.containerBoundingRectCache = {};
-        if (ctx.containerBoundingRectCacheTimer) {
-            win.clearTimeout(ctx.containerBoundingRectCacheTimer);
-        }
+        clearTimer(ctx.containerBoundingRectCacheTimer, win);
         delete w.__tabsterInstanceContext;
     }
 }
@@ -185,17 +183,22 @@ export function getBoundingRect(
         element,
     };
 
-    if (!context.containerBoundingRectCacheTimer) {
-        context.containerBoundingRectCacheTimer = window.setTimeout(() => {
-            context.containerBoundingRectCacheTimer = undefined;
+    if (!isTimerActive(context.containerBoundingRectCacheTimer)) {
+        context.containerBoundingRectCacheTimer = setTimer(
+            context.containerBoundingRectCacheTimer,
+            window,
+            () => {
+                for (const cId of Object.keys(
+                    context.containerBoundingRectCache
+                )) {
+                    delete context.containerBoundingRectCache[cId].element
+                        .__tabsterCacheId;
+                }
 
-            for (const cId of Object.keys(context.containerBoundingRectCache)) {
-                delete context.containerBoundingRectCache[cId].element
-                    .__tabsterCacheId;
-            }
-
-            context.containerBoundingRectCache = {};
-        }, 50);
+                context.containerBoundingRectCache = {};
+            },
+            50
+        );
     }
 
     return rect;
@@ -599,6 +602,61 @@ export function getRadioButtonGroup(
         buttons: new Set(radioButtons),
         checked,
     };
+}
+
+/**
+ * Opaque handle for a single setTimeout id. Use {@link setTimer},
+ * {@link clearTimer}, and {@link isTimerActive} to operate on it.
+ *
+ * Built as a free-function API rather than methods because the function names
+ * mangle to single characters (1 char per call site) while property names like
+ * `.clear` would be preserved by the minifier (~5 chars per call site).
+ *
+ * `id` is `undefined` while no timeout is pending (either never scheduled or
+ * already fired/cleared). Typed as the raw `setTimeout` return so the value
+ * round-trips through `window.setTimeout` / `window.clearTimeout` without a
+ * cast.
+ */
+export interface Timer {
+    id: ReturnType<typeof setTimeout> | undefined;
+}
+
+/**
+ * Cancels any pending timeout on `t` and schedules `callback` after `delay` ms.
+ * Pass `undefined` (or a never-used field) the first time — a fresh {@link Timer}
+ * is created and returned. Reuse the returned handle on subsequent calls.
+ */
+export function setTimer(
+    t: Timer | undefined,
+    window: Window,
+    callback: () => void,
+    delay: number
+): Timer {
+    if (t?.id !== undefined) {
+        window.clearTimeout(t.id);
+    }
+
+    const timer: Timer = t ?? { id: undefined };
+
+    timer.id = window.setTimeout(() => {
+        timer.id = undefined;
+        callback();
+    }, delay);
+
+    return timer;
+}
+
+/** Cancels the pending timeout on `t`; no-op if there isn't one. */
+export function clearTimer(t: Timer | undefined, window: Window): void {
+    if (t?.id !== undefined) {
+        window.clearTimeout(t.id);
+        t.id = undefined;
+    }
+}
+
+/** Whether `t` has a pending timeout. */
+export function isTimerActive(t: Timer | undefined): boolean {
+    return t?.id !== undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Introduces single-character-mangleable wrappers in `Utils.ts` for the window timer APIs whose property names would otherwise be preserved verbatim by the minifier:

- `setTimer` / `clearTimer` / `isTimerActive`, operating on an opaque `Timer = { id }` handle stored on instance fields.

`setTimer(t, window, callback, delay)` lazily creates the `Timer` when passed `undefined` and returns it, so callers just write `this._timer = setTimer(this._timer, …)` — no separate constructor-time allocation. `Timer.id` is typed as `ReturnType<typeof setTimeout>` so the id round-trips through `window.setTimeout` / `clearTimeout` without a cast; `undefined` is the not-pending sentinel.

All `src/**/*.ts` call sites converted; raw `.setTimeout` / `.clearTimeout` property accesses now eliminated outside `Utils.ts`.

Enforced via two additional `no-restricted-syntax` entries in `eslint.config.mjs` (next to the existing event-helper rules from #560) so the wrappers can't drift back into raw timer calls in future PRs.

## Stack context

Follow-up to #560 — same wrapper pattern applied to timer APIs.