### PR TITLE
refactor(bundle-size): skip class-field emit via useDefineForClassFields

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
         "skipLibCheck": true,
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
+        "useDefineForClassFields": false,
         "forceConsistentCasingInFileNames": true,
         "lib": ["DOM", "ESNext"],
         "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Set `useDefineForClassFields: false` in `tsconfig.base.json`. With `target: ES2022` (TS default since 4.7), every uninitialized class field emits a `void 0` install at the field-declaration site that the constructor immediately overwrites. Flipping the flag drops that emit for all fields, with `strictPropertyInitialization: true` still enforcing init at type-check time.

Same pattern as the [TypeScript compiler](https://github.com/microsoft/TypeScript/blob/main/src/tsconfig-base.json) (implicit via `target: es2020`), [VS Code](https://github.com/microsoft/vscode/blob/main/src/tsconfig.base.json) (explicit), [Vue core](https://github.com/vuejs/core/blob/main/tsconfig.json) (explicit), and [Lit `reactive-element`](https://github.com/lit/lit/blob/main/packages/reactive-element/tsconfig.json) (implicit via `target: es2021`).

Safe for tabster: `src/` has no `get`/`set` accessors, so the one behavioural diff under this flag (field-vs-inherited-accessor shadowing) cannot trigger.