### PR TITLE
feat: support native focus options

### DIFF
--- a/src/State/FocusedElement.ts
+++ b/src/State/FocusedElement.ts
@@ -204,7 +204,7 @@ export class FocusedElementState
         element: HTMLElement,
         noFocusedProgrammaticallyFlag?: boolean,
         noAccessibleCheck?: boolean,
-        preventScroll?: boolean
+        focusOptions?: boolean | Types.TabsterFocusOptions
     ): boolean {
         if (
             !this._tabster.focusable.isFocusable(
@@ -217,7 +217,12 @@ export class FocusedElementState
             return false;
         }
 
-        element.focus({ preventScroll });
+        const options =
+            typeof focusOptions === "boolean"
+                ? { preventScroll: focusOptions }
+                : focusOptions;
+
+        element.focus(options);
 
         return true;
     }

--- a/src/State/ObservedElement.ts
+++ b/src/State/ObservedElement.ts
@@ -395,7 +395,7 @@ export class ObservedElementAPI
     requestFocus(
         observedName: string,
         timeout: number,
-        options: Pick<FocusOptions, "preventScroll"> = {}
+        options: Types.TabsterFocusOptions = {}
     ): Types.ObservedElementAsyncRequest<boolean> {
         const requestId = ++this._lastRequestFocusId;
         const currentRequestFocus = this._currentRequest;
@@ -437,7 +437,7 @@ export class ObservedElementAPI
                     element,
                     true,
                     undefined,
-                    options.preventScroll
+                    options
                 );
 
                 if (!focusResult) {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -139,6 +139,16 @@ export type AsyncFocusSources = typeof _AsyncFocusSources;
 
 export type AsyncFocusSource = AsyncFocusSources[keyof AsyncFocusSources];
 
+export interface TabsterFocusOptions extends FocusOptions {
+    /**
+     * Forces the browser to show or hide a visible focus indicator.
+     *
+     * This is declared explicitly until it is available in all supported
+     * TypeScript DOM library versions.
+     */
+    focusVisible?: boolean;
+}
+
 export interface FocusedElementState
     extends
         Subscribable<HTMLElement | undefined, FocusedElementDetail>,
@@ -149,7 +159,7 @@ export interface FocusedElementState
         element: HTMLElement,
         noFocusedProgrammaticallyFlag?: boolean,
         noAccessibleCheck?: boolean,
-        preventScroll?: boolean
+        focusOptions?: boolean | TabsterFocusOptions
     ): boolean;
     focusDefault(container: HTMLElement): boolean;
     /** @internal */

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -347,7 +347,7 @@ export interface ObservedElementAPI
     requestFocus(
         observedName: string,
         timeout: number,
-        options?: Pick<FocusOptions, "preventScroll">
+        options?: TabsterFocusOptions
     ): ObservedElementAsyncRequest<boolean>;
     /**
      * Returns all currently registered observed elements grouped by their observed names.

--- a/tests/ObservedElement.test.tsx
+++ b/tests/ObservedElement.test.tsx
@@ -17,6 +17,64 @@ describe("Focusable", () => {
         await BroTest.bootstrapTabsterPage({ observed: true });
     });
 
+    it("should forward focus options", async () => {
+        const name = "test";
+        const focusOptions: Types.TabsterFocusOptions = {
+            preventScroll: true,
+            focusVisible: true,
+        };
+
+        await new BroTest.BroTest(
+            <button
+                id="button"
+                {...getTabsterAttribute({
+                    observed: { names: [name] },
+                })}
+            >
+                Button
+            </button>
+        )
+            .eval(
+                async ({
+                    name,
+                    options,
+                }: {
+                    name: string;
+                    options: Types.TabsterFocusOptions;
+                }) => {
+                    const button =
+                        getTabsterTestVariables().dom?.getElementById(
+                            document,
+                            "button"
+                        ) as HTMLButtonElement;
+                    const receivedOptions: Array<
+                        Types.TabsterFocusOptions | undefined
+                    > = [];
+
+                    button.focus = (received?: FocusOptions) => {
+                        receivedOptions.push(received);
+                    };
+
+                    const request =
+                        getTabsterTestVariables().observedElement?.requestFocus(
+                            name,
+                            0,
+                            options
+                        );
+
+                    return {
+                        result: request ? await request.result : false,
+                        receivedOptions,
+                    };
+                },
+                { name, options: focusOptions }
+            )
+            .check(({ result, receivedOptions }) => {
+                expect(result).toBe(true);
+                expect(receivedOptions).toEqual([focusOptions]);
+            });
+    });
+
     it("should request focus for element with tabindex -1", async () => {
         const name = "test";
         await new BroTest.BroTest(

--- a/tests/Tabster.test.tsx
+++ b/tests/Tabster.test.tsx
@@ -31,7 +31,8 @@ describe("FocusedElement", () => {
 
         await new BroTest.BroTest(<button id="button">Button</button>)
             .eval((options: Types.TabsterFocusOptions) => {
-                const button = document.getElementById(
+                const button = getTabsterTestVariables().dom?.getElementById(
+                    document,
                     "button"
                 ) as HTMLButtonElement;
                 const receivedOptions: Array<

--- a/tests/Tabster.test.tsx
+++ b/tests/Tabster.test.tsx
@@ -18,6 +18,59 @@ interface NodeWithVirtualParent extends Node {
     };
 }
 
+describe("FocusedElement", () => {
+    beforeEach(async () => {
+        await BroTest.bootstrapTabsterPage({});
+    });
+
+    it("should forward focus options and support the legacy boolean", async () => {
+        const focusOptions: Types.TabsterFocusOptions = {
+            preventScroll: true,
+            focusVisible: true,
+        };
+
+        await new BroTest.BroTest(<button id="button">Button</button>)
+            .eval((options: Types.TabsterFocusOptions) => {
+                const button = document.getElementById(
+                    "button"
+                ) as HTMLButtonElement;
+                const receivedOptions: Array<
+                    Types.TabsterFocusOptions | undefined
+                > = [];
+
+                button.focus = (received?: FocusOptions) => {
+                    receivedOptions.push(received);
+                };
+
+                const tabster = (window as unknown as WindowWithTabster)
+                    .__tabsterInstance as Types.TabsterCore;
+
+                const legacyResult = tabster.focusedElement.focus(
+                    button,
+                    undefined,
+                    undefined,
+                    true
+                );
+                const optionsResult = tabster.focusedElement.focus(
+                    button,
+                    undefined,
+                    undefined,
+                    options
+                );
+
+                return { legacyResult, optionsResult, receivedOptions };
+            }, focusOptions)
+            .check(({ legacyResult, optionsResult, receivedOptions }) => {
+                expect(legacyResult).toBe(true);
+                expect(optionsResult).toBe(true);
+                expect(receivedOptions).toEqual([
+                    { preventScroll: true },
+                    focusOptions,
+                ]);
+            });
+    });
+});
+
 describe("Tabster dispose", () => {
     beforeEach(async () => {
         await BroTest.bootstrapTabsterPage({});


### PR DESCRIPTION
## Summary

- add `TabsterFocusOptions`, including `focusVisible` for TypeScript DOM versions that do not declare it yet
- allow `FocusedElementState.focus()` to accept and forward native focus options
- pass the same options through `ObservedElement.requestFocus()`
- preserve the existing boolean `preventScroll` argument for backwards compatibility

## Motivation

`HTMLElement.focus()` supports options beyond `preventScroll`, including `focusVisible`. Tabster currently exposes only a positional `preventScroll` boolean, so consumers cannot preserve valid native focus behavior when routing focus through Tabster.

## Compatibility

Existing calls such as `focusedElement.focus(element, undefined, undefined, true)` continue to work and are normalized to `{ preventScroll: true }`. Object options are forwarded unchanged.

`focusVisible` is declared explicitly in `TabsterFocusOptions` until it is available in all supported TypeScript DOM library versions.

## Validation

- `npm run format:check`
- `npm run lint:check`
- `npm run type-check:lib`
- `npm run type-check:tests`
- `npm run build-bundle`
- focused browser tests in normal DOM and Shadow DOM modes

> The initial bundle-size check failed because the stored `master` comparison artifact had expired (HTTP 410), not because of a bundle regression.